### PR TITLE
Removed `rails assets:compile` command from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,9 +54,6 @@ ENV RAILS_LOG_TO_STDOUT $RAILS_LOG_TO_STDOUT
 ENV RACK_ENV $RACK_ENV
 ENV RAILS_SERVE_STATIC_FILES true
 
-# Precompile assets
-RUN bundle exec rails assets:precompile
-
 # Add additional labels to our image
 ARG GIT_SHA=unknown
 ARG GIT_TAG=unknown


### PR DESCRIPTION
* Not needed as it's an API and has no assets