### PR TITLE
[WEBDEV-674] Add Cloudflare ID to logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2.5.1-alpine3.7
 
-# Add command line argument variables used to cusomise the image at build-time.
+# Add command line argument variables used to customise the image at build-time.
 
 ARG PARLIAMENT_API_VERSION
 ARG OPENSEARCH_DESCRIPTION_URL

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,6 +34,9 @@ module Thorney
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
 
+    # Get the Cloudflare ID from the HTTP headers and log it
+    config.log_tags = [->(request) { "Cloudflare ID: #{request.headers['HTTP_CF_RAY']}" }]
+
     # Add our custom validators to our autoload paths
     config.autoload_paths += %W["#{config.root}/app/validators/"]
 


### PR DESCRIPTION
This takes the `cf-ray` HTTP header and prefixes each log line with it. The version of Rails we use capitalises and prefixes HTTP headers with `HTTP_`. It also converts dashes to underscores.

That is, `cf-ray` becomes `HTTP_CF_RAY` and it can be accessed from the request object as `request.headers['HTTP_CF_RAY]`.

This results in the following logs, for example
```
[Cloudflare ID: 4526492b0a67bc68-LHR] Started GET "/search" for 127.0.0.1 at 2018-09-12 10:31:28 +0100
[Cloudflare ID: 4526492b0a67bc68-LHR] Processing by SearchController#index as */*
[Cloudflare ID: 4526492b0a67bc68-LHR] Completed 200 OK in 10ms (Views: 0.7ms)
```
Which enables us to tie multiple log lines to a single request in a sea of logs.