### PR TITLE
[WEBDEV-602] Implement zero results page

### DIFF
--- a/app/serializers/page_serializer/search_index_page_serializer.rb
+++ b/app/serializers/page_serializer/search_index_page_serializer.rb
@@ -35,24 +35,22 @@ module PageSerializer
     end
 
     def content_without_query
-      [
-        ComponentSerializer::SectionComponentSerializer.new(section_primary_components('search.search-heading'), type: 'primary', content_flag: true).to_h
-      ]
+      [ComponentSerializer::SectionComponentSerializer.new(section_primary_components('search.search-heading'), type: 'primary', content_flag: true).to_h]
     end
 
     def content_with_query
       [].tap do |content|
         content << ComponentSerializer::SectionComponentSerializer.new(section_primary_components('search.results-heading'), type: 'primary').to_h
         content << ComponentSerializer::SectionComponentSerializer.new(results_section_components, content_flag: true).to_h
-        content << ComponentSerializer::SectionComponentSerializer.new(@pagination_helper.navigation_section_components).to_h if @results.totalResults.to_i >= 1
+        content << ComponentSerializer::SectionComponentSerializer.new(@pagination_helper.navigation_section_components).to_h if total_results >= 1
       end
     end
 
     def content_with_flash_message
-      [
-        ComponentSerializer::SectionComponentSerializer.new(section_primary_components('search.search-heading'), type: 'primary').to_h,
-        ComponentSerializer::SectionComponentSerializer.new([ComponentSerializer::StatusComponentSerializer.new(type: 'highlight', display_data: flash_message_display_data, components: [flash_message_paragraph]).to_h], content_flag: true).to_h
-      ]
+      [].tap do |content|
+        content << ComponentSerializer::SectionComponentSerializer.new(section_primary_components('search.search-heading'), type: 'primary').to_h
+        content << ComponentSerializer::SectionComponentSerializer.new([ComponentSerializer::StatusComponentSerializer.new(type: 'highlight', display_data: flash_message_display_data, components: [flash_message_paragraph]).to_h], content_flag: true).to_h
+      end
     end
 
     def flash_message_paragraph
@@ -64,20 +62,25 @@ module PageSerializer
     end
 
     def section_primary_components(results_heading)
-      [
-        ComponentSerializer::HeadingComponentSerializer.new(content: [results_heading], size: 1).to_h,
-        ComponentSerializer::SearchFormComponentSerializer.new(@query, [ComponentSerializer::SearchIconComponentSerializer.new.to_h]).to_h
-      ]
+      [].tap do |content|
+        content << ComponentSerializer::HeadingComponentSerializer.new(content: [results_heading], size: 1).to_h
+        content << ComponentSerializer::SearchFormComponentSerializer.new(@query, [ComponentSerializer::SearchIconComponentSerializer.new.to_h]).to_h
+      end
     end
 
     def results_section_components
-      translation_data = { count: @results.totalResults }
+      translation_data = { count: total_results }
 
-      [
-        ComponentSerializer::HeadingComponentSerializer.new(translation_key: 'search.count', translation_data: translation_data, size: 2).to_h,
-        ComponentSerializer::StatusComponentSerializer.new(type: 'highlight', display_data: [display_data(component: 'status', variant: 'highlight')], components: [ComponentSerializer::ParagraphComponentSerializer.new([{ content: 'search.new-search' }]).to_h]).to_h,
-        ComponentSerializer::ListComponentSerializer.new(display: 'generic', display_data: [display_data(component: 'list', variant: 'block')], components: SearchResultHelper.create_search_results(@results)).to_h
-      ]
+      [].tap do |content|
+        content << ComponentSerializer::HeadingComponentSerializer.new(translation_key: 'search.count', translation_data: translation_data, size: 2).to_h if total_results >= 1
+        content << ComponentSerializer::HeadingComponentSerializer.new(content: ['search.no-results'], size: 2).to_h if total_results < 1
+        content << ComponentSerializer::StatusComponentSerializer.new(type: 'highlight', display_data: [display_data(component: 'status', variant: 'highlight')], components: [ComponentSerializer::ParagraphComponentSerializer.new([{ content: 'search.new-search' }]).to_h]).to_h
+        content << ComponentSerializer::ListComponentSerializer.new(display: 'generic', display_data: [display_data(component: 'list', variant: 'block')], components: SearchResultHelper.create_search_results(@results)).to_h if total_results.positive?
+      end
+    end
+
+    def total_results
+      @results.totalResults.to_i
     end
   end
 end

--- a/spec/fixtures/controllers/search_controller/index/last_page.yml
+++ b/spec/fixtures/controllers/search_controller/index/last_page.yml
@@ -84,7 +84,7 @@ main-components:
         translation:
           key: search.count
           data:
-            count: '7470'
+            count: 7470
         size: 2
     - name: status__highlight
       data:

--- a/spec/fixtures/controllers/search_controller/index/no_results.yml
+++ b/spec/fixtures/controllers/search_controller/index/no_results.yml
@@ -1,0 +1,113 @@
+---
+layout:
+  template: layout
+title: dfgdfh89rhosiubreoweh - Search - UK Parliament
+pugin-version: 1.10.1
+open-search: http://www.example.com/search/opensearch
+header-components:
+- name: link
+  data:
+    link: "#content"
+    display:
+      data:
+      - component: skip-to-content
+    selector: skiplink
+    content: common.header.skip-to-content
+- name: status__banner
+  data:
+    display:
+      data:
+      - component: status
+        variant: banner
+      - component: theme
+        variant: caution
+      - component: cookie
+    selector: cookie
+    components:
+    - name: paragraph
+      data:
+      - content: common.header.cookie-banner-text
+        data:
+          link: "/meta/cookie-policy"
+- name: status__banner
+  data:
+    display:
+      data:
+      - component: status
+        variant: banner
+    components:
+    - name: list__generic
+      data:
+        type: ul
+        display:
+          data:
+          - component: list
+            variant: inline
+        contents:
+        - content: common.header.pages-being-tested
+        - content: common.header.current-website
+- name: header
+  data:
+    components:
+    - name: link
+      data:
+        link: "/"
+        display:
+          data:
+          - component: uk_parliament
+        label: common.header.label
+        components:
+        - name: icon__uk-parliament
+          data: common.header.label
+main-components:
+- name: section__primary
+  data:
+    components:
+    - name: heading
+      data:
+        content:
+        - search.results-heading
+        size: 1
+    - name: form__search
+      data:
+        value: dfgdfh89rhosiubreoweh
+        label: search.label
+        components:
+        - name: icon__search
+          data: search.search-icon
+- name: section__section
+  data:
+    content-flag: true
+    components:
+    - name: heading
+      data:
+        content:
+        - search.no-results
+        size: 2
+    - name: status__highlight
+      data:
+        display:
+          data:
+          - component: status
+            variant: highlight
+        components:
+        - name: paragraph
+          data:
+          - content: search.new-search
+footer-components:
+- name: footer
+  data:
+    uk-parliament: common.footer.uk-parliament
+    components:
+    - name: list__generic
+      data:
+        type: ul
+        display:
+          data:
+          - component: list
+        contents:
+        - content: common.footer.current-website
+        - content: common.footer.cookie-policy
+          data:
+            link: "/meta/cookie-policy"
+        - content: common.footer.data-protection-privacy

--- a/spec/fixtures/controllers/search_controller/index/second_page.yml
+++ b/spec/fixtures/controllers/search_controller/index/second_page.yml
@@ -84,7 +84,7 @@ main-components:
         translation:
           key: search.count
           data:
-            count: '7470'
+            count: 7470
         size: 2
     - name: status__highlight
       data:

--- a/spec/fixtures/controllers/search_controller/index/with_a_query.yml
+++ b/spec/fixtures/controllers/search_controller/index/with_a_query.yml
@@ -84,7 +84,7 @@ main-components:
         translation:
           key: search.count
           data:
-            count: '844'
+            count: 844
         size: 2
     - name: status__highlight
       data:

--- a/spec/fixtures/serializers/page_serializer/search_index_page_serializer/no_results.yml
+++ b/spec/fixtures/serializers/page_serializer/search_index_page_serializer/no_results.yml
@@ -1,0 +1,113 @@
+---
+layout:
+  template: layout
+title: hello - Search - UK Parliament
+pugin-version: 1.10.1
+open-search: 
+header-components:
+- name: link
+  data:
+    link: "#content"
+    display:
+      data:
+      - component: skip-to-content
+    selector: skiplink
+    content: common.header.skip-to-content
+- name: status__banner
+  data:
+    display:
+      data:
+      - component: status
+        variant: banner
+      - component: theme
+        variant: caution
+      - component: cookie
+    selector: cookie
+    components:
+    - name: paragraph
+      data:
+      - content: common.header.cookie-banner-text
+        data:
+          link: "/meta/cookie-policy"
+- name: status__banner
+  data:
+    display:
+      data:
+      - component: status
+        variant: banner
+    components:
+    - name: list__generic
+      data:
+        type: ul
+        display:
+          data:
+          - component: list
+            variant: inline
+        contents:
+        - content: common.header.pages-being-tested
+        - content: common.header.current-website
+- name: header
+  data:
+    components:
+    - name: link
+      data:
+        link: "/"
+        display:
+          data:
+          - component: uk_parliament
+        label: common.header.label
+        components:
+        - name: icon__uk-parliament
+          data: common.header.label
+main-components:
+- name: section__primary
+  data:
+    components:
+    - name: heading
+      data:
+        content:
+        - search.results-heading
+        size: 1
+    - name: form__search
+      data:
+        value: hello
+        label: search.label
+        components:
+        - name: icon__search
+          data: search.search-icon
+- name: section__section
+  data:
+    content-flag: true
+    components:
+    - name: heading
+      data:
+        content:
+        - search.no-results
+        size: 2
+    - name: status__highlight
+      data:
+        display:
+          data:
+          - component: status
+            variant: highlight
+        components:
+        - name: paragraph
+          data:
+          - content: search.new-search
+footer-components:
+- name: footer
+  data:
+    uk-parliament: common.footer.uk-parliament
+    components:
+    - name: list__generic
+      data:
+        type: ul
+        display:
+          data:
+          - component: list
+        contents:
+        - content: common.footer.current-website
+        - content: common.footer.cookie-policy
+          data:
+            link: "/meta/cookie-policy"
+        - content: common.footer.data-protection-privacy

--- a/spec/fixtures/vcr_cassettes/SearchController/GET_index/with_a_query/when_there_are_no_results.yml
+++ b/spec/fixtures/vcr_cassettes/SearchController/GET_index/with_a_query/when_there_are_no_results.yml
@@ -1,0 +1,114 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.parliament.uk/search/description
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      - application/opensearchdescription+xml
+      User-Agent:
+      - Ruby
+      Ocp-Apim-Subscription-Key:
+      - "<AUTH_TOKEN>"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/opensearchdescription+xml
+      Expires:
+      - "-1"
+      Request-Context:
+      - appId=cid-v1:330aa411-57af-491f-b22a-1cab7d08a6a9
+      Set-Cookie:
+      - ARRAffinity=e971ab7be1e7da7ed53156043087973b40c2615e69bda7765747c464af02c933;Path=/;HttpOnly;Domain=search201710091000.azurewebsites.net
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Fri, 06 Jul 2018 12:57:41 GMT
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\"?>\r\n<OpenSearchDescription xmlns=\"http://a9.com/-/spec/opensearch/1.1/\">\r\n
+        \ <ShortName>parliament.uk</ShortName>\r\n  <Description>UK Parliament</Description>\r\n
+        \ <Url template=\"https://api-parliament-uk.azure-api.net/Staging/search?q={searchTerms}&amp;start={startIndex?}&amp;count={count?}\"
+        type=\"application/atom+xml\" />\r\n  <Url template=\"https://api-parliament-uk.azure-api.net/Staging/search?q={searchTerms}&amp;start={startIndex?}&amp;count={count?}\"
+        type=\"application/rss+xml\" />\r\n  <Url template=\"https://api-parliament-uk.azure-api.net/Staging/search?q={searchTerms}&amp;start={startIndex?}&amp;count={count?}\"
+        type=\"application/json\" />\r\n  <Url template=\"https://api-parliament-uk.azure-api.net/Staging/search?q={searchTerms}&amp;start={startIndex?}&amp;count={count?}\"
+        type=\"text/json\" />\r\n  <Url template=\"https://api-parliament-uk.azure-api.net/Staging/search?q={searchTerms}&amp;start={startIndex?}&amp;count={count?}\"
+        type=\"text/xml\" />\r\n  <Url template=\"https://api-parliament-uk.azure-api.net/Staging/search?q={searchTerms}&amp;start={startIndex?}&amp;count={count?}\"
+        type=\"application/xml\" />\r\n</OpenSearchDescription>"
+    http_version: 
+  recorded_at: Fri, 06 Jul 2018 12:57:38 GMT
+- request:
+    method: get
+    uri: https://api-parliament-uk.azure-api.net/Staging/search?count=10&q=dfgdfh89rhosiubreoweh&start=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      - application/atom+xml
+      User-Agent:
+      - Ruby
+      Ocp-Apim-Subscription-Key:
+      - "<AUTH_TOKEN>"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '501'
+      Content-Type:
+      - application/atom+xml
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Request-Context:
+      - appId=cid-v1:330aa411-57af-491f-b22a-1cab7d08a6a9
+      Set-Cookie:
+      - ARRAffinity=e971ab7be1e7da7ed53156043087973b40c2615e69bda7765747c464af02c933;Path=/;HttpOnly;Domain=search201710091000.azurewebsites.net
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Fri, 06 Jul 2018 12:57:41 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '<?xml version="1.0" encoding="utf-8"?><feed xmlns="http://www.w3.org/2005/Atom"><title
+        type="text">Parliament.uk Search: dfgdfh89rhosiubreoweh</title><id>uuid:96efd79e-00ff-455b-9302-43870ac2cb9d;id=116</id><updated>2018-07-06T12:57:41Z</updated><author><name>Parliament.uk</name></author><Query
+        role="request" searchTerms="dfgdfh89rhosiubreoweh" totalResults="0" count="10"
+        startIndex="1" xmlns="http://a9.com/-/spec/opensearch/1.1/" /><totalResults
+        xmlns="http://a9.com/-/spec/opensearch/1.1/">0</totalResults><startIndex xmlns="http://a9.com/-/spec/opensearch/1.1/">1</startIndex><itemsPerPage
+        xmlns="http://a9.com/-/spec/opensearch/1.1/">0</itemsPerPage></feed>'
+    http_version: 
+  recorded_at: Fri, 06 Jul 2018 12:57:38 GMT
+recorded_with: VCR 4.0.0

--- a/spec/integration/controllers/search_controller_spec.rb
+++ b/spec/integration/controllers/search_controller_spec.rb
@@ -44,6 +44,14 @@ RSpec.describe SearchController, vcr: true do
 
         expect(JSON.parse(response.body).to_yaml).to eq(expected_json)
       end
+
+      it 'when there are no results' do
+        get '/search?q=dfgdfh89rhosiubreoweh'
+
+        expected_json = get_fixture('index', 'no_results')
+
+        expect(JSON.parse(response.body).to_yaml).to eq(expected_json)
+      end
     end
   end
 end


### PR DESCRIPTION
- Change creation of arrays to use #tap in SearchIndexPageSerializer
- Add #total_results to SearchIndexPageSerializer
- Render results differently based on whether or not there are results
- Use total_results.positive? instead of total_results > 0