### PR TITLE
[WEBDEV-791] Create Groups::LayingsController#index

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,7 +128,7 @@ GEM
     parliament-opensearch (0.7.0)
       activesupport (>= 5.0.0.1)
       feedjira (~> 2.1, >= 2.1.2)
-    parliament-routes (0.6.13)
+    parliament-routes (0.6.15)
     parliament-ruby (0.10.2)
     parser (2.5.1.2)
       ast (~> 2.4.0)

--- a/app/controllers/concerns/page_range_helper.rb
+++ b/app/controllers/concerns/page_range_helper.rb
@@ -17,7 +17,7 @@ class PageRangeHelper
   # If there are at least 8 pages, the array has 8 zero-indexed elements as such:
   # [0 .. 7]
   # Otherwise, the array has as many elements as there are pages. For example, if there are 4 pages in total, the array would be:
-  # [0 .. 4]
+  # [0 .. 3]
   #
   # The array is populated by first finding where in the array the current page lies
   # and then filling in the elements preceding and succeeding the current page

--- a/app/controllers/groups/layings_controller.rb
+++ b/app/controllers/groups/layings_controller.rb
@@ -1,0 +1,41 @@
+module Groups
+  class LayingsController < ApplicationController
+    before_action :build_request, :data_check
+
+    ROUTE_MAP = {
+      index: proc { |params| ParliamentHelper.parliament_request.group_layings_index.set_url_params({ group_id: params[:group_id] }) }
+    }.freeze
+
+    def index
+      @group, @layings = FilterHelper.filter(@api_request, 'Group', 'Laying')
+      @group = @group.first
+
+      list_components = @layings.map do |laying|
+        laying_type = I18n.t('layings.type.si')
+        heading_url = statutory_instrument_path(laying.laid_thing.graph_id)
+
+        if laying.laid_thing.is_a?(Parliament::Grom::Decorator::ProposedNegativeStatutoryInstrumentPaper)
+          laying_type = I18n.t('layings.type.pnsi')
+          heading_url = proposed_negative_statutory_instrument_path(laying.laid_thing.graph_id)
+        end
+
+        paragraph_content = [].tap do |content|
+          content << { content: 'groups.layings.date', date: I18n.l(Time.parse(laying.date.to_s)) } if laying.date
+          content << { content: 'groups.layings.type', type: laying_type } if laying.type
+        end
+
+        CardFactory.new(
+          heading_text:      laying.laid_thing.try(:laidThingName),
+          heading_url:       heading_url,
+          paragraph_content: paragraph_content
+        ).build_card
+      end
+
+      heading = ComponentSerializer::Heading1ComponentSerializer.new(heading_content: I18n.t('layings.title'), subheading_content: @group.try(:groupName), subheading_link: group_path)
+
+      serializer = PageSerializer::ListPageSerializer.new(request: request, heading_component: heading, list_components: list_components, data_alternates: @alternates)
+
+      render_page(serializer)
+    end
+  end
+end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -24,7 +24,9 @@ class GroupsController < ApplicationController
       ).build_card
     end
 
-    serializer = PageSerializer::ListPageSerializer.new(request: request, page_title: I18n.t('groups.index.title'), list_components: list_components, data_alternates: @alternates)
+    heading = ComponentSerializer::Heading1ComponentSerializer.new(heading_content: I18n.t('groups.index.title'))
+
+    serializer = PageSerializer::ListPageSerializer.new(request: request, heading_component: heading, list_components: list_components, data_alternates: @alternates)
 
     render_page(serializer)
   end

--- a/app/controllers/proposed_negative_statutory_instruments_controller.rb
+++ b/app/controllers/proposed_negative_statutory_instruments_controller.rb
@@ -17,7 +17,9 @@ class ProposedNegativeStatutoryInstrumentsController < ApplicationController
       ).build_card
     end
 
-    serializer = PageSerializer::ListPageSerializer.new(request: request, page_title: I18n.t('proposed_negative_statutory_instruments.index.title'), list_components: list_components, data_alternates: @alternates)
+    heading = ComponentSerializer::Heading1ComponentSerializer.new(heading_content: I18n.t('proposed_negative_statutory_instruments.index.title'))
+
+    serializer = PageSerializer::ListPageSerializer.new(request: request, heading_component: heading, list_components: list_components, data_alternates: @alternates)
 
     render_page(serializer)
   end

--- a/app/controllers/statutory_instruments_controller.rb
+++ b/app/controllers/statutory_instruments_controller.rb
@@ -17,7 +17,9 @@ class StatutoryInstrumentsController < ApplicationController
       ).build_card
     end
 
-    serializer = PageSerializer::ListPageSerializer.new(request: request, page_title: I18n.t('statutory_instruments.index.title'), list_components: list_components, data_alternates: @alternates)
+    heading = ComponentSerializer::Heading1ComponentSerializer.new(heading_content: I18n.t('statutory_instruments.index.title'))
+
+    serializer = PageSerializer::ListPageSerializer.new(request: request, heading_component: heading, list_components: list_components, data_alternates: @alternates)
 
     render_page(serializer)
   end

--- a/app/serializers/component_serializer/heading1_component_serializer.rb
+++ b/app/serializers/component_serializer/heading1_component_serializer.rb
@@ -4,25 +4,33 @@ module ComponentSerializer
     #
     # @param [String] subheading_content content of the subheading, this could be a string or a translation key.
     # @param [String] subheading_data data for the subheading, for example this could be an integer or url which can be passed into a translation in the front end.
+    # @param [String] subheading_link link for the subheading, providing this will wrap the subheading in <a> tags
     # @param [String] heading_content content of the heading, this could be a string or a translation key.
     # @param [String] heading_data data for the heading, for example this could be an integer or url which can be passed into a translation in the front end.
     # @param [String] context_content content of the context, this could be a string or a translation key.
     # @param [String] context_data data for the context, for example this could be an integer or url which can be passed into a translation in the front end.
-    # @param [Boolean] context_hidden this boolean indicated if the context is only avalibale to screen readers.
+    # @param [Boolean] context_hidden this boolean indicated if the context is only available to screen readers.
     #
     # @example Initialising a heading1 component with content
     #  string_or_translation_key = 'Here are the headings'
     #  backend_data_for_translation = 'beta.parliament.uk'
     #  boolean = true
     #  ComponentSerializer::Heading1ComponentSerializer.new(subheading_content: string_or_translation_key, subheading_data: {"link": backend_data_for_translation}, heading_content: string_or_translation_key, heading_data: {"link": backend_data_for_translation}, context_content: string_or_translation_key, context_data: {"link": backend_data_for_translation}, context_hidden: boolean).to_h
-    def initialize(subheading_content: nil, subheading_data: nil, heading_content: nil, heading_data: nil, context_content: nil, context_data: nil, context_hidden: nil)
+    def initialize(subheading_content: nil, subheading_data: nil, subheading_link: nil, heading_content: nil, heading_data: nil, context_content: nil, context_data: nil, context_hidden: nil)
       @subheading_content = subheading_content
       @subheading_data = subheading_data
+      @subheading_link = subheading_link
       @heading_content = heading_content
       @heading_data = heading_data
       @context_content = context_content
       @context_data = context_data
       @context_hidden = context_hidden
+    end
+
+    def to_s
+      return "#{@subheading_content} - #{@heading_content}" unless @subheading_content.nil?
+
+      @heading_content || t('no_name')
     end
 
     private
@@ -40,8 +48,10 @@ module ComponentSerializer
     end
 
     def subheading
+      content = @subheading_link ? link_to(@subheading_content, @subheading_link) : @subheading_content
+
       {}.tap do |hash|
-        hash[:content] = @subheading_content if @subheading_content
+        hash[:content] = content if content
         hash[:data] = @subheading_data if @subheading_data
       end
     end

--- a/app/serializers/component_serializer/paragraph_component_serializer.rb
+++ b/app/serializers/component_serializer/paragraph_component_serializer.rb
@@ -2,12 +2,16 @@ module ComponentSerializer
   class ParagraphComponentSerializer < ComponentSerializer::BaseComponentSerializer
     # Initialise a paragraph component with one or more pieces of content.
     #
-    # @param [Array<Hash>] content one or more pieces of content to be wrapped in <p> tags. The hashes have a content key and and optional link key.
+    # @param [Array<Hash>] content one or more pieces of content to be wrapped in <p> tags. The hashes have a content key and any other optional keys.
     #
     # @example Initialising a paragraph component
     #  string_or_translation_key = 'Here is some paragraph text'
     #  link = 'beta.parliament.uk'
     #  ComponentSerializer::ParagraphComponentSerializer.new(content: [{ content: string_or_translation_key, link: link }]).to_h
+    #
+    # @example You can also add custom properties for use with translations on the front end
+    #  hash = { content: 'some content', date: '14 May 2018', type: 'Statutory Instrument' }
+    #  ComponentSerializer::ParagraphComponentSerializer.new(content: [hash]).to_h
     def initialize(content: nil)
       @content = content
     end
@@ -22,7 +26,10 @@ module ComponentSerializer
       @content.map do |content|
         {}.tap do |hash|
           hash[:content] = content[:content]
-          hash[:data] = { link: content[:link] } if content[:link]
+
+          data = content.try(:except, :content)
+
+          hash[:data] = data if data.present?
         end
       end
     end

--- a/app/serializers/page_serializer/list_page_serializer.rb
+++ b/app/serializers/page_serializer/list_page_serializer.rb
@@ -3,11 +3,11 @@ module PageSerializer
     # Initialise a list page serializer.
     #
     # @param [ActionDispatch::Request] request the current request object
-    # @param @param [String] page_title title of the page
+    # @param [ComponentSerializer::Heading1ComponentSerializer] heading_component a heading object used for heading information
     # @param [Array<Hash>] list_components an array of components to be passed into the list
     # @param [Array<Hash>] data_alternates array containing the href and type of the alternative data url
-    def initialize(request: nil, page_title: nil, list_components: nil, data_alternates: nil)
-      @page_title = page_title
+    def initialize(request: nil, heading_component: nil, list_components: nil, data_alternates: nil)
+      @heading_component = heading_component
       @list_components = list_components
       @data_alternates = data_alternates
 
@@ -17,7 +17,7 @@ module PageSerializer
     private
 
     def meta
-      super(title: @page_title)
+      super(title: @heading_component.to_s)
     end
 
     def content
@@ -28,7 +28,7 @@ module PageSerializer
     end
 
     def section_primary_components
-      [ComponentSerializer::Heading1ComponentSerializer.new({ heading_content: @page_title }).to_h]
+      [@heading_component.to_h]
     end
 
     def section_components

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -47,8 +47,11 @@ en:
       flash: "Please enter a search term."
     opensearch:
       short_name: "UK Parliament"
-
-  layings: Layings
+  layings:
+    title: "Layings"
+    type:
+      si: "Statutory Instrument"
+      pnsi: "Proposed Negative Statutory Instrument"
   groups:
     index:
       title: Groups

--- a/spec/controllers/group_controller_spec.rb
+++ b/spec/controllers/group_controller_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe GroupsController, vcr: true do
 
     before(:each) do
       allow(PageSerializer::ListPageSerializer).to receive(:new)
+      allow(ComponentSerializer::Heading1ComponentSerializer).to receive(:new).with(heading_content: 'Groups') { heading }
 
       allow(controller.request).to receive(:env).and_return({'ApplicationInsights.request.id' => '|1234abcd.'})
 
@@ -43,7 +44,8 @@ RSpec.describe GroupsController, vcr: true do
 
     it 'calls the serializer correctly' do
       list_components = [{"data"=> {"heading"=> {"data"=> {"content"=>"groupName - 1", "link"=>"/groups/tz34m7Vt", "size"=>2}, "name"=>"heading"}, "paragraph"=> {"data"=> [{"content"=>"28 July 1997 to 12 September 2017"}],"name"=>"paragraph"}}, "name"=>"card__generic"}]
-      expect(PageSerializer::ListPageSerializer).to have_received(:new).with(request: request, page_title: 'Groups', list_components: list_components, data_alternates: data_alternates)
+
+      expect(PageSerializer::ListPageSerializer).to have_received(:new).with(request: request, heading_component: heading, list_components: list_components, data_alternates: data_alternates)
     end
   end
 

--- a/spec/controllers/groups/layings_controller_spec.rb
+++ b/spec/controllers/groups/layings_controller_spec.rb
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+require 'rails_helper'
+
+RSpec.describe Groups::LayingsController, vcr: true do
+  describe 'GET index' do
+    let(:data_alternates) do
+      [{
+           :href => "#{ENV['PARLIAMENT_BASE_URL']}/group_layings_index.nt?group_id=XouN12Ow",
+           :type => "application/n-triples" },
+       { :href => "#{ENV['PARLIAMENT_BASE_URL']}/group_layings_index.ttl?group_id=XouN12Ow",
+         :type => "text/turtle" },
+       { :href => "#{ENV['PARLIAMENT_BASE_URL']}/group_layings_index.tsv?group_id=XouN12Ow",
+         :type => "text/tab-separated-values" },
+       { :href => "#{ENV['PARLIAMENT_BASE_URL']}/group_layings_index.csv?group_id=XouN12Ow",
+         :type => "text/csv" },
+       { :href => "#{ENV['PARLIAMENT_BASE_URL']}/group_layings_index.rj?group_id=XouN12Ow",
+         :type => "application/json+rdf" },
+       { :href => "#{ENV['PARLIAMENT_BASE_URL']}/group_layings_index.json?group_id=XouN12Ow",
+         :type => "application/json+ld" },
+       { :href => "#{ENV['PARLIAMENT_BASE_URL']}/group_layings_index.xml?group_id=XouN12Ow",
+         :type => "application/rdf+xml" }]
+    end
+
+    let(:heading) { 'a heading component' }
+
+    before(:each) do
+      allow(PageSerializer::ListPageSerializer).to receive(:new)
+      allow(ComponentSerializer::Heading1ComponentSerializer).to receive(:new) { heading }
+
+      allow(controller.request).to receive(:env).and_return({'ApplicationInsights.request.id' => '|1234abcd.'})
+
+      get :index, params: { group_id: 'XouN12Ow' }
+    end
+
+    it 'should have a response with http status ok (200)' do
+      expect(response).to have_http_status(:ok)
+    end
+
+    context 'the correct instance variables' do
+      it 'assigns @group' do
+        expect(assigns(:group)).to be_a(Grom::Node)
+        expect(assigns(:group).type).to include('https://id.parliament.uk/schema/Group')
+      end
+
+      it 'assigns @layings' do
+        assigns(:layings).each do |laying|
+          expect(laying).to be_a(Grom::Node)
+          expect(laying.type).to include('https://id.parliament.uk/schema/Laying')
+        end
+      end
+    end
+
+    context 'calling the serializers correctly' do
+      it 'calls the Heading1ComponentSerializer correctly' do
+        expect(ComponentSerializer::Heading1ComponentSerializer).to have_received(:new).with(heading_content: 'Layings', subheading_content: 'groupName - 1', subheading_link: '/groups/XouN12Ow')
+      end
+
+      it 'calls the ListPageSerializer correctly' do
+        list_components = [{"name"=>"card__generic", "data"=>{"heading"=>{"name"=>"heading", "data"=>{"content"=>"laidThingName - 1", "size"=>2, "link"=>"/statutory-instruments/QV9rpep6"}}, "paragraph"=>{"name"=>"paragraph", "data"=>[{"content"=>"groups.layings.date", "data"=>{"date"=>"27 April 2018"}}, {"content"=>"groups.layings.type", "data"=>{"type"=>"Statutory Instrument"}}]}}}, {"name"=>"card__generic", "data"=>{"heading"=>{"name"=>"heading", "data"=>{"content"=>"laidThingName - 2", "size"=>2, "link"=>"/statutory-instruments/HJ7BlYte"}}, "paragraph"=>{"name"=>"paragraph", "data"=>[{"content"=>"groups.layings.date", "data"=>{"date"=>"8 May 2018"}}, {"content"=>"groups.layings.type", "data"=>{"type"=>"Statutory Instrument"}}]}}}, {"name"=>"card__generic", "data"=>{"heading"=>{"name"=>"heading", "data"=>{"content"=>"laidThingName - 3", "size"=>2, "link"=>"/statutory-instruments/3dAYwLoB"}}, "paragraph"=>{"name"=>"paragraph", "data"=>[{"content"=>"groups.layings.date", "data"=>{"date"=>"3 April 2018"}}, {"content"=>"groups.layings.type", "data"=>{"type"=>"Statutory Instrument"}}]}}}, {"name"=>"card__generic", "data"=>{"heading"=>{"name"=>"heading", "data"=>{"content"=>"laidThingName - 4", "size"=>2, "link"=>"/statutory-instruments/rjzMGG28"}}, "paragraph"=>{"name"=>"paragraph", "data"=>[{"content"=>"groups.layings.date", "data"=>{"date"=>"21 May 2018"}}, {"content"=>"groups.layings.type", "data"=>{"type"=>"Statutory Instrument"}}]}}}, {"name"=>"card__generic", "data"=>{"heading"=>{"name"=>"heading", "data"=>{"content"=>"laidThingName - 5", "size"=>2, "link"=>"/statutory-instruments/uNiGNHey"}}, "paragraph"=>{"name"=>"paragraph", "data"=>[{"content"=>"groups.layings.date", "data"=>{"date"=>"24 May 2018"}}, {"content"=>"groups.layings.type", "data"=>{"type"=>"Statutory Instrument"}}]}}}, {"name"=>"card__generic", "data"=>{"heading"=>{"name"=>"heading", "data"=>{"content"=>"laidThingName - 6", "size"=>2, "link"=>"/statutory-instruments/8HUWJm9e"}}, "paragraph"=>{"name"=>"paragraph", "data"=>[{"content"=>"groups.layings.date", "data"=>{"date"=>"18 May 2018"}}, {"content"=>"groups.layings.type", "data"=>{"type"=>"Statutory Instrument"}}]}}}, {"name"=>"card__generic", "data"=>{"heading"=>{"name"=>"heading", "data"=>{"content"=>"laidThingName - 7", "size"=>2, "link"=>"/statutory-instruments/ez3sdNNT"}}, "paragraph"=>{"name"=>"paragraph", "data"=>[{"content"=>"groups.layings.date", "data"=>{"date"=>"4 June 2018"}}, {"content"=>"groups.layings.type", "data"=>{"type"=>"Statutory Instrument"}}]}}}, {"name"=>"card__generic", "data"=>{"heading"=>{"name"=>"heading", "data"=>{"content"=>"laidThingName - 8", "size"=>2, "link"=>"/statutory-instruments/w3m931qg"}}, "paragraph"=>{"name"=>"paragraph", "data"=>[{"content"=>"groups.layings.date", "data"=>{"date"=>"6 June 2018"}}, {"content"=>"groups.layings.type", "data"=>{"type"=>"Statutory Instrument"}}]}}}, {"name"=>"card__generic", "data"=>{"heading"=>{"name"=>"heading", "data"=>{"content"=>"laidThingName - 9", "size"=>2, "link"=>"/statutory-instruments/PhwmELqG"}}, "paragraph"=>{"name"=>"paragraph", "data"=>[{"content"=>"groups.layings.date", "data"=>{"date"=>"8 June 2018"}}, {"content"=>"groups.layings.type", "data"=>{"type"=>"Statutory Instrument"}}]}}}, {"name"=>"card__generic", "data"=>{"heading"=>{"name"=>"heading", "data"=>{"content"=>"laidThingName - 10", "size"=>2, "link"=>"/statutory-instruments/aQaZuLyK"}}, "paragraph"=>{"name"=>"paragraph", "data"=>[{"content"=>"groups.layings.date", "data"=>{"date"=>"13 June 2018"}}, {"content"=>"groups.layings.type", "data"=>{"type"=>"Statutory Instrument"}}]}}}, {"name"=>"card__generic", "data"=>{"heading"=>{"name"=>"heading", "data"=>{"content"=>"laidThingName - 11", "size"=>2, "link"=>"/statutory-instruments/I9rWxORS"}}, "paragraph"=>{"name"=>"paragraph", "data"=>[{"content"=>"groups.layings.date", "data"=>{"date"=>"13 June 2018"}}, {"content"=>"groups.layings.type", "data"=>{"type"=>"Statutory Instrument"}}]}}}, {"name"=>"card__generic", "data"=>{"heading"=>{"name"=>"heading", "data"=>{"content"=>"laidThingName - 12", "size"=>2, "link"=>"/statutory-instruments/9Nv0gELe"}}, "paragraph"=>{"name"=>"paragraph", "data"=>[{"content"=>"groups.layings.date", "data"=>{"date"=>"15 June 2018"}}, {"content"=>"groups.layings.type", "data"=>{"type"=>"Statutory Instrument"}}]}}}, {"name"=>"card__generic", "data"=>{"heading"=>{"name"=>"heading", "data"=>{"content"=>"laidThingName - 13", "size"=>2, "link"=>"/statutory-instruments/YhMNMpYo"}}, "paragraph"=>{"name"=>"paragraph", "data"=>[{"content"=>"groups.layings.date", "data"=>{"date"=>"18 June 2018"}}, {"content"=>"groups.layings.type", "data"=>{"type"=>"Statutory Instrument"}}]}}}, {"name"=>"card__generic", "data"=>{"heading"=>{"name"=>"heading", "data"=>{"content"=>"laidThingName - 14", "size"=>2, "link"=>"/statutory-instruments/UD4HjKbu"}}, "paragraph"=>{"name"=>"paragraph", "data"=>[{"content"=>"groups.layings.date", "data"=>{"date"=>"25 June 2018"}}, {"content"=>"groups.layings.type", "data"=>{"type"=>"Statutory Instrument"}}]}}}, {"name"=>"card__generic", "data"=>{"heading"=>{"name"=>"heading", "data"=>{"content"=>"laidThingName - 15", "size"=>2, "link"=>"/statutory-instruments/P5Zu6fkP"}}, "paragraph"=>{"name"=>"paragraph", "data"=>[{"content"=>"groups.layings.date", "data"=>{"date"=>"28 June 2018"}}, {"content"=>"groups.layings.type", "data"=>{"type"=>"Statutory Instrument"}}]}}}, {"name"=>"card__generic", "data"=>{"heading"=>{"name"=>"heading", "data"=>{"content"=>"laidThingName - 16", "size"=>2, "link"=>"/statutory-instruments/JXxhQblu"}}, "paragraph"=>{"name"=>"paragraph", "data"=>[{"content"=>"groups.layings.date", "data"=>{"date"=>"3 July 2018"}}, {"content"=>"groups.layings.type", "data"=>{"type"=>"Statutory Instrument"}}]}}}, {"name"=>"card__generic", "data"=>{"heading"=>{"name"=>"heading", "data"=>{"content"=>"laidThingName - 17", "size"=>2, "link"=>"/statutory-instruments/IjLgnN8z"}}, "paragraph"=>{"name"=>"paragraph", "data"=>[{"content"=>"groups.layings.date", "data"=>{"date"=>"2 July 2018"}}, {"content"=>"groups.layings.type", "data"=>{"type"=>"Statutory Instrument"}}]}}}, {"name"=>"card__generic", "data"=>{"heading"=>{"name"=>"heading", "data"=>{"content"=>"laidThingName - 18", "size"=>2, "link"=>"/statutory-instruments/BRZBy463"}}, "paragraph"=>{"name"=>"paragraph", "data"=>[{"content"=>"groups.layings.date", "data"=>{"date"=>"12 July 2018"}}, {"content"=>"groups.layings.type", "data"=>{"type"=>"Statutory Instrument"}}]}}}, {"name"=>"card__generic", "data"=>{"heading"=>{"name"=>"heading", "data"=>{"content"=>"laidThingName - 19", "size"=>2, "link"=>"/statutory-instruments/Uhsvsfdn"}}, "paragraph"=>{"name"=>"paragraph", "data"=>[{"content"=>"groups.layings.date", "data"=>{"date"=>"19 July 2018"}}, {"content"=>"groups.layings.type", "data"=>{"type"=>"Statutory Instrument"}}]}}}, {"name"=>"card__generic", "data"=>{"heading"=>{"name"=>"heading", "data"=>{"content"=>"laidThingName - 20", "size"=>2, "link"=>"/statutory-instruments/SbxmGLcR"}}, "paragraph"=>{"name"=>"paragraph", "data"=>[{"content"=>"groups.layings.date", "data"=>{"date"=>"20 July 2018"}}, {"content"=>"groups.layings.type", "data"=>{"type"=>"Statutory Instrument"}}]}}}, {"name"=>"card__generic", "data"=>{"heading"=>{"name"=>"heading", "data"=>{"content"=>"laidThingName - 21", "size"=>2, "link"=>"/proposed-negative-statutory-instruments/W3l3iqIJ"}}, "paragraph"=>{"name"=>"paragraph", "data"=>[{"content"=>"groups.layings.date", "data"=>{"date"=>"25 July 2018"}}, {"content"=>"groups.layings.type", "data"=>{"type"=>"Proposed Negative Statutory Instrument"}}]}}}, {"name"=>"card__generic", "data"=>{"heading"=>{"name"=>"heading", "data"=>{"content"=>"laidThingName - 22", "size"=>2, "link"=>"/statutory-instruments/hLF7ZU6f"}}, "paragraph"=>{"name"=>"paragraph", "data"=>[{"content"=>"groups.layings.date", "data"=>{"date"=>"26 July 2018"}}, {"content"=>"groups.layings.type", "data"=>{"type"=>"Statutory Instrument"}}]}}}, {"name"=>"card__generic", "data"=>{"heading"=>{"name"=>"heading", "data"=>{"content"=>"laidThingName - 23", "size"=>2, "link"=>"/statutory-instruments/BuMKAKjA"}}, "paragraph"=>{"name"=>"paragraph", "data"=>[{"content"=>"groups.layings.date", "data"=>{"date"=>"6 September 2018"}}, {"content"=>"groups.layings.type", "data"=>{"type"=>"Statutory Instrument"}}]}}}, {"name"=>"card__generic", "data"=>{"heading"=>{"name"=>"heading", "data"=>{"content"=>"laidThingName - 24", "size"=>2, "link"=>"/statutory-instruments/WBlaNvyq"}}, "paragraph"=>{"name"=>"paragraph", "data"=>[{"content"=>"groups.layings.date", "data"=>{"date"=>"10 September 2018"}}, {"content"=>"groups.layings.type", "data"=>{"type"=>"Statutory Instrument"}}]}}}, {"name"=>"card__generic", "data"=>{"heading"=>{"name"=>"heading", "data"=>{"content"=>"laidThingName - 25", "size"=>2, "link"=>"/statutory-instruments/lSRBYtGi"}}, "paragraph"=>{"name"=>"paragraph", "data"=>[{"content"=>"groups.layings.date", "data"=>{"date"=>"13 September 2018"}}, {"content"=>"groups.layings.type", "data"=>{"type"=>"Statutory Instrument"}}]}}}, {"name"=>"card__generic", "data"=>{"heading"=>{"name"=>"heading", "data"=>{"content"=>"laidThingName - 26", "size"=>2, "link"=>"/statutory-instruments/H1uGO0VI"}}, "paragraph"=>{"name"=>"paragraph", "data"=>[{"content"=>"groups.layings.date", "data"=>{"date"=>"13 September 2018"}}, {"content"=>"groups.layings.type", "data"=>{"type"=>"Statutory Instrument"}}]}}}]
+
+        expect(PageSerializer::ListPageSerializer).to have_received(:new).with(request: request, heading_component: heading, list_components: list_components, data_alternates: data_alternates)
+      end
+    end
+  end
+end

--- a/spec/controllers/proposed_negative_statutory_instruments_controller_spec.rb
+++ b/spec/controllers/proposed_negative_statutory_instruments_controller_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe ProposedNegativeStatutoryInstrumentsController, vcr: true do
 
     before(:each) do
       allow(PageSerializer::ListPageSerializer).to receive(:new)
+      allow(ComponentSerializer::Heading1ComponentSerializer).to receive(:new).with(heading_content: 'Proposed Negative Statutory Instruments') { heading }
 
       allow(controller.request).to receive(:env).and_return({'ApplicationInsights.request.id' => '|1234abcd.'})
 
@@ -44,7 +45,8 @@ RSpec.describe ProposedNegativeStatutoryInstrumentsController, vcr: true do
 
     it 'calls the serializer correctly' do
       list_components = [{"data"=> {"heading"=> {"data"=> {"content"=>"proposedNegativeStatutoryInstrumentPaperName - 1", "link"=>"/proposed-negative-statutory-instruments/Tn1xqHc0", "size"=>2}, "name"=>"heading"}}, "name"=>"card__generic"}]
-      expect(PageSerializer::ListPageSerializer).to have_received(:new).with(request: request, page_title: 'Proposed Negative Statutory Instruments', list_components: list_components, data_alternates: data_alternates)
+
+      expect(PageSerializer::ListPageSerializer).to have_received(:new).with(request: request, heading_component: heading, list_components: list_components, data_alternates: data_alternates)
     end
   end
 

--- a/spec/controllers/statutory_instruments_controller_spec.rb
+++ b/spec/controllers/statutory_instruments_controller_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe StatutoryInstrumentsController, vcr: true do
 
     before(:each) do
       allow(PageSerializer::ListPageSerializer).to receive(:new)
+      allow(ComponentSerializer::Heading1ComponentSerializer).to receive(:new).with(heading_content: 'Statutory Instruments') { heading }
 
       allow(controller.request).to receive(:env).and_return({'ApplicationInsights.request.id' => '|1234abcd.'})
 
@@ -45,7 +46,7 @@ RSpec.describe StatutoryInstrumentsController, vcr: true do
     it 'calls the serializer correctly' do
       list_components = [{"data"=> {"heading"=> {"data"=> {"content"=>"statutoryInstrumentPaperName - 1", "link"=>"/statutory-instruments/5trFJNih", "size"=>2}, "name"=>"heading"}}, "name"=>"card__generic"}]
 
-      expect(PageSerializer::ListPageSerializer).to have_received(:new).with(request: request, page_title: 'Statutory Instruments', list_components: list_components, data_alternates: data_alternates)
+      expect(PageSerializer::ListPageSerializer).to have_received(:new).with(request: request, heading_component: heading, list_components: list_components, data_alternates: data_alternates)
     end
   end
 

--- a/spec/fixtures/controllers/groups/layings_controller/index/fixture.yml
+++ b/spec/fixtures/controllers/groups/layings_controller/index/fixture.yml
@@ -1,0 +1,605 @@
+---
+layout:
+  template: layout
+meta:
+  title: groupName - 1 - Layings - UK Parliament
+  request-id: 123456
+  data-alternates:
+  - type: application/n-triples
+    href: http://localhost:3030/group_layings_index.nt?group_id=XouN12Ow
+  - type: text/turtle
+    href: http://localhost:3030/group_layings_index.ttl?group_id=XouN12Ow
+  - type: text/tab-separated-values
+    href: http://localhost:3030/group_layings_index.tsv?group_id=XouN12Ow
+  - type: text/csv
+    href: http://localhost:3030/group_layings_index.csv?group_id=XouN12Ow
+  - type: application/json+rdf
+    href: http://localhost:3030/group_layings_index.rj?group_id=XouN12Ow
+  - type: application/json+ld
+    href: http://localhost:3030/group_layings_index.json?group_id=XouN12Ow
+  - type: application/rdf+xml
+    href: http://localhost:3030/group_layings_index.xml?group_id=XouN12Ow
+  open-graph:
+    title: groupName - 1 - Layings - UK Parliament
+    original-url: https://www.example.com/groups/XouN12Ow/made-available/availability-types/layings
+    image-url: https://static.parliament.uk/assets-public/opengraph-oblong.png
+    image-width: '1200'
+    image-height: '630'
+    twitter-card: summary_large_image
+  opensearch-description-url: https://www.example.com/search/opensearch
+header-components:
+- name: link
+  data:
+    link: "#content"
+    display:
+      name: partials__display
+      data:
+      - component: skip-to-content
+    selector: skiplink
+    content: shared.header.skip-to-content
+- name: status__banner
+  data:
+    display:
+      name: partials__display
+      data:
+      - component: status
+        variant: banner
+      - component: theme
+        variant: caution
+      - component: cookie
+    selector: cookie
+    components:
+    - name: paragraph
+      data:
+      - content: shared.header.cookie-banner-text
+        data:
+          link: "/meta/cookie-policy"
+- name: status__banner
+  data:
+    display:
+      name: partials__display
+      data:
+      - component: status
+        variant: banner
+    components:
+    - name: paragraph
+      data:
+      - content: shared.header.beta-status
+- name: header
+  data:
+    components:
+    - name: link
+      data:
+        link: "/"
+        display:
+          name: partials__display
+          data:
+          - component: uk_parliament
+        label: shared.header.label
+        components:
+        - name: icon__uk-parliament
+          data: shared.header.label
+    - name: form__search
+      data:
+        global: true
+        label: search.label
+        components:
+        - name: icon__search
+          data: search.search-icon
+        search-action: "/search"
+main-components:
+- name: section__primary
+  data:
+    components:
+    - name: heading1
+      data:
+        subheading:
+          content: <a href="/groups/XouN12Ow">groupName - 1</a>
+        heading:
+          content: Layings
+- name: section__section
+  data:
+    components:
+    - name: list__generic
+      data:
+        type: ol
+        display:
+          name: partials__display
+          data:
+          - component: list
+            variant: block
+        components:
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: laidThingName - 1
+                size: 2
+                link: "/statutory-instruments/xic2yu5i"
+            paragraph:
+              name: paragraph
+              data:
+              - content: groups.layings.date
+                data:
+                  date: 20 April 2018
+              - content: groups.layings.type
+                data:
+                  type: Statutory Instrument
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: laidThingName - 2
+                size: 2
+                link: "/statutory-instruments/O8GS8jnH"
+            paragraph:
+              name: paragraph
+              data:
+              - content: groups.layings.date
+                data:
+                  date: 3 April 2018
+              - content: groups.layings.type
+                data:
+                  type: Statutory Instrument
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: laidThingName - 3
+                size: 2
+                link: "/statutory-instruments/AaXxxzda"
+            paragraph:
+              name: paragraph
+              data:
+              - content: groups.layings.date
+                data:
+                  date: 3 April 2018
+              - content: groups.layings.type
+                data:
+                  type: Statutory Instrument
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: laidThingName - 4
+                size: 2
+                link: "/statutory-instruments/daySypEn"
+            paragraph:
+              name: paragraph
+              data:
+              - content: groups.layings.date
+                data:
+                  date: 3 April 2018
+              - content: groups.layings.type
+                data:
+                  type: Statutory Instrument
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: laidThingName - 5
+                size: 2
+                link: "/statutory-instruments/9PfnbabC"
+            paragraph:
+              name: paragraph
+              data:
+              - content: groups.layings.date
+                data:
+                  date: 16 May 2018
+              - content: groups.layings.type
+                data:
+                  type: Statutory Instrument
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: laidThingName - 6
+                size: 2
+                link: "/statutory-instruments/8xNcqHgV"
+            paragraph:
+              name: paragraph
+              data:
+              - content: groups.layings.date
+                data:
+                  date: 7 June 2018
+              - content: groups.layings.type
+                data:
+                  type: Statutory Instrument
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: laidThingName - 7
+                size: 2
+                link: "/statutory-instruments/LldrrMNS"
+            paragraph:
+              name: paragraph
+              data:
+              - content: groups.layings.date
+                data:
+                  date: 8 June 2018
+              - content: groups.layings.type
+                data:
+                  type: Statutory Instrument
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: laidThingName - 8
+                size: 2
+                link: "/statutory-instruments/nohxpB6K"
+            paragraph:
+              name: paragraph
+              data:
+              - content: groups.layings.date
+                data:
+                  date: 8 June 2018
+              - content: groups.layings.type
+                data:
+                  type: Statutory Instrument
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: laidThingName - 9
+                size: 2
+                link: "/statutory-instruments/rdYNYrB9"
+            paragraph:
+              name: paragraph
+              data:
+              - content: groups.layings.date
+                data:
+                  date: 15 June 2018
+              - content: groups.layings.type
+                data:
+                  type: Statutory Instrument
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: laidThingName - 10
+                size: 2
+                link: "/statutory-instruments/NTd30zpo"
+            paragraph:
+              name: paragraph
+              data:
+              - content: groups.layings.date
+                data:
+                  date: 28 June 2018
+              - content: groups.layings.type
+                data:
+                  type: Statutory Instrument
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: laidThingName - 11
+                size: 2
+                link: "/statutory-instruments/C8kKvTBL"
+            paragraph:
+              name: paragraph
+              data:
+              - content: groups.layings.date
+                data:
+                  date: 2 July 2018
+              - content: groups.layings.type
+                data:
+                  type: Statutory Instrument
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: laidThingName - 12
+                size: 2
+                link: "/statutory-instruments/BZPGfEza"
+            paragraph:
+              name: paragraph
+              data:
+              - content: groups.layings.date
+                data:
+                  date: 2 July 2018
+              - content: groups.layings.type
+                data:
+                  type: Statutory Instrument
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: laidThingName - 13
+                size: 2
+                link: "/statutory-instruments/KF90wtY4"
+            paragraph:
+              name: paragraph
+              data:
+              - content: groups.layings.date
+                data:
+                  date: 9 July 2018
+              - content: groups.layings.type
+                data:
+                  type: Statutory Instrument
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: laidThingName - 14
+                size: 2
+                link: "/statutory-instruments/55gPdheg"
+            paragraph:
+              name: paragraph
+              data:
+              - content: groups.layings.date
+                data:
+                  date: 13 July 2018
+              - content: groups.layings.type
+                data:
+                  type: Statutory Instrument
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: laidThingName - 15
+                size: 2
+                link: "/proposed-negative-statutory-instruments/Tn1xqHc0"
+            paragraph:
+              name: paragraph
+              data:
+              - content: groups.layings.date
+                data:
+                  date: 19 July 2018
+              - content: groups.layings.type
+                data:
+                  type: Proposed Negative Statutory Instrument
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: laidThingName - 16
+                size: 2
+                link: "/proposed-negative-statutory-instruments/wzsrSFQP"
+            paragraph:
+              name: paragraph
+              data:
+              - content: groups.layings.date
+                data:
+                  date: 19 July 2018
+              - content: groups.layings.type
+                data:
+                  type: Proposed Negative Statutory Instrument
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: laidThingName - 17
+                size: 2
+                link: "/proposed-negative-statutory-instruments/H95FzZVv"
+            paragraph:
+              name: paragraph
+              data:
+              - content: groups.layings.date
+                data:
+                  date: 19 July 2018
+              - content: groups.layings.type
+                data:
+                  type: Proposed Negative Statutory Instrument
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: laidThingName - 18
+                size: 2
+                link: "/statutory-instruments/QI5WArIQ"
+            paragraph:
+              name: paragraph
+              data:
+              - content: groups.layings.date
+                data:
+                  date: 19 July 2018
+              - content: groups.layings.type
+                data:
+                  type: Statutory Instrument
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: laidThingName - 19
+                size: 2
+                link: "/proposed-negative-statutory-instruments/cL5yuFbG"
+            paragraph:
+              name: paragraph
+              data:
+              - content: groups.layings.date
+                data:
+                  date: 19 July 2018
+              - content: groups.layings.type
+                data:
+                  type: Proposed Negative Statutory Instrument
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: laidThingName - 20
+                size: 2
+                link: "/proposed-negative-statutory-instruments/mssRQnqj"
+            paragraph:
+              name: paragraph
+              data:
+              - content: groups.layings.date
+                data:
+                  date: 19 July 2018
+              - content: groups.layings.type
+                data:
+                  type: Proposed Negative Statutory Instrument
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: laidThingName - 21
+                size: 2
+                link: "/statutory-instruments/ePPVgmgN"
+            paragraph:
+              name: paragraph
+              data:
+              - content: groups.layings.date
+                data:
+                  date: 23 July 2018
+              - content: groups.layings.type
+                data:
+                  type: Statutory Instrument
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: laidThingName - 22
+                size: 2
+                link: "/statutory-instruments/qRweamaE"
+            paragraph:
+              name: paragraph
+              data:
+              - content: groups.layings.date
+                data:
+                  date: 23 July 2018
+              - content: groups.layings.type
+                data:
+                  type: Statutory Instrument
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: laidThingName - 23
+                size: 2
+                link: "/statutory-instruments/YdIWHZS3"
+            paragraph:
+              name: paragraph
+              data:
+              - content: groups.layings.date
+                data:
+                  date: 23 July 2018
+              - content: groups.layings.type
+                data:
+                  type: Statutory Instrument
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: laidThingName - 24
+                size: 2
+                link: "/statutory-instruments/l05U8jIT"
+            paragraph:
+              name: paragraph
+              data:
+              - content: groups.layings.date
+                data:
+                  date: 7 September 2018
+              - content: groups.layings.type
+                data:
+                  type: Statutory Instrument
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: laidThingName - 25
+                size: 2
+                link: "/statutory-instruments/IyxF7Re7"
+            paragraph:
+              name: paragraph
+              data:
+              - content: groups.layings.date
+                data:
+                  date: 13 September 2018
+              - content: groups.layings.type
+                data:
+                  type: Statutory Instrument
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: laidThingName - 26
+                size: 2
+                link: "/statutory-instruments/vWSvjJPY"
+            paragraph:
+              name: paragraph
+              data:
+              - content: groups.layings.date
+                data:
+                  date: 13 September 2018
+              - content: groups.layings.type
+                data:
+                  type: Statutory Instrument
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: laidThingName - 27
+                size: 2
+                link: "/statutory-instruments/558R1vHw"
+            paragraph:
+              name: paragraph
+              data:
+              - content: groups.layings.date
+                data:
+                  date: 17 September 2018
+              - content: groups.layings.type
+                data:
+                  type: Statutory Instrument
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: laidThingName - 28
+                size: 2
+                link: "/proposed-negative-statutory-instruments/eIcl19m5"
+            paragraph:
+              name: paragraph
+              data:
+              - content: groups.layings.date
+                data:
+                  date: 18 September 2018
+              - content: groups.layings.type
+                data:
+                  type: Proposed Negative Statutory Instrument
+footer-components:
+- name: footer
+  data:
+    uk-parliament: shared.footer.uk-parliament
+    components:
+    - name: list__generic
+      data:
+        type: ul
+        display:
+          name: partials__display
+          data:
+          - component: list
+        contents:
+        - content: shared.footer.current-website
+        - content: shared.footer.cookie-policy
+          data:
+            link: "/meta/cookie-policy"
+        - content: shared.footer.data-protection-privacy

--- a/spec/fixtures/serializers/component_serializer/heading1_component_serializer/no_subheading_link.yml
+++ b/spec/fixtures/serializers/component_serializer/heading1_component_serializer/no_subheading_link.yml
@@ -1,0 +1,5 @@
+---
+name: heading1
+data:
+  subheading:
+    content: MP for

--- a/spec/fixtures/serializers/component_serializer/heading1_component_serializer/subheading_link.yml
+++ b/spec/fixtures/serializers/component_serializer/heading1_component_serializer/subheading_link.yml
@@ -1,0 +1,5 @@
+---
+name: heading1
+data:
+  subheading:
+    content: <a href="/people/12345678">MP for</a>

--- a/spec/fixtures/serializers/component_serializer/paragraph_component_serializer/any_property.yml
+++ b/spec/fixtures/serializers/component_serializer/paragraph_component_serializer/any_property.yml
@@ -1,0 +1,7 @@
+---
+name: paragraph
+data:
+- content: some content
+  data:
+    one: property
+    yet: another

--- a/spec/fixtures/serializers/page_serializer/list_page_serializer/fixture.yml
+++ b/spec/fixtures/serializers/page_serializer/list_page_serializer/fixture.yml
@@ -2,10 +2,10 @@
 layout:
   template: layout
 meta:
-  title: Test page - UK Parliament
+  title: some meta heading - UK Parliament
   request-id: 123456
   open-graph:
-    title: Test page - UK Parliament
+    title: some meta heading - UK Parliament
     original-url: https://example.com/
     image-url: https://static.parliament.uk/assets-public/opengraph-oblong.png
     image-width: '1200'

--- a/spec/fixtures/vcr_cassettes/Groups_LayingsController/GET_index/calling_the_serializers_correctly/calls_the_Heading1ComponentSerializer_correctly.yml
+++ b/spec/fixtures/vcr_cassettes/Groups_LayingsController/GET_index/calling_the_serializers_correctly/calls_the_Heading1ComponentSerializer_correctly.yml
@@ -1,0 +1,333 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3030/group_layings_index?group_id=XouN12Ow
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      - application/n-triples
+      User-Agent:
+      - Ruby
+      Ocp-Apim-Subscription-Key:
+      - "<AUTH_TOKEN>"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/n-triples
+      Content-Disposition:
+      - inline; filename="index"
+      Last-Modified:
+      - Thu, 04 Oct 2018 14:33:35 GMT
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '40625'
+    body:
+      encoding: UTF-8
+      string: |
+        <https://id.parliament.uk/NDZSYjeE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Group> .
+        <https://id.parliament.uk/NDZSYjeE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LayingBody> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/groupName> "groupName - 1" .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/groupStartDate> "1900-01-01+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/FrRQLlKT> .
+        <https://id.parliament.uk/FrRQLlKT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/FrRQLlKT> <https://id.parliament.uk/schema/layingDate> "2018-04-27+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/FrRQLlKT> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/QV9rpep6> .
+        <https://id.parliament.uk/QV9rpep6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/QV9rpep6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/QV9rpep6> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 1" .
+        <https://id.parliament.uk/QV9rpep6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/QV9rpep6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/QV9rpep6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/QV9rpep6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/p064wsz5> .
+        <https://id.parliament.uk/p064wsz5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/p064wsz5> <https://id.parliament.uk/schema/layingDate> "2018-05-08+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/p064wsz5> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/HJ7BlYte> .
+        <https://id.parliament.uk/HJ7BlYte> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/HJ7BlYte> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/HJ7BlYte> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 2" .
+        <https://id.parliament.uk/HJ7BlYte> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/HJ7BlYte> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/HJ7BlYte> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/HJ7BlYte> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/ZQsu6c18> .
+        <https://id.parliament.uk/ZQsu6c18> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/ZQsu6c18> <https://id.parliament.uk/schema/layingDate> "2018-04-03+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/ZQsu6c18> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/3dAYwLoB> .
+        <https://id.parliament.uk/3dAYwLoB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/3dAYwLoB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/3dAYwLoB> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 3" .
+        <https://id.parliament.uk/3dAYwLoB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/3dAYwLoB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/3dAYwLoB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/3dAYwLoB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/rWaK4CZm> .
+        <https://id.parliament.uk/rWaK4CZm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/rWaK4CZm> <https://id.parliament.uk/schema/layingDate> "2018-05-21+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/rWaK4CZm> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/rjzMGG28> .
+        <https://id.parliament.uk/rjzMGG28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/rjzMGG28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/rjzMGG28> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 4" .
+        <https://id.parliament.uk/rjzMGG28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/rjzMGG28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/rjzMGG28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/rjzMGG28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/8nTtARxa> .
+        <https://id.parliament.uk/8nTtARxa> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/8nTtARxa> <https://id.parliament.uk/schema/layingDate> "2018-05-24+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/8nTtARxa> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/uNiGNHey> .
+        <https://id.parliament.uk/uNiGNHey> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/uNiGNHey> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/uNiGNHey> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 5" .
+        <https://id.parliament.uk/uNiGNHey> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/uNiGNHey> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/uNiGNHey> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/uNiGNHey> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/S0ebryc4> .
+        <https://id.parliament.uk/S0ebryc4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/S0ebryc4> <https://id.parliament.uk/schema/layingDate> "2018-05-18+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/S0ebryc4> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/8HUWJm9e> .
+        <https://id.parliament.uk/8HUWJm9e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/8HUWJm9e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/8HUWJm9e> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 6" .
+        <https://id.parliament.uk/8HUWJm9e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/8HUWJm9e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/8HUWJm9e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/8HUWJm9e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/Je3lAVxM> .
+        <https://id.parliament.uk/Je3lAVxM> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/Je3lAVxM> <https://id.parliament.uk/schema/layingDate> "2018-06-04+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/Je3lAVxM> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/ez3sdNNT> .
+        <https://id.parliament.uk/ez3sdNNT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/ez3sdNNT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/ez3sdNNT> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 7" .
+        <https://id.parliament.uk/ez3sdNNT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/ez3sdNNT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/ez3sdNNT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/ez3sdNNT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/TZR852WV> .
+        <https://id.parliament.uk/TZR852WV> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/TZR852WV> <https://id.parliament.uk/schema/layingDate> "2018-06-06+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/TZR852WV> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/w3m931qg> .
+        <https://id.parliament.uk/w3m931qg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/w3m931qg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/w3m931qg> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 8" .
+        <https://id.parliament.uk/w3m931qg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/w3m931qg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/w3m931qg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/w3m931qg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/630Ft4k4> .
+        <https://id.parliament.uk/630Ft4k4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/630Ft4k4> <https://id.parliament.uk/schema/layingDate> "2018-06-08+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/630Ft4k4> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/PhwmELqG> .
+        <https://id.parliament.uk/PhwmELqG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/PhwmELqG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/PhwmELqG> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 9" .
+        <https://id.parliament.uk/PhwmELqG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/PhwmELqG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/PhwmELqG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/PhwmELqG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/SKzgadiu> .
+        <https://id.parliament.uk/SKzgadiu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/SKzgadiu> <https://id.parliament.uk/schema/layingDate> "2018-06-13+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/SKzgadiu> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/aQaZuLyK> .
+        <https://id.parliament.uk/aQaZuLyK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/aQaZuLyK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/aQaZuLyK> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 10" .
+        <https://id.parliament.uk/aQaZuLyK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/aQaZuLyK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/aQaZuLyK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/aQaZuLyK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/nBIracyf> .
+        <https://id.parliament.uk/nBIracyf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/nBIracyf> <https://id.parliament.uk/schema/layingDate> "2018-06-13+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/nBIracyf> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/I9rWxORS> .
+        <https://id.parliament.uk/I9rWxORS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/I9rWxORS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/I9rWxORS> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 11" .
+        <https://id.parliament.uk/I9rWxORS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/I9rWxORS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/I9rWxORS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/I9rWxORS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/ktlPPWYD> .
+        <https://id.parliament.uk/ktlPPWYD> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/ktlPPWYD> <https://id.parliament.uk/schema/layingDate> "2018-06-15+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/ktlPPWYD> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/9Nv0gELe> .
+        <https://id.parliament.uk/9Nv0gELe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/9Nv0gELe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/9Nv0gELe> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 12" .
+        <https://id.parliament.uk/9Nv0gELe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/9Nv0gELe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/9Nv0gELe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/9Nv0gELe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/yzmWisVv> .
+        <https://id.parliament.uk/yzmWisVv> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/yzmWisVv> <https://id.parliament.uk/schema/layingDate> "2018-06-18+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/yzmWisVv> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/YhMNMpYo> .
+        <https://id.parliament.uk/YhMNMpYo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/YhMNMpYo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/YhMNMpYo> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 13" .
+        <https://id.parliament.uk/YhMNMpYo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/YhMNMpYo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/YhMNMpYo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/YhMNMpYo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/9UPBD2Md> .
+        <https://id.parliament.uk/9UPBD2Md> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/9UPBD2Md> <https://id.parliament.uk/schema/layingDate> "2018-06-25+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/9UPBD2Md> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/UD4HjKbu> .
+        <https://id.parliament.uk/UD4HjKbu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/UD4HjKbu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/UD4HjKbu> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 14" .
+        <https://id.parliament.uk/UD4HjKbu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/UD4HjKbu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/UD4HjKbu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/UD4HjKbu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/FafO3XiI> .
+        <https://id.parliament.uk/FafO3XiI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/FafO3XiI> <https://id.parliament.uk/schema/layingDate> "2018-06-28+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/FafO3XiI> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/P5Zu6fkP> .
+        <https://id.parliament.uk/P5Zu6fkP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/P5Zu6fkP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/P5Zu6fkP> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 15" .
+        <https://id.parliament.uk/P5Zu6fkP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/P5Zu6fkP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/P5Zu6fkP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/P5Zu6fkP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/Wd3zlHhD> .
+        <https://id.parliament.uk/Wd3zlHhD> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/Wd3zlHhD> <https://id.parliament.uk/schema/layingDate> "2018-07-03+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/Wd3zlHhD> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/JXxhQblu> .
+        <https://id.parliament.uk/JXxhQblu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/JXxhQblu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/JXxhQblu> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 16" .
+        <https://id.parliament.uk/JXxhQblu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/JXxhQblu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/JXxhQblu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/JXxhQblu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/i4m8WLDM> .
+        <https://id.parliament.uk/i4m8WLDM> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/i4m8WLDM> <https://id.parliament.uk/schema/layingDate> "2018-07-02+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/i4m8WLDM> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/IjLgnN8z> .
+        <https://id.parliament.uk/IjLgnN8z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/IjLgnN8z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/IjLgnN8z> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 17" .
+        <https://id.parliament.uk/IjLgnN8z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/IjLgnN8z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/IjLgnN8z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/IjLgnN8z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/JBIhn7el> .
+        <https://id.parliament.uk/JBIhn7el> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/JBIhn7el> <https://id.parliament.uk/schema/layingDate> "2018-07-12+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/JBIhn7el> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/BRZBy463> .
+        <https://id.parliament.uk/BRZBy463> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/BRZBy463> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/BRZBy463> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 18" .
+        <https://id.parliament.uk/BRZBy463> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/BRZBy463> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/BRZBy463> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/BRZBy463> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/MAHrwKV2> .
+        <https://id.parliament.uk/MAHrwKV2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/MAHrwKV2> <https://id.parliament.uk/schema/layingDate> "2018-07-19+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/MAHrwKV2> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/Uhsvsfdn> .
+        <https://id.parliament.uk/Uhsvsfdn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/Uhsvsfdn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/Uhsvsfdn> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 19" .
+        <https://id.parliament.uk/Uhsvsfdn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/Uhsvsfdn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/Uhsvsfdn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/Uhsvsfdn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/vAu6L0Zc> .
+        <https://id.parliament.uk/vAu6L0Zc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/vAu6L0Zc> <https://id.parliament.uk/schema/layingDate> "2018-07-20+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/vAu6L0Zc> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/SbxmGLcR> .
+        <https://id.parliament.uk/SbxmGLcR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/SbxmGLcR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/SbxmGLcR> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 20" .
+        <https://id.parliament.uk/SbxmGLcR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/SbxmGLcR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/SbxmGLcR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/SbxmGLcR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/4mREgKhH> .
+        <https://id.parliament.uk/4mREgKhH> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/4mREgKhH> <https://id.parliament.uk/schema/layingDate> "2018-07-25+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/4mREgKhH> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/W3l3iqIJ> .
+        <https://id.parliament.uk/W3l3iqIJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/W3l3iqIJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/W3l3iqIJ> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 21" .
+        <https://id.parliament.uk/W3l3iqIJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/W3l3iqIJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/W3l3iqIJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/W3l3iqIJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ProposedNegativeStatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/biZLgqIV> .
+        <https://id.parliament.uk/biZLgqIV> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/biZLgqIV> <https://id.parliament.uk/schema/layingDate> "2018-07-26+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/biZLgqIV> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/hLF7ZU6f> .
+        <https://id.parliament.uk/hLF7ZU6f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/hLF7ZU6f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/hLF7ZU6f> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 22" .
+        <https://id.parliament.uk/hLF7ZU6f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/hLF7ZU6f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/hLF7ZU6f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/hLF7ZU6f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/jNi948H2> .
+        <https://id.parliament.uk/jNi948H2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/jNi948H2> <https://id.parliament.uk/schema/layingDate> "2018-09-06+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/jNi948H2> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/BuMKAKjA> .
+        <https://id.parliament.uk/BuMKAKjA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/BuMKAKjA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/BuMKAKjA> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 23" .
+        <https://id.parliament.uk/BuMKAKjA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/BuMKAKjA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/BuMKAKjA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/BuMKAKjA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/BuMKAKjA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/MadeStatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/yGqCp359> .
+        <https://id.parliament.uk/yGqCp359> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/yGqCp359> <https://id.parliament.uk/schema/layingDate> "2018-09-10+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/yGqCp359> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/WBlaNvyq> .
+        <https://id.parliament.uk/WBlaNvyq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/WBlaNvyq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/WBlaNvyq> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 24" .
+        <https://id.parliament.uk/WBlaNvyq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/WBlaNvyq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/WBlaNvyq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/WBlaNvyq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/WBlaNvyq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/MadeStatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/4JKyg0Au> .
+        <https://id.parliament.uk/4JKyg0Au> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/4JKyg0Au> <https://id.parliament.uk/schema/layingDate> "2018-09-13+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/4JKyg0Au> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/lSRBYtGi> .
+        <https://id.parliament.uk/lSRBYtGi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/lSRBYtGi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/lSRBYtGi> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 25" .
+        <https://id.parliament.uk/lSRBYtGi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/lSRBYtGi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/lSRBYtGi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/lSRBYtGi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/lSRBYtGi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/MadeStatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/C6qh45v5> .
+        <https://id.parliament.uk/C6qh45v5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/C6qh45v5> <https://id.parliament.uk/schema/layingDate> "2018-09-13+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/C6qh45v5> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/H1uGO0VI> .
+        <https://id.parliament.uk/H1uGO0VI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/H1uGO0VI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/H1uGO0VI> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 26" .
+        <https://id.parliament.uk/H1uGO0VI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/H1uGO0VI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/H1uGO0VI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/H1uGO0VI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/H1uGO0VI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/MadeStatutoryInstrumentPaper> .
+    http_version: 
+  recorded_at: Mon, 08 Oct 2018 12:44:40 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Groups_LayingsController/GET_index/calling_the_serializers_correctly/calls_the_ListPageSerializer_correctly.yml
+++ b/spec/fixtures/vcr_cassettes/Groups_LayingsController/GET_index/calling_the_serializers_correctly/calls_the_ListPageSerializer_correctly.yml
@@ -1,0 +1,333 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3030/group_layings_index?group_id=XouN12Ow
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      - application/n-triples
+      User-Agent:
+      - Ruby
+      Ocp-Apim-Subscription-Key:
+      - "<AUTH_TOKEN>"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/n-triples
+      Content-Disposition:
+      - inline; filename="index"
+      Last-Modified:
+      - Thu, 04 Oct 2018 14:33:35 GMT
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '40625'
+    body:
+      encoding: UTF-8
+      string: |
+        <https://id.parliament.uk/NDZSYjeE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Group> .
+        <https://id.parliament.uk/NDZSYjeE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LayingBody> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/groupName> "groupName - 1" .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/groupStartDate> "1900-01-01+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/FrRQLlKT> .
+        <https://id.parliament.uk/FrRQLlKT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/FrRQLlKT> <https://id.parliament.uk/schema/layingDate> "2018-04-27+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/FrRQLlKT> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/QV9rpep6> .
+        <https://id.parliament.uk/QV9rpep6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/QV9rpep6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/QV9rpep6> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 1" .
+        <https://id.parliament.uk/QV9rpep6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/QV9rpep6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/QV9rpep6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/QV9rpep6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/p064wsz5> .
+        <https://id.parliament.uk/p064wsz5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/p064wsz5> <https://id.parliament.uk/schema/layingDate> "2018-05-08+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/p064wsz5> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/HJ7BlYte> .
+        <https://id.parliament.uk/HJ7BlYte> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/HJ7BlYte> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/HJ7BlYte> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 2" .
+        <https://id.parliament.uk/HJ7BlYte> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/HJ7BlYte> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/HJ7BlYte> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/HJ7BlYte> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/ZQsu6c18> .
+        <https://id.parliament.uk/ZQsu6c18> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/ZQsu6c18> <https://id.parliament.uk/schema/layingDate> "2018-04-03+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/ZQsu6c18> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/3dAYwLoB> .
+        <https://id.parliament.uk/3dAYwLoB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/3dAYwLoB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/3dAYwLoB> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 3" .
+        <https://id.parliament.uk/3dAYwLoB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/3dAYwLoB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/3dAYwLoB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/3dAYwLoB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/rWaK4CZm> .
+        <https://id.parliament.uk/rWaK4CZm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/rWaK4CZm> <https://id.parliament.uk/schema/layingDate> "2018-05-21+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/rWaK4CZm> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/rjzMGG28> .
+        <https://id.parliament.uk/rjzMGG28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/rjzMGG28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/rjzMGG28> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 4" .
+        <https://id.parliament.uk/rjzMGG28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/rjzMGG28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/rjzMGG28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/rjzMGG28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/8nTtARxa> .
+        <https://id.parliament.uk/8nTtARxa> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/8nTtARxa> <https://id.parliament.uk/schema/layingDate> "2018-05-24+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/8nTtARxa> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/uNiGNHey> .
+        <https://id.parliament.uk/uNiGNHey> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/uNiGNHey> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/uNiGNHey> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 5" .
+        <https://id.parliament.uk/uNiGNHey> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/uNiGNHey> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/uNiGNHey> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/uNiGNHey> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/S0ebryc4> .
+        <https://id.parliament.uk/S0ebryc4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/S0ebryc4> <https://id.parliament.uk/schema/layingDate> "2018-05-18+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/S0ebryc4> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/8HUWJm9e> .
+        <https://id.parliament.uk/8HUWJm9e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/8HUWJm9e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/8HUWJm9e> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 6" .
+        <https://id.parliament.uk/8HUWJm9e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/8HUWJm9e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/8HUWJm9e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/8HUWJm9e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/Je3lAVxM> .
+        <https://id.parliament.uk/Je3lAVxM> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/Je3lAVxM> <https://id.parliament.uk/schema/layingDate> "2018-06-04+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/Je3lAVxM> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/ez3sdNNT> .
+        <https://id.parliament.uk/ez3sdNNT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/ez3sdNNT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/ez3sdNNT> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 7" .
+        <https://id.parliament.uk/ez3sdNNT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/ez3sdNNT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/ez3sdNNT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/ez3sdNNT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/TZR852WV> .
+        <https://id.parliament.uk/TZR852WV> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/TZR852WV> <https://id.parliament.uk/schema/layingDate> "2018-06-06+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/TZR852WV> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/w3m931qg> .
+        <https://id.parliament.uk/w3m931qg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/w3m931qg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/w3m931qg> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 8" .
+        <https://id.parliament.uk/w3m931qg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/w3m931qg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/w3m931qg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/w3m931qg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/630Ft4k4> .
+        <https://id.parliament.uk/630Ft4k4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/630Ft4k4> <https://id.parliament.uk/schema/layingDate> "2018-06-08+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/630Ft4k4> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/PhwmELqG> .
+        <https://id.parliament.uk/PhwmELqG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/PhwmELqG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/PhwmELqG> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 9" .
+        <https://id.parliament.uk/PhwmELqG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/PhwmELqG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/PhwmELqG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/PhwmELqG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/SKzgadiu> .
+        <https://id.parliament.uk/SKzgadiu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/SKzgadiu> <https://id.parliament.uk/schema/layingDate> "2018-06-13+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/SKzgadiu> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/aQaZuLyK> .
+        <https://id.parliament.uk/aQaZuLyK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/aQaZuLyK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/aQaZuLyK> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 10" .
+        <https://id.parliament.uk/aQaZuLyK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/aQaZuLyK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/aQaZuLyK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/aQaZuLyK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/nBIracyf> .
+        <https://id.parliament.uk/nBIracyf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/nBIracyf> <https://id.parliament.uk/schema/layingDate> "2018-06-13+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/nBIracyf> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/I9rWxORS> .
+        <https://id.parliament.uk/I9rWxORS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/I9rWxORS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/I9rWxORS> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 11" .
+        <https://id.parliament.uk/I9rWxORS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/I9rWxORS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/I9rWxORS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/I9rWxORS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/ktlPPWYD> .
+        <https://id.parliament.uk/ktlPPWYD> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/ktlPPWYD> <https://id.parliament.uk/schema/layingDate> "2018-06-15+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/ktlPPWYD> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/9Nv0gELe> .
+        <https://id.parliament.uk/9Nv0gELe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/9Nv0gELe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/9Nv0gELe> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 12" .
+        <https://id.parliament.uk/9Nv0gELe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/9Nv0gELe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/9Nv0gELe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/9Nv0gELe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/yzmWisVv> .
+        <https://id.parliament.uk/yzmWisVv> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/yzmWisVv> <https://id.parliament.uk/schema/layingDate> "2018-06-18+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/yzmWisVv> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/YhMNMpYo> .
+        <https://id.parliament.uk/YhMNMpYo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/YhMNMpYo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/YhMNMpYo> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 13" .
+        <https://id.parliament.uk/YhMNMpYo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/YhMNMpYo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/YhMNMpYo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/YhMNMpYo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/9UPBD2Md> .
+        <https://id.parliament.uk/9UPBD2Md> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/9UPBD2Md> <https://id.parliament.uk/schema/layingDate> "2018-06-25+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/9UPBD2Md> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/UD4HjKbu> .
+        <https://id.parliament.uk/UD4HjKbu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/UD4HjKbu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/UD4HjKbu> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 14" .
+        <https://id.parliament.uk/UD4HjKbu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/UD4HjKbu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/UD4HjKbu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/UD4HjKbu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/FafO3XiI> .
+        <https://id.parliament.uk/FafO3XiI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/FafO3XiI> <https://id.parliament.uk/schema/layingDate> "2018-06-28+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/FafO3XiI> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/P5Zu6fkP> .
+        <https://id.parliament.uk/P5Zu6fkP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/P5Zu6fkP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/P5Zu6fkP> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 15" .
+        <https://id.parliament.uk/P5Zu6fkP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/P5Zu6fkP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/P5Zu6fkP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/P5Zu6fkP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/Wd3zlHhD> .
+        <https://id.parliament.uk/Wd3zlHhD> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/Wd3zlHhD> <https://id.parliament.uk/schema/layingDate> "2018-07-03+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/Wd3zlHhD> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/JXxhQblu> .
+        <https://id.parliament.uk/JXxhQblu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/JXxhQblu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/JXxhQblu> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 16" .
+        <https://id.parliament.uk/JXxhQblu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/JXxhQblu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/JXxhQblu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/JXxhQblu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/i4m8WLDM> .
+        <https://id.parliament.uk/i4m8WLDM> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/i4m8WLDM> <https://id.parliament.uk/schema/layingDate> "2018-07-02+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/i4m8WLDM> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/IjLgnN8z> .
+        <https://id.parliament.uk/IjLgnN8z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/IjLgnN8z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/IjLgnN8z> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 17" .
+        <https://id.parliament.uk/IjLgnN8z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/IjLgnN8z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/IjLgnN8z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/IjLgnN8z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/JBIhn7el> .
+        <https://id.parliament.uk/JBIhn7el> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/JBIhn7el> <https://id.parliament.uk/schema/layingDate> "2018-07-12+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/JBIhn7el> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/BRZBy463> .
+        <https://id.parliament.uk/BRZBy463> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/BRZBy463> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/BRZBy463> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 18" .
+        <https://id.parliament.uk/BRZBy463> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/BRZBy463> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/BRZBy463> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/BRZBy463> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/MAHrwKV2> .
+        <https://id.parliament.uk/MAHrwKV2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/MAHrwKV2> <https://id.parliament.uk/schema/layingDate> "2018-07-19+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/MAHrwKV2> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/Uhsvsfdn> .
+        <https://id.parliament.uk/Uhsvsfdn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/Uhsvsfdn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/Uhsvsfdn> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 19" .
+        <https://id.parliament.uk/Uhsvsfdn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/Uhsvsfdn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/Uhsvsfdn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/Uhsvsfdn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/vAu6L0Zc> .
+        <https://id.parliament.uk/vAu6L0Zc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/vAu6L0Zc> <https://id.parliament.uk/schema/layingDate> "2018-07-20+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/vAu6L0Zc> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/SbxmGLcR> .
+        <https://id.parliament.uk/SbxmGLcR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/SbxmGLcR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/SbxmGLcR> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 20" .
+        <https://id.parliament.uk/SbxmGLcR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/SbxmGLcR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/SbxmGLcR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/SbxmGLcR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/4mREgKhH> .
+        <https://id.parliament.uk/4mREgKhH> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/4mREgKhH> <https://id.parliament.uk/schema/layingDate> "2018-07-25+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/4mREgKhH> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/W3l3iqIJ> .
+        <https://id.parliament.uk/W3l3iqIJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/W3l3iqIJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/W3l3iqIJ> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 21" .
+        <https://id.parliament.uk/W3l3iqIJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/W3l3iqIJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/W3l3iqIJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/W3l3iqIJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ProposedNegativeStatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/biZLgqIV> .
+        <https://id.parliament.uk/biZLgqIV> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/biZLgqIV> <https://id.parliament.uk/schema/layingDate> "2018-07-26+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/biZLgqIV> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/hLF7ZU6f> .
+        <https://id.parliament.uk/hLF7ZU6f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/hLF7ZU6f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/hLF7ZU6f> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 22" .
+        <https://id.parliament.uk/hLF7ZU6f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/hLF7ZU6f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/hLF7ZU6f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/hLF7ZU6f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/jNi948H2> .
+        <https://id.parliament.uk/jNi948H2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/jNi948H2> <https://id.parliament.uk/schema/layingDate> "2018-09-06+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/jNi948H2> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/BuMKAKjA> .
+        <https://id.parliament.uk/BuMKAKjA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/BuMKAKjA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/BuMKAKjA> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 23" .
+        <https://id.parliament.uk/BuMKAKjA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/BuMKAKjA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/BuMKAKjA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/BuMKAKjA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/BuMKAKjA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/MadeStatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/yGqCp359> .
+        <https://id.parliament.uk/yGqCp359> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/yGqCp359> <https://id.parliament.uk/schema/layingDate> "2018-09-10+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/yGqCp359> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/WBlaNvyq> .
+        <https://id.parliament.uk/WBlaNvyq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/WBlaNvyq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/WBlaNvyq> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 24" .
+        <https://id.parliament.uk/WBlaNvyq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/WBlaNvyq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/WBlaNvyq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/WBlaNvyq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/WBlaNvyq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/MadeStatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/4JKyg0Au> .
+        <https://id.parliament.uk/4JKyg0Au> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/4JKyg0Au> <https://id.parliament.uk/schema/layingDate> "2018-09-13+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/4JKyg0Au> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/lSRBYtGi> .
+        <https://id.parliament.uk/lSRBYtGi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/lSRBYtGi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/lSRBYtGi> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 25" .
+        <https://id.parliament.uk/lSRBYtGi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/lSRBYtGi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/lSRBYtGi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/lSRBYtGi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/lSRBYtGi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/MadeStatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/C6qh45v5> .
+        <https://id.parliament.uk/C6qh45v5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/C6qh45v5> <https://id.parliament.uk/schema/layingDate> "2018-09-13+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/C6qh45v5> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/H1uGO0VI> .
+        <https://id.parliament.uk/H1uGO0VI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/H1uGO0VI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/H1uGO0VI> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 26" .
+        <https://id.parliament.uk/H1uGO0VI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/H1uGO0VI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/H1uGO0VI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/H1uGO0VI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/H1uGO0VI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/MadeStatutoryInstrumentPaper> .
+    http_version: 
+  recorded_at: Mon, 08 Oct 2018 12:58:49 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Groups_LayingsController/GET_index/navigating_to_the_index_page/renders_expected_JSON_output.yml
+++ b/spec/fixtures/vcr_cassettes/Groups_LayingsController/GET_index/navigating_to_the_index_page/renders_expected_JSON_output.yml
@@ -1,0 +1,510 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3030/group_layings_index?group_id=XouN12Ow
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      - application/n-triples
+      User-Agent:
+      - Ruby
+      Ocp-Apim-Subscription-Key:
+      - "<AUTH_TOKEN>"
+      Api-Version:
+      - Staging
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '3020'
+      Content-Type:
+      - application/n-triples
+      Expires:
+      - Tue, 16 Oct 2018 15:12:28 GMT
+      Request-Context:
+      - appId=cid-v1:330aa411-57af-491f-b22a-1cab7d08a6a9
+      Access-Control-Expose-Headers:
+      - Request-Context
+      Set-Cookie:
+      - ARRAffinity=51129f6ce0b17a195eed11bdad8f788427b282cd2b3794cb0536e014bc0b3fc3;Path=/;HttpOnly;Domain=fixedquery201810051005.azurewebsites.net
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Tue, 16 Oct 2018 15:12:27 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "<https://id.parliament.uk/XouN12Ow> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Group> .\r\n<https://id.parliament.uk/XouN12Ow>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LayingBody>
+        .\r\n<https://id.parliament.uk/XouN12Ow> <https://id.parliament.uk/schema/groupName>
+        \"groupName - 1\" .\r\n<https://id.parliament.uk/XouN12Ow> <https://id.parliament.uk/schema/groupStartDate>
+        \"2002-05-29+00:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/XouN12Ow>
+        <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/c240s9cD>
+        .\r\n<https://id.parliament.uk/c240s9cD> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/c240s9cD>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-20+00:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/c240s9cD> <https://id.parliament.uk/schema/layingHasLaidThing>
+        <https://id.parliament.uk/xic2yu5i> .\r\n<https://id.parliament.uk/xic2yu5i>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/xic2yu5i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <http://www.w3.org/2000/01/rdf-schema#Resource> .\r\n<https://id.parliament.uk/xic2yu5i>
+        <https://id.parliament.uk/schema/laidThingName> \"laidThingName - 1\" .\r\n<https://id.parliament.uk/xic2yu5i>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing>
+        .\r\n<https://id.parliament.uk/xic2yu5i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WebLinkedThing> .\r\n<https://id.parliament.uk/xic2yu5i>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/xic2yu5i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/XouN12Ow>
+        <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/KgB4r60a>
+        .\r\n<https://id.parliament.uk/KgB4r60a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/KgB4r60a>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-03+00:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/KgB4r60a> <https://id.parliament.uk/schema/layingHasLaidThing>
+        <https://id.parliament.uk/O8GS8jnH> .\r\n<https://id.parliament.uk/O8GS8jnH>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/O8GS8jnH> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <http://www.w3.org/2000/01/rdf-schema#Resource> .\r\n<https://id.parliament.uk/O8GS8jnH>
+        <https://id.parliament.uk/schema/laidThingName> \"laidThingName - 2\" .\r\n<https://id.parliament.uk/O8GS8jnH>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing>
+        .\r\n<https://id.parliament.uk/O8GS8jnH> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WebLinkedThing> .\r\n<https://id.parliament.uk/O8GS8jnH>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/O8GS8jnH> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/XouN12Ow>
+        <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/Phw9bTAd>
+        .\r\n<https://id.parliament.uk/Phw9bTAd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/Phw9bTAd>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-03+00:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/Phw9bTAd> <https://id.parliament.uk/schema/layingHasLaidThing>
+        <https://id.parliament.uk/AaXxxzda> .\r\n<https://id.parliament.uk/AaXxxzda>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/AaXxxzda> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <http://www.w3.org/2000/01/rdf-schema#Resource> .\r\n<https://id.parliament.uk/AaXxxzda>
+        <https://id.parliament.uk/schema/laidThingName> \"laidThingName - 3\" .\r\n<https://id.parliament.uk/AaXxxzda>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing>
+        .\r\n<https://id.parliament.uk/AaXxxzda> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WebLinkedThing> .\r\n<https://id.parliament.uk/AaXxxzda>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/AaXxxzda> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/XouN12Ow>
+        <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/pg0TWSqT>
+        .\r\n<https://id.parliament.uk/pg0TWSqT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/pg0TWSqT>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-03+00:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/pg0TWSqT> <https://id.parliament.uk/schema/layingHasLaidThing>
+        <https://id.parliament.uk/daySypEn> .\r\n<https://id.parliament.uk/daySypEn>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/daySypEn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <http://www.w3.org/2000/01/rdf-schema#Resource> .\r\n<https://id.parliament.uk/daySypEn>
+        <https://id.parliament.uk/schema/laidThingName> \"laidThingName - 4\" .\r\n<https://id.parliament.uk/daySypEn>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing>
+        .\r\n<https://id.parliament.uk/daySypEn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WebLinkedThing> .\r\n<https://id.parliament.uk/daySypEn>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/daySypEn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/XouN12Ow>
+        <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/4ckl6Ecn>
+        .\r\n<https://id.parliament.uk/4ckl6Ecn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/4ckl6Ecn>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-16+00:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/4ckl6Ecn> <https://id.parliament.uk/schema/layingHasLaidThing>
+        <https://id.parliament.uk/9PfnbabC> .\r\n<https://id.parliament.uk/9PfnbabC>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/9PfnbabC> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <http://www.w3.org/2000/01/rdf-schema#Resource> .\r\n<https://id.parliament.uk/9PfnbabC>
+        <https://id.parliament.uk/schema/laidThingName> \"laidThingName - 5\" .\r\n<https://id.parliament.uk/9PfnbabC>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing>
+        .\r\n<https://id.parliament.uk/9PfnbabC> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WebLinkedThing> .\r\n<https://id.parliament.uk/9PfnbabC>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/9PfnbabC> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/XouN12Ow>
+        <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/jzdEemyP>
+        .\r\n<https://id.parliament.uk/jzdEemyP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/jzdEemyP>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-07+00:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/jzdEemyP> <https://id.parliament.uk/schema/layingHasLaidThing>
+        <https://id.parliament.uk/8xNcqHgV> .\r\n<https://id.parliament.uk/8xNcqHgV>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/8xNcqHgV> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <http://www.w3.org/2000/01/rdf-schema#Resource> .\r\n<https://id.parliament.uk/8xNcqHgV>
+        <https://id.parliament.uk/schema/laidThingName> \"laidThingName - 6\" .\r\n<https://id.parliament.uk/8xNcqHgV>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing>
+        .\r\n<https://id.parliament.uk/8xNcqHgV> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WebLinkedThing> .\r\n<https://id.parliament.uk/8xNcqHgV>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/8xNcqHgV> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/XouN12Ow>
+        <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/21jNcoz8>
+        .\r\n<https://id.parliament.uk/21jNcoz8> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/21jNcoz8>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-08+00:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/21jNcoz8> <https://id.parliament.uk/schema/layingHasLaidThing>
+        <https://id.parliament.uk/LldrrMNS> .\r\n<https://id.parliament.uk/LldrrMNS>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/LldrrMNS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <http://www.w3.org/2000/01/rdf-schema#Resource> .\r\n<https://id.parliament.uk/LldrrMNS>
+        <https://id.parliament.uk/schema/laidThingName> \"laidThingName - 7\" .\r\n<https://id.parliament.uk/LldrrMNS>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing>
+        .\r\n<https://id.parliament.uk/LldrrMNS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WebLinkedThing> .\r\n<https://id.parliament.uk/LldrrMNS>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/LldrrMNS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/XouN12Ow>
+        <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/buWmokrg>
+        .\r\n<https://id.parliament.uk/buWmokrg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/buWmokrg>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-08+00:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/buWmokrg> <https://id.parliament.uk/schema/layingHasLaidThing>
+        <https://id.parliament.uk/nohxpB6K> .\r\n<https://id.parliament.uk/nohxpB6K>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/nohxpB6K> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <http://www.w3.org/2000/01/rdf-schema#Resource> .\r\n<https://id.parliament.uk/nohxpB6K>
+        <https://id.parliament.uk/schema/laidThingName> \"laidThingName - 8\" .\r\n<https://id.parliament.uk/nohxpB6K>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing>
+        .\r\n<https://id.parliament.uk/nohxpB6K> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WebLinkedThing> .\r\n<https://id.parliament.uk/nohxpB6K>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/nohxpB6K> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/XouN12Ow>
+        <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/mAHMh7zR>
+        .\r\n<https://id.parliament.uk/mAHMh7zR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/mAHMh7zR>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-15+00:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/mAHMh7zR> <https://id.parliament.uk/schema/layingHasLaidThing>
+        <https://id.parliament.uk/rdYNYrB9> .\r\n<https://id.parliament.uk/rdYNYrB9>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/rdYNYrB9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <http://www.w3.org/2000/01/rdf-schema#Resource> .\r\n<https://id.parliament.uk/rdYNYrB9>
+        <https://id.parliament.uk/schema/laidThingName> \"laidThingName - 9\" .\r\n<https://id.parliament.uk/rdYNYrB9>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing>
+        .\r\n<https://id.parliament.uk/rdYNYrB9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WebLinkedThing> .\r\n<https://id.parliament.uk/rdYNYrB9>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/rdYNYrB9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/XouN12Ow>
+        <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/IsIZtZBp>
+        .\r\n<https://id.parliament.uk/IsIZtZBp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/IsIZtZBp>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-28+00:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/IsIZtZBp> <https://id.parliament.uk/schema/layingHasLaidThing>
+        <https://id.parliament.uk/NTd30zpo> .\r\n<https://id.parliament.uk/NTd30zpo>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/NTd30zpo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <http://www.w3.org/2000/01/rdf-schema#Resource> .\r\n<https://id.parliament.uk/NTd30zpo>
+        <https://id.parliament.uk/schema/laidThingName> \"laidThingName - 10\" .\r\n<https://id.parliament.uk/NTd30zpo>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing>
+        .\r\n<https://id.parliament.uk/NTd30zpo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WebLinkedThing> .\r\n<https://id.parliament.uk/NTd30zpo>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/NTd30zpo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/XouN12Ow>
+        <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/YX81GShN>
+        .\r\n<https://id.parliament.uk/YX81GShN> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/YX81GShN>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-02+00:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/YX81GShN> <https://id.parliament.uk/schema/layingHasLaidThing>
+        <https://id.parliament.uk/C8kKvTBL> .\r\n<https://id.parliament.uk/C8kKvTBL>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/C8kKvTBL> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <http://www.w3.org/2000/01/rdf-schema#Resource> .\r\n<https://id.parliament.uk/C8kKvTBL>
+        <https://id.parliament.uk/schema/laidThingName> \"laidThingName - 11\" .\r\n<https://id.parliament.uk/C8kKvTBL>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing>
+        .\r\n<https://id.parliament.uk/C8kKvTBL> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WebLinkedThing> .\r\n<https://id.parliament.uk/C8kKvTBL>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/C8kKvTBL> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/XouN12Ow>
+        <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/ftFuVyQ5>
+        .\r\n<https://id.parliament.uk/ftFuVyQ5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/ftFuVyQ5>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-02+00:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/ftFuVyQ5> <https://id.parliament.uk/schema/layingHasLaidThing>
+        <https://id.parliament.uk/BZPGfEza> .\r\n<https://id.parliament.uk/BZPGfEza>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/BZPGfEza> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <http://www.w3.org/2000/01/rdf-schema#Resource> .\r\n<https://id.parliament.uk/BZPGfEza>
+        <https://id.parliament.uk/schema/laidThingName> \"laidThingName - 12\" .\r\n<https://id.parliament.uk/BZPGfEza>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing>
+        .\r\n<https://id.parliament.uk/BZPGfEza> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WebLinkedThing> .\r\n<https://id.parliament.uk/BZPGfEza>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/BZPGfEza> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/XouN12Ow>
+        <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/AWsJmRFZ>
+        .\r\n<https://id.parliament.uk/AWsJmRFZ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/AWsJmRFZ>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-09+00:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/AWsJmRFZ> <https://id.parliament.uk/schema/layingHasLaidThing>
+        <https://id.parliament.uk/KF90wtY4> .\r\n<https://id.parliament.uk/KF90wtY4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/KF90wtY4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <http://www.w3.org/2000/01/rdf-schema#Resource> .\r\n<https://id.parliament.uk/KF90wtY4>
+        <https://id.parliament.uk/schema/laidThingName> \"laidThingName - 13\" .\r\n<https://id.parliament.uk/KF90wtY4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing>
+        .\r\n<https://id.parliament.uk/KF90wtY4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WebLinkedThing> .\r\n<https://id.parliament.uk/KF90wtY4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/KF90wtY4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/XouN12Ow>
+        <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/9T8nEUBG>
+        .\r\n<https://id.parliament.uk/9T8nEUBG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/9T8nEUBG>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-13+00:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/9T8nEUBG> <https://id.parliament.uk/schema/layingHasLaidThing>
+        <https://id.parliament.uk/55gPdheg> .\r\n<https://id.parliament.uk/55gPdheg>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/55gPdheg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <http://www.w3.org/2000/01/rdf-schema#Resource> .\r\n<https://id.parliament.uk/55gPdheg>
+        <https://id.parliament.uk/schema/laidThingName> \"laidThingName - 14\" .\r\n<https://id.parliament.uk/55gPdheg>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing>
+        .\r\n<https://id.parliament.uk/55gPdheg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WebLinkedThing> .\r\n<https://id.parliament.uk/55gPdheg>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/55gPdheg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/XouN12Ow>
+        <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/jzHlJ1mb>
+        .\r\n<https://id.parliament.uk/jzHlJ1mb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/jzHlJ1mb>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-19+00:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/jzHlJ1mb> <https://id.parliament.uk/schema/layingHasLaidThing>
+        <https://id.parliament.uk/Tn1xqHc0> .\r\n<https://id.parliament.uk/Tn1xqHc0>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/Tn1xqHc0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <http://www.w3.org/2000/01/rdf-schema#Resource> .\r\n<https://id.parliament.uk/Tn1xqHc0>
+        <https://id.parliament.uk/schema/laidThingName> \"laidThingName - 15\" .\r\n<https://id.parliament.uk/Tn1xqHc0>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing>
+        .\r\n<https://id.parliament.uk/Tn1xqHc0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WebLinkedThing> .\r\n<https://id.parliament.uk/Tn1xqHc0>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/Tn1xqHc0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/ProposedNegativeStatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/XouN12Ow> <https://id.parliament.uk/schema/layingBodyHasLaying>
+        <https://id.parliament.uk/wN2D7eGI> .\r\n<https://id.parliament.uk/wN2D7eGI>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/wN2D7eGI> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-19+00:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/wN2D7eGI>
+        <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/wzsrSFQP>
+        .\r\n<https://id.parliament.uk/wzsrSFQP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/wzsrSFQP>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource>
+        .\r\n<https://id.parliament.uk/wzsrSFQP> <https://id.parliament.uk/schema/laidThingName>
+        \"laidThingName - 16\" .\r\n<https://id.parliament.uk/wzsrSFQP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/NamedThing> .\r\n<https://id.parliament.uk/wzsrSFQP>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing>
+        .\r\n<https://id.parliament.uk/wzsrSFQP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/wzsrSFQP>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ProposedNegativeStatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/XouN12Ow> <https://id.parliament.uk/schema/layingBodyHasLaying>
+        <https://id.parliament.uk/3ZBwPCUy> .\r\n<https://id.parliament.uk/3ZBwPCUy>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/3ZBwPCUy> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-19+00:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/3ZBwPCUy>
+        <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/H95FzZVv>
+        .\r\n<https://id.parliament.uk/H95FzZVv> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/H95FzZVv>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource>
+        .\r\n<https://id.parliament.uk/H95FzZVv> <https://id.parliament.uk/schema/laidThingName>
+        \"laidThingName - 17\" .\r\n<https://id.parliament.uk/H95FzZVv> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/NamedThing> .\r\n<https://id.parliament.uk/H95FzZVv>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing>
+        .\r\n<https://id.parliament.uk/H95FzZVv> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/H95FzZVv>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ProposedNegativeStatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/XouN12Ow> <https://id.parliament.uk/schema/layingBodyHasLaying>
+        <https://id.parliament.uk/FDFI2J2G> .\r\n<https://id.parliament.uk/FDFI2J2G>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/FDFI2J2G> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-19+00:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/FDFI2J2G>
+        <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/QI5WArIQ>
+        .\r\n<https://id.parliament.uk/QI5WArIQ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/QI5WArIQ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource>
+        .\r\n<https://id.parliament.uk/QI5WArIQ> <https://id.parliament.uk/schema/laidThingName>
+        \"laidThingName - 18\" .\r\n<https://id.parliament.uk/QI5WArIQ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/NamedThing> .\r\n<https://id.parliament.uk/QI5WArIQ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing>
+        .\r\n<https://id.parliament.uk/QI5WArIQ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/QI5WArIQ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/XouN12Ow> <https://id.parliament.uk/schema/layingBodyHasLaying>
+        <https://id.parliament.uk/lh0DnMME> .\r\n<https://id.parliament.uk/lh0DnMME>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/lh0DnMME> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-19+00:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/lh0DnMME>
+        <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/cL5yuFbG>
+        .\r\n<https://id.parliament.uk/cL5yuFbG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/cL5yuFbG>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource>
+        .\r\n<https://id.parliament.uk/cL5yuFbG> <https://id.parliament.uk/schema/laidThingName>
+        \"laidThingName - 19\" .\r\n<https://id.parliament.uk/cL5yuFbG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/NamedThing> .\r\n<https://id.parliament.uk/cL5yuFbG>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing>
+        .\r\n<https://id.parliament.uk/cL5yuFbG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/cL5yuFbG>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ProposedNegativeStatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/XouN12Ow> <https://id.parliament.uk/schema/layingBodyHasLaying>
+        <https://id.parliament.uk/qO4klsgb> .\r\n<https://id.parliament.uk/qO4klsgb>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/qO4klsgb> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-19+00:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/qO4klsgb>
+        <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/mssRQnqj>
+        .\r\n<https://id.parliament.uk/mssRQnqj> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/mssRQnqj>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource>
+        .\r\n<https://id.parliament.uk/mssRQnqj> <https://id.parliament.uk/schema/laidThingName>
+        \"laidThingName - 20\" .\r\n<https://id.parliament.uk/mssRQnqj> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/NamedThing> .\r\n<https://id.parliament.uk/mssRQnqj>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing>
+        .\r\n<https://id.parliament.uk/mssRQnqj> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/mssRQnqj>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ProposedNegativeStatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/XouN12Ow> <https://id.parliament.uk/schema/layingBodyHasLaying>
+        <https://id.parliament.uk/72UR3b5X> .\r\n<https://id.parliament.uk/72UR3b5X>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/72UR3b5X> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-23+00:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/72UR3b5X>
+        <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/ePPVgmgN>
+        .\r\n<https://id.parliament.uk/ePPVgmgN> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/ePPVgmgN>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource>
+        .\r\n<https://id.parliament.uk/ePPVgmgN> <https://id.parliament.uk/schema/laidThingName>
+        \"laidThingName - 21\" .\r\n<https://id.parliament.uk/ePPVgmgN> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/NamedThing> .\r\n<https://id.parliament.uk/ePPVgmgN>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing>
+        .\r\n<https://id.parliament.uk/ePPVgmgN> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/ePPVgmgN>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/XouN12Ow> <https://id.parliament.uk/schema/layingBodyHasLaying>
+        <https://id.parliament.uk/Bc9nWfWq> .\r\n<https://id.parliament.uk/Bc9nWfWq>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/Bc9nWfWq> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-23+00:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/Bc9nWfWq>
+        <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/qRweamaE>
+        .\r\n<https://id.parliament.uk/qRweamaE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/qRweamaE>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource>
+        .\r\n<https://id.parliament.uk/qRweamaE> <https://id.parliament.uk/schema/laidThingName>
+        \"laidThingName - 22\" .\r\n<https://id.parliament.uk/qRweamaE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/NamedThing> .\r\n<https://id.parliament.uk/qRweamaE>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing>
+        .\r\n<https://id.parliament.uk/qRweamaE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/qRweamaE>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/XouN12Ow> <https://id.parliament.uk/schema/layingBodyHasLaying>
+        <https://id.parliament.uk/WwdgeYfb> .\r\n<https://id.parliament.uk/WwdgeYfb>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/WwdgeYfb> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-23+00:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/WwdgeYfb>
+        <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/YdIWHZS3>
+        .\r\n<https://id.parliament.uk/YdIWHZS3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/YdIWHZS3>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource>
+        .\r\n<https://id.parliament.uk/YdIWHZS3> <https://id.parliament.uk/schema/laidThingName>
+        \"laidThingName - 23\" .\r\n<https://id.parliament.uk/YdIWHZS3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/NamedThing> .\r\n<https://id.parliament.uk/YdIWHZS3>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing>
+        .\r\n<https://id.parliament.uk/YdIWHZS3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/YdIWHZS3>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/XouN12Ow> <https://id.parliament.uk/schema/layingBodyHasLaying>
+        <https://id.parliament.uk/8pfIlVcp> .\r\n<https://id.parliament.uk/8pfIlVcp>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/8pfIlVcp> <https://id.parliament.uk/schema/layingDate>
+        \"2018-09-07+00:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/8pfIlVcp>
+        <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/l05U8jIT>
+        .\r\n<https://id.parliament.uk/l05U8jIT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/l05U8jIT>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource>
+        .\r\n<https://id.parliament.uk/l05U8jIT> <https://id.parliament.uk/schema/laidThingName>
+        \"laidThingName - 24\" .\r\n<https://id.parliament.uk/l05U8jIT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/NamedThing> .\r\n<https://id.parliament.uk/l05U8jIT>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing>
+        .\r\n<https://id.parliament.uk/l05U8jIT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/l05U8jIT>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/l05U8jIT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/MadeStatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/XouN12Ow>
+        <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/O5x2bz0C>
+        .\r\n<https://id.parliament.uk/O5x2bz0C> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/O5x2bz0C>
+        <https://id.parliament.uk/schema/layingDate> \"2018-09-13+00:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/O5x2bz0C> <https://id.parliament.uk/schema/layingHasLaidThing>
+        <https://id.parliament.uk/IyxF7Re7> .\r\n<https://id.parliament.uk/IyxF7Re7>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/IyxF7Re7> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <http://www.w3.org/2000/01/rdf-schema#Resource> .\r\n<https://id.parliament.uk/IyxF7Re7>
+        <https://id.parliament.uk/schema/laidThingName> \"laidThingName - 25\" .\r\n<https://id.parliament.uk/IyxF7Re7>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing>
+        .\r\n<https://id.parliament.uk/IyxF7Re7> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WebLinkedThing> .\r\n<https://id.parliament.uk/IyxF7Re7>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/IyxF7Re7> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/IyxF7Re7>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/MadeStatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/XouN12Ow> <https://id.parliament.uk/schema/layingBodyHasLaying>
+        <https://id.parliament.uk/BoIqC4vN> .\r\n<https://id.parliament.uk/BoIqC4vN>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/BoIqC4vN> <https://id.parliament.uk/schema/layingDate>
+        \"2018-09-13+00:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/BoIqC4vN>
+        <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/vWSvjJPY>
+        .\r\n<https://id.parliament.uk/vWSvjJPY> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/vWSvjJPY>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource>
+        .\r\n<https://id.parliament.uk/vWSvjJPY> <https://id.parliament.uk/schema/laidThingName>
+        \"laidThingName - 26\" .\r\n<https://id.parliament.uk/vWSvjJPY> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/NamedThing> .\r\n<https://id.parliament.uk/vWSvjJPY>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing>
+        .\r\n<https://id.parliament.uk/vWSvjJPY> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/vWSvjJPY>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/XouN12Ow> <https://id.parliament.uk/schema/layingBodyHasLaying>
+        <https://id.parliament.uk/JO1GX0Yc> .\r\n<https://id.parliament.uk/JO1GX0Yc>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/JO1GX0Yc> <https://id.parliament.uk/schema/layingDate>
+        \"2018-09-17+00:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/JO1GX0Yc>
+        <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/558R1vHw>
+        .\r\n<https://id.parliament.uk/558R1vHw> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/558R1vHw>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource>
+        .\r\n<https://id.parliament.uk/558R1vHw> <https://id.parliament.uk/schema/laidThingName>
+        \"laidThingName - 27\" .\r\n<https://id.parliament.uk/558R1vHw> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/NamedThing> .\r\n<https://id.parliament.uk/558R1vHw>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing>
+        .\r\n<https://id.parliament.uk/558R1vHw> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/558R1vHw>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/558R1vHw> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/MadeStatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/XouN12Ow>
+        <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/fSnMQqcj>
+        .\r\n<https://id.parliament.uk/fSnMQqcj> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/fSnMQqcj>
+        <https://id.parliament.uk/schema/layingDate> \"2018-09-18+00:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/fSnMQqcj> <https://id.parliament.uk/schema/layingHasLaidThing>
+        <https://id.parliament.uk/eIcl19m5> .\r\n<https://id.parliament.uk/eIcl19m5>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/eIcl19m5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <http://www.w3.org/2000/01/rdf-schema#Resource> .\r\n<https://id.parliament.uk/eIcl19m5>
+        <https://id.parliament.uk/schema/laidThingName> \"laidThingName - 28\" .\r\n<https://id.parliament.uk/eIcl19m5>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing>
+        .\r\n<https://id.parliament.uk/eIcl19m5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WebLinkedThing> .\r\n<https://id.parliament.uk/eIcl19m5>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/eIcl19m5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/ProposedNegativeStatutoryInstrumentPaper>
+        .\r\n"
+    http_version: 
+  recorded_at: Tue, 16 Oct 2018 15:12:18 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Groups_LayingsController/GET_index/should_have_a_response_with_http_status_ok_200_.yml
+++ b/spec/fixtures/vcr_cassettes/Groups_LayingsController/GET_index/should_have_a_response_with_http_status_ok_200_.yml
@@ -1,0 +1,333 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3030/group_layings_index?group_id=XouN12Ow
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      - application/n-triples
+      User-Agent:
+      - Ruby
+      Ocp-Apim-Subscription-Key:
+      - "<AUTH_TOKEN>"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/n-triples
+      Content-Disposition:
+      - inline; filename="index"
+      Last-Modified:
+      - Thu, 04 Oct 2018 14:33:35 GMT
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '40625'
+    body:
+      encoding: UTF-8
+      string: |
+        <https://id.parliament.uk/NDZSYjeE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Group> .
+        <https://id.parliament.uk/NDZSYjeE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LayingBody> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/groupName> "groupName - 1" .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/groupStartDate> "1900-01-01+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/FrRQLlKT> .
+        <https://id.parliament.uk/FrRQLlKT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/FrRQLlKT> <https://id.parliament.uk/schema/layingDate> "2018-04-27+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/FrRQLlKT> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/QV9rpep6> .
+        <https://id.parliament.uk/QV9rpep6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/QV9rpep6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/QV9rpep6> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 1" .
+        <https://id.parliament.uk/QV9rpep6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/QV9rpep6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/QV9rpep6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/QV9rpep6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/p064wsz5> .
+        <https://id.parliament.uk/p064wsz5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/p064wsz5> <https://id.parliament.uk/schema/layingDate> "2018-05-08+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/p064wsz5> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/HJ7BlYte> .
+        <https://id.parliament.uk/HJ7BlYte> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/HJ7BlYte> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/HJ7BlYte> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 2" .
+        <https://id.parliament.uk/HJ7BlYte> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/HJ7BlYte> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/HJ7BlYte> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/HJ7BlYte> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/ZQsu6c18> .
+        <https://id.parliament.uk/ZQsu6c18> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/ZQsu6c18> <https://id.parliament.uk/schema/layingDate> "2018-04-03+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/ZQsu6c18> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/3dAYwLoB> .
+        <https://id.parliament.uk/3dAYwLoB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/3dAYwLoB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/3dAYwLoB> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 3" .
+        <https://id.parliament.uk/3dAYwLoB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/3dAYwLoB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/3dAYwLoB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/3dAYwLoB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/rWaK4CZm> .
+        <https://id.parliament.uk/rWaK4CZm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/rWaK4CZm> <https://id.parliament.uk/schema/layingDate> "2018-05-21+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/rWaK4CZm> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/rjzMGG28> .
+        <https://id.parliament.uk/rjzMGG28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/rjzMGG28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/rjzMGG28> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 4" .
+        <https://id.parliament.uk/rjzMGG28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/rjzMGG28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/rjzMGG28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/rjzMGG28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/8nTtARxa> .
+        <https://id.parliament.uk/8nTtARxa> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/8nTtARxa> <https://id.parliament.uk/schema/layingDate> "2018-05-24+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/8nTtARxa> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/uNiGNHey> .
+        <https://id.parliament.uk/uNiGNHey> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/uNiGNHey> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/uNiGNHey> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 5" .
+        <https://id.parliament.uk/uNiGNHey> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/uNiGNHey> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/uNiGNHey> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/uNiGNHey> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/S0ebryc4> .
+        <https://id.parliament.uk/S0ebryc4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/S0ebryc4> <https://id.parliament.uk/schema/layingDate> "2018-05-18+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/S0ebryc4> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/8HUWJm9e> .
+        <https://id.parliament.uk/8HUWJm9e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/8HUWJm9e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/8HUWJm9e> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 6" .
+        <https://id.parliament.uk/8HUWJm9e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/8HUWJm9e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/8HUWJm9e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/8HUWJm9e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/Je3lAVxM> .
+        <https://id.parliament.uk/Je3lAVxM> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/Je3lAVxM> <https://id.parliament.uk/schema/layingDate> "2018-06-04+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/Je3lAVxM> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/ez3sdNNT> .
+        <https://id.parliament.uk/ez3sdNNT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/ez3sdNNT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/ez3sdNNT> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 7" .
+        <https://id.parliament.uk/ez3sdNNT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/ez3sdNNT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/ez3sdNNT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/ez3sdNNT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/TZR852WV> .
+        <https://id.parliament.uk/TZR852WV> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/TZR852WV> <https://id.parliament.uk/schema/layingDate> "2018-06-06+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/TZR852WV> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/w3m931qg> .
+        <https://id.parliament.uk/w3m931qg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/w3m931qg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/w3m931qg> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 8" .
+        <https://id.parliament.uk/w3m931qg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/w3m931qg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/w3m931qg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/w3m931qg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/630Ft4k4> .
+        <https://id.parliament.uk/630Ft4k4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/630Ft4k4> <https://id.parliament.uk/schema/layingDate> "2018-06-08+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/630Ft4k4> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/PhwmELqG> .
+        <https://id.parliament.uk/PhwmELqG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/PhwmELqG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/PhwmELqG> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 9" .
+        <https://id.parliament.uk/PhwmELqG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/PhwmELqG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/PhwmELqG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/PhwmELqG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/SKzgadiu> .
+        <https://id.parliament.uk/SKzgadiu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/SKzgadiu> <https://id.parliament.uk/schema/layingDate> "2018-06-13+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/SKzgadiu> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/aQaZuLyK> .
+        <https://id.parliament.uk/aQaZuLyK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/aQaZuLyK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/aQaZuLyK> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 10" .
+        <https://id.parliament.uk/aQaZuLyK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/aQaZuLyK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/aQaZuLyK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/aQaZuLyK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/nBIracyf> .
+        <https://id.parliament.uk/nBIracyf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/nBIracyf> <https://id.parliament.uk/schema/layingDate> "2018-06-13+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/nBIracyf> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/I9rWxORS> .
+        <https://id.parliament.uk/I9rWxORS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/I9rWxORS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/I9rWxORS> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 11" .
+        <https://id.parliament.uk/I9rWxORS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/I9rWxORS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/I9rWxORS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/I9rWxORS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/ktlPPWYD> .
+        <https://id.parliament.uk/ktlPPWYD> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/ktlPPWYD> <https://id.parliament.uk/schema/layingDate> "2018-06-15+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/ktlPPWYD> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/9Nv0gELe> .
+        <https://id.parliament.uk/9Nv0gELe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/9Nv0gELe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/9Nv0gELe> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 12" .
+        <https://id.parliament.uk/9Nv0gELe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/9Nv0gELe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/9Nv0gELe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/9Nv0gELe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/yzmWisVv> .
+        <https://id.parliament.uk/yzmWisVv> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/yzmWisVv> <https://id.parliament.uk/schema/layingDate> "2018-06-18+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/yzmWisVv> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/YhMNMpYo> .
+        <https://id.parliament.uk/YhMNMpYo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/YhMNMpYo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/YhMNMpYo> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 13" .
+        <https://id.parliament.uk/YhMNMpYo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/YhMNMpYo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/YhMNMpYo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/YhMNMpYo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/9UPBD2Md> .
+        <https://id.parliament.uk/9UPBD2Md> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/9UPBD2Md> <https://id.parliament.uk/schema/layingDate> "2018-06-25+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/9UPBD2Md> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/UD4HjKbu> .
+        <https://id.parliament.uk/UD4HjKbu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/UD4HjKbu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/UD4HjKbu> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 14" .
+        <https://id.parliament.uk/UD4HjKbu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/UD4HjKbu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/UD4HjKbu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/UD4HjKbu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/FafO3XiI> .
+        <https://id.parliament.uk/FafO3XiI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/FafO3XiI> <https://id.parliament.uk/schema/layingDate> "2018-06-28+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/FafO3XiI> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/P5Zu6fkP> .
+        <https://id.parliament.uk/P5Zu6fkP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/P5Zu6fkP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/P5Zu6fkP> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 15" .
+        <https://id.parliament.uk/P5Zu6fkP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/P5Zu6fkP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/P5Zu6fkP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/P5Zu6fkP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/Wd3zlHhD> .
+        <https://id.parliament.uk/Wd3zlHhD> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/Wd3zlHhD> <https://id.parliament.uk/schema/layingDate> "2018-07-03+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/Wd3zlHhD> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/JXxhQblu> .
+        <https://id.parliament.uk/JXxhQblu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/JXxhQblu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/JXxhQblu> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 16" .
+        <https://id.parliament.uk/JXxhQblu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/JXxhQblu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/JXxhQblu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/JXxhQblu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/i4m8WLDM> .
+        <https://id.parliament.uk/i4m8WLDM> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/i4m8WLDM> <https://id.parliament.uk/schema/layingDate> "2018-07-02+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/i4m8WLDM> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/IjLgnN8z> .
+        <https://id.parliament.uk/IjLgnN8z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/IjLgnN8z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/IjLgnN8z> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 17" .
+        <https://id.parliament.uk/IjLgnN8z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/IjLgnN8z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/IjLgnN8z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/IjLgnN8z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/JBIhn7el> .
+        <https://id.parliament.uk/JBIhn7el> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/JBIhn7el> <https://id.parliament.uk/schema/layingDate> "2018-07-12+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/JBIhn7el> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/BRZBy463> .
+        <https://id.parliament.uk/BRZBy463> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/BRZBy463> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/BRZBy463> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 18" .
+        <https://id.parliament.uk/BRZBy463> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/BRZBy463> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/BRZBy463> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/BRZBy463> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/MAHrwKV2> .
+        <https://id.parliament.uk/MAHrwKV2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/MAHrwKV2> <https://id.parliament.uk/schema/layingDate> "2018-07-19+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/MAHrwKV2> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/Uhsvsfdn> .
+        <https://id.parliament.uk/Uhsvsfdn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/Uhsvsfdn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/Uhsvsfdn> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 19" .
+        <https://id.parliament.uk/Uhsvsfdn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/Uhsvsfdn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/Uhsvsfdn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/Uhsvsfdn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/vAu6L0Zc> .
+        <https://id.parliament.uk/vAu6L0Zc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/vAu6L0Zc> <https://id.parliament.uk/schema/layingDate> "2018-07-20+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/vAu6L0Zc> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/SbxmGLcR> .
+        <https://id.parliament.uk/SbxmGLcR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/SbxmGLcR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/SbxmGLcR> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 20" .
+        <https://id.parliament.uk/SbxmGLcR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/SbxmGLcR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/SbxmGLcR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/SbxmGLcR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/4mREgKhH> .
+        <https://id.parliament.uk/4mREgKhH> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/4mREgKhH> <https://id.parliament.uk/schema/layingDate> "2018-07-25+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/4mREgKhH> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/W3l3iqIJ> .
+        <https://id.parliament.uk/W3l3iqIJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/W3l3iqIJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/W3l3iqIJ> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 21" .
+        <https://id.parliament.uk/W3l3iqIJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/W3l3iqIJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/W3l3iqIJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/W3l3iqIJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ProposedNegativeStatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/biZLgqIV> .
+        <https://id.parliament.uk/biZLgqIV> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/biZLgqIV> <https://id.parliament.uk/schema/layingDate> "2018-07-26+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/biZLgqIV> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/hLF7ZU6f> .
+        <https://id.parliament.uk/hLF7ZU6f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/hLF7ZU6f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/hLF7ZU6f> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 22" .
+        <https://id.parliament.uk/hLF7ZU6f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/hLF7ZU6f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/hLF7ZU6f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/hLF7ZU6f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/jNi948H2> .
+        <https://id.parliament.uk/jNi948H2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/jNi948H2> <https://id.parliament.uk/schema/layingDate> "2018-09-06+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/jNi948H2> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/BuMKAKjA> .
+        <https://id.parliament.uk/BuMKAKjA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/BuMKAKjA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/BuMKAKjA> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 23" .
+        <https://id.parliament.uk/BuMKAKjA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/BuMKAKjA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/BuMKAKjA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/BuMKAKjA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/BuMKAKjA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/MadeStatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/yGqCp359> .
+        <https://id.parliament.uk/yGqCp359> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/yGqCp359> <https://id.parliament.uk/schema/layingDate> "2018-09-10+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/yGqCp359> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/WBlaNvyq> .
+        <https://id.parliament.uk/WBlaNvyq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/WBlaNvyq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/WBlaNvyq> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 24" .
+        <https://id.parliament.uk/WBlaNvyq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/WBlaNvyq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/WBlaNvyq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/WBlaNvyq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/WBlaNvyq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/MadeStatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/4JKyg0Au> .
+        <https://id.parliament.uk/4JKyg0Au> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/4JKyg0Au> <https://id.parliament.uk/schema/layingDate> "2018-09-13+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/4JKyg0Au> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/lSRBYtGi> .
+        <https://id.parliament.uk/lSRBYtGi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/lSRBYtGi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/lSRBYtGi> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 25" .
+        <https://id.parliament.uk/lSRBYtGi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/lSRBYtGi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/lSRBYtGi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/lSRBYtGi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/lSRBYtGi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/MadeStatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/C6qh45v5> .
+        <https://id.parliament.uk/C6qh45v5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/C6qh45v5> <https://id.parliament.uk/schema/layingDate> "2018-09-13+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/C6qh45v5> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/H1uGO0VI> .
+        <https://id.parliament.uk/H1uGO0VI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/H1uGO0VI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/H1uGO0VI> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 26" .
+        <https://id.parliament.uk/H1uGO0VI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/H1uGO0VI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/H1uGO0VI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/H1uGO0VI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/H1uGO0VI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/MadeStatutoryInstrumentPaper> .
+    http_version: 
+  recorded_at: Mon, 08 Oct 2018 12:18:09 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Groups_LayingsController/GET_index/the_correct_instance_variables/assigns_group.yml
+++ b/spec/fixtures/vcr_cassettes/Groups_LayingsController/GET_index/the_correct_instance_variables/assigns_group.yml
@@ -1,0 +1,333 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3030/group_layings_index?group_id=XouN12Ow
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      - application/n-triples
+      User-Agent:
+      - Ruby
+      Ocp-Apim-Subscription-Key:
+      - "<AUTH_TOKEN>"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/n-triples
+      Content-Disposition:
+      - inline; filename="index"
+      Last-Modified:
+      - Thu, 04 Oct 2018 14:33:35 GMT
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '40625'
+    body:
+      encoding: UTF-8
+      string: |
+        <https://id.parliament.uk/NDZSYjeE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Group> .
+        <https://id.parliament.uk/NDZSYjeE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LayingBody> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/groupName> "groupName - 1" .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/groupStartDate> "1900-01-01+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/FrRQLlKT> .
+        <https://id.parliament.uk/FrRQLlKT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/FrRQLlKT> <https://id.parliament.uk/schema/layingDate> "2018-04-27+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/FrRQLlKT> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/QV9rpep6> .
+        <https://id.parliament.uk/QV9rpep6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/QV9rpep6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/QV9rpep6> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 1" .
+        <https://id.parliament.uk/QV9rpep6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/QV9rpep6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/QV9rpep6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/QV9rpep6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/p064wsz5> .
+        <https://id.parliament.uk/p064wsz5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/p064wsz5> <https://id.parliament.uk/schema/layingDate> "2018-05-08+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/p064wsz5> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/HJ7BlYte> .
+        <https://id.parliament.uk/HJ7BlYte> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/HJ7BlYte> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/HJ7BlYte> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 2" .
+        <https://id.parliament.uk/HJ7BlYte> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/HJ7BlYte> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/HJ7BlYte> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/HJ7BlYte> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/ZQsu6c18> .
+        <https://id.parliament.uk/ZQsu6c18> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/ZQsu6c18> <https://id.parliament.uk/schema/layingDate> "2018-04-03+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/ZQsu6c18> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/3dAYwLoB> .
+        <https://id.parliament.uk/3dAYwLoB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/3dAYwLoB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/3dAYwLoB> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 3" .
+        <https://id.parliament.uk/3dAYwLoB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/3dAYwLoB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/3dAYwLoB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/3dAYwLoB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/rWaK4CZm> .
+        <https://id.parliament.uk/rWaK4CZm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/rWaK4CZm> <https://id.parliament.uk/schema/layingDate> "2018-05-21+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/rWaK4CZm> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/rjzMGG28> .
+        <https://id.parliament.uk/rjzMGG28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/rjzMGG28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/rjzMGG28> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 4" .
+        <https://id.parliament.uk/rjzMGG28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/rjzMGG28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/rjzMGG28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/rjzMGG28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/8nTtARxa> .
+        <https://id.parliament.uk/8nTtARxa> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/8nTtARxa> <https://id.parliament.uk/schema/layingDate> "2018-05-24+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/8nTtARxa> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/uNiGNHey> .
+        <https://id.parliament.uk/uNiGNHey> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/uNiGNHey> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/uNiGNHey> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 5" .
+        <https://id.parliament.uk/uNiGNHey> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/uNiGNHey> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/uNiGNHey> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/uNiGNHey> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/S0ebryc4> .
+        <https://id.parliament.uk/S0ebryc4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/S0ebryc4> <https://id.parliament.uk/schema/layingDate> "2018-05-18+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/S0ebryc4> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/8HUWJm9e> .
+        <https://id.parliament.uk/8HUWJm9e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/8HUWJm9e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/8HUWJm9e> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 6" .
+        <https://id.parliament.uk/8HUWJm9e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/8HUWJm9e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/8HUWJm9e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/8HUWJm9e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/Je3lAVxM> .
+        <https://id.parliament.uk/Je3lAVxM> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/Je3lAVxM> <https://id.parliament.uk/schema/layingDate> "2018-06-04+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/Je3lAVxM> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/ez3sdNNT> .
+        <https://id.parliament.uk/ez3sdNNT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/ez3sdNNT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/ez3sdNNT> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 7" .
+        <https://id.parliament.uk/ez3sdNNT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/ez3sdNNT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/ez3sdNNT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/ez3sdNNT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/TZR852WV> .
+        <https://id.parliament.uk/TZR852WV> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/TZR852WV> <https://id.parliament.uk/schema/layingDate> "2018-06-06+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/TZR852WV> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/w3m931qg> .
+        <https://id.parliament.uk/w3m931qg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/w3m931qg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/w3m931qg> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 8" .
+        <https://id.parliament.uk/w3m931qg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/w3m931qg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/w3m931qg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/w3m931qg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/630Ft4k4> .
+        <https://id.parliament.uk/630Ft4k4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/630Ft4k4> <https://id.parliament.uk/schema/layingDate> "2018-06-08+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/630Ft4k4> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/PhwmELqG> .
+        <https://id.parliament.uk/PhwmELqG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/PhwmELqG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/PhwmELqG> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 9" .
+        <https://id.parliament.uk/PhwmELqG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/PhwmELqG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/PhwmELqG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/PhwmELqG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/SKzgadiu> .
+        <https://id.parliament.uk/SKzgadiu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/SKzgadiu> <https://id.parliament.uk/schema/layingDate> "2018-06-13+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/SKzgadiu> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/aQaZuLyK> .
+        <https://id.parliament.uk/aQaZuLyK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/aQaZuLyK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/aQaZuLyK> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 10" .
+        <https://id.parliament.uk/aQaZuLyK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/aQaZuLyK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/aQaZuLyK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/aQaZuLyK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/nBIracyf> .
+        <https://id.parliament.uk/nBIracyf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/nBIracyf> <https://id.parliament.uk/schema/layingDate> "2018-06-13+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/nBIracyf> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/I9rWxORS> .
+        <https://id.parliament.uk/I9rWxORS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/I9rWxORS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/I9rWxORS> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 11" .
+        <https://id.parliament.uk/I9rWxORS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/I9rWxORS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/I9rWxORS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/I9rWxORS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/ktlPPWYD> .
+        <https://id.parliament.uk/ktlPPWYD> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/ktlPPWYD> <https://id.parliament.uk/schema/layingDate> "2018-06-15+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/ktlPPWYD> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/9Nv0gELe> .
+        <https://id.parliament.uk/9Nv0gELe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/9Nv0gELe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/9Nv0gELe> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 12" .
+        <https://id.parliament.uk/9Nv0gELe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/9Nv0gELe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/9Nv0gELe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/9Nv0gELe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/yzmWisVv> .
+        <https://id.parliament.uk/yzmWisVv> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/yzmWisVv> <https://id.parliament.uk/schema/layingDate> "2018-06-18+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/yzmWisVv> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/YhMNMpYo> .
+        <https://id.parliament.uk/YhMNMpYo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/YhMNMpYo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/YhMNMpYo> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 13" .
+        <https://id.parliament.uk/YhMNMpYo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/YhMNMpYo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/YhMNMpYo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/YhMNMpYo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/9UPBD2Md> .
+        <https://id.parliament.uk/9UPBD2Md> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/9UPBD2Md> <https://id.parliament.uk/schema/layingDate> "2018-06-25+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/9UPBD2Md> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/UD4HjKbu> .
+        <https://id.parliament.uk/UD4HjKbu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/UD4HjKbu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/UD4HjKbu> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 14" .
+        <https://id.parliament.uk/UD4HjKbu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/UD4HjKbu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/UD4HjKbu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/UD4HjKbu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/FafO3XiI> .
+        <https://id.parliament.uk/FafO3XiI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/FafO3XiI> <https://id.parliament.uk/schema/layingDate> "2018-06-28+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/FafO3XiI> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/P5Zu6fkP> .
+        <https://id.parliament.uk/P5Zu6fkP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/P5Zu6fkP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/P5Zu6fkP> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 15" .
+        <https://id.parliament.uk/P5Zu6fkP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/P5Zu6fkP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/P5Zu6fkP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/P5Zu6fkP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/Wd3zlHhD> .
+        <https://id.parliament.uk/Wd3zlHhD> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/Wd3zlHhD> <https://id.parliament.uk/schema/layingDate> "2018-07-03+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/Wd3zlHhD> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/JXxhQblu> .
+        <https://id.parliament.uk/JXxhQblu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/JXxhQblu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/JXxhQblu> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 16" .
+        <https://id.parliament.uk/JXxhQblu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/JXxhQblu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/JXxhQblu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/JXxhQblu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/i4m8WLDM> .
+        <https://id.parliament.uk/i4m8WLDM> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/i4m8WLDM> <https://id.parliament.uk/schema/layingDate> "2018-07-02+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/i4m8WLDM> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/IjLgnN8z> .
+        <https://id.parliament.uk/IjLgnN8z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/IjLgnN8z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/IjLgnN8z> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 17" .
+        <https://id.parliament.uk/IjLgnN8z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/IjLgnN8z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/IjLgnN8z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/IjLgnN8z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/JBIhn7el> .
+        <https://id.parliament.uk/JBIhn7el> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/JBIhn7el> <https://id.parliament.uk/schema/layingDate> "2018-07-12+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/JBIhn7el> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/BRZBy463> .
+        <https://id.parliament.uk/BRZBy463> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/BRZBy463> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/BRZBy463> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 18" .
+        <https://id.parliament.uk/BRZBy463> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/BRZBy463> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/BRZBy463> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/BRZBy463> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/MAHrwKV2> .
+        <https://id.parliament.uk/MAHrwKV2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/MAHrwKV2> <https://id.parliament.uk/schema/layingDate> "2018-07-19+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/MAHrwKV2> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/Uhsvsfdn> .
+        <https://id.parliament.uk/Uhsvsfdn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/Uhsvsfdn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/Uhsvsfdn> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 19" .
+        <https://id.parliament.uk/Uhsvsfdn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/Uhsvsfdn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/Uhsvsfdn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/Uhsvsfdn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/vAu6L0Zc> .
+        <https://id.parliament.uk/vAu6L0Zc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/vAu6L0Zc> <https://id.parliament.uk/schema/layingDate> "2018-07-20+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/vAu6L0Zc> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/SbxmGLcR> .
+        <https://id.parliament.uk/SbxmGLcR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/SbxmGLcR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/SbxmGLcR> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 20" .
+        <https://id.parliament.uk/SbxmGLcR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/SbxmGLcR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/SbxmGLcR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/SbxmGLcR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/4mREgKhH> .
+        <https://id.parliament.uk/4mREgKhH> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/4mREgKhH> <https://id.parliament.uk/schema/layingDate> "2018-07-25+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/4mREgKhH> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/W3l3iqIJ> .
+        <https://id.parliament.uk/W3l3iqIJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/W3l3iqIJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/W3l3iqIJ> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 21" .
+        <https://id.parliament.uk/W3l3iqIJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/W3l3iqIJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/W3l3iqIJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/W3l3iqIJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ProposedNegativeStatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/biZLgqIV> .
+        <https://id.parliament.uk/biZLgqIV> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/biZLgqIV> <https://id.parliament.uk/schema/layingDate> "2018-07-26+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/biZLgqIV> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/hLF7ZU6f> .
+        <https://id.parliament.uk/hLF7ZU6f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/hLF7ZU6f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/hLF7ZU6f> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 22" .
+        <https://id.parliament.uk/hLF7ZU6f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/hLF7ZU6f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/hLF7ZU6f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/hLF7ZU6f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/jNi948H2> .
+        <https://id.parliament.uk/jNi948H2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/jNi948H2> <https://id.parliament.uk/schema/layingDate> "2018-09-06+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/jNi948H2> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/BuMKAKjA> .
+        <https://id.parliament.uk/BuMKAKjA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/BuMKAKjA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/BuMKAKjA> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 23" .
+        <https://id.parliament.uk/BuMKAKjA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/BuMKAKjA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/BuMKAKjA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/BuMKAKjA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/BuMKAKjA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/MadeStatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/yGqCp359> .
+        <https://id.parliament.uk/yGqCp359> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/yGqCp359> <https://id.parliament.uk/schema/layingDate> "2018-09-10+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/yGqCp359> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/WBlaNvyq> .
+        <https://id.parliament.uk/WBlaNvyq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/WBlaNvyq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/WBlaNvyq> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 24" .
+        <https://id.parliament.uk/WBlaNvyq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/WBlaNvyq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/WBlaNvyq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/WBlaNvyq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/WBlaNvyq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/MadeStatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/4JKyg0Au> .
+        <https://id.parliament.uk/4JKyg0Au> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/4JKyg0Au> <https://id.parliament.uk/schema/layingDate> "2018-09-13+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/4JKyg0Au> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/lSRBYtGi> .
+        <https://id.parliament.uk/lSRBYtGi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/lSRBYtGi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/lSRBYtGi> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 25" .
+        <https://id.parliament.uk/lSRBYtGi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/lSRBYtGi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/lSRBYtGi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/lSRBYtGi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/lSRBYtGi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/MadeStatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/C6qh45v5> .
+        <https://id.parliament.uk/C6qh45v5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/C6qh45v5> <https://id.parliament.uk/schema/layingDate> "2018-09-13+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/C6qh45v5> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/H1uGO0VI> .
+        <https://id.parliament.uk/H1uGO0VI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/H1uGO0VI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/H1uGO0VI> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 26" .
+        <https://id.parliament.uk/H1uGO0VI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/H1uGO0VI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/H1uGO0VI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/H1uGO0VI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/H1uGO0VI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/MadeStatutoryInstrumentPaper> .
+    http_version: 
+  recorded_at: Mon, 08 Oct 2018 12:21:34 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Groups_LayingsController/GET_index/the_correct_instance_variables/assigns_layings.yml
+++ b/spec/fixtures/vcr_cassettes/Groups_LayingsController/GET_index/the_correct_instance_variables/assigns_layings.yml
@@ -1,0 +1,333 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3030/group_layings_index?group_id=XouN12Ow
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      - application/n-triples
+      User-Agent:
+      - Ruby
+      Ocp-Apim-Subscription-Key:
+      - "<AUTH_TOKEN>"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/n-triples
+      Content-Disposition:
+      - inline; filename="index"
+      Last-Modified:
+      - Thu, 04 Oct 2018 14:33:35 GMT
+      X-Content-Type-Options:
+      - nosniff
+      Content-Length:
+      - '40625'
+    body:
+      encoding: UTF-8
+      string: |
+        <https://id.parliament.uk/NDZSYjeE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Group> .
+        <https://id.parliament.uk/NDZSYjeE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LayingBody> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/groupName> "groupName - 1" .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/groupStartDate> "1900-01-01+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/FrRQLlKT> .
+        <https://id.parliament.uk/FrRQLlKT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/FrRQLlKT> <https://id.parliament.uk/schema/layingDate> "2018-04-27+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/FrRQLlKT> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/QV9rpep6> .
+        <https://id.parliament.uk/QV9rpep6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/QV9rpep6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/QV9rpep6> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 1" .
+        <https://id.parliament.uk/QV9rpep6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/QV9rpep6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/QV9rpep6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/QV9rpep6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/p064wsz5> .
+        <https://id.parliament.uk/p064wsz5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/p064wsz5> <https://id.parliament.uk/schema/layingDate> "2018-05-08+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/p064wsz5> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/HJ7BlYte> .
+        <https://id.parliament.uk/HJ7BlYte> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/HJ7BlYte> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/HJ7BlYte> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 2" .
+        <https://id.parliament.uk/HJ7BlYte> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/HJ7BlYte> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/HJ7BlYte> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/HJ7BlYte> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/ZQsu6c18> .
+        <https://id.parliament.uk/ZQsu6c18> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/ZQsu6c18> <https://id.parliament.uk/schema/layingDate> "2018-04-03+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/ZQsu6c18> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/3dAYwLoB> .
+        <https://id.parliament.uk/3dAYwLoB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/3dAYwLoB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/3dAYwLoB> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 3" .
+        <https://id.parliament.uk/3dAYwLoB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/3dAYwLoB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/3dAYwLoB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/3dAYwLoB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/rWaK4CZm> .
+        <https://id.parliament.uk/rWaK4CZm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/rWaK4CZm> <https://id.parliament.uk/schema/layingDate> "2018-05-21+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/rWaK4CZm> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/rjzMGG28> .
+        <https://id.parliament.uk/rjzMGG28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/rjzMGG28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/rjzMGG28> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 4" .
+        <https://id.parliament.uk/rjzMGG28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/rjzMGG28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/rjzMGG28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/rjzMGG28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/8nTtARxa> .
+        <https://id.parliament.uk/8nTtARxa> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/8nTtARxa> <https://id.parliament.uk/schema/layingDate> "2018-05-24+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/8nTtARxa> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/uNiGNHey> .
+        <https://id.parliament.uk/uNiGNHey> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/uNiGNHey> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/uNiGNHey> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 5" .
+        <https://id.parliament.uk/uNiGNHey> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/uNiGNHey> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/uNiGNHey> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/uNiGNHey> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/S0ebryc4> .
+        <https://id.parliament.uk/S0ebryc4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/S0ebryc4> <https://id.parliament.uk/schema/layingDate> "2018-05-18+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/S0ebryc4> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/8HUWJm9e> .
+        <https://id.parliament.uk/8HUWJm9e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/8HUWJm9e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/8HUWJm9e> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 6" .
+        <https://id.parliament.uk/8HUWJm9e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/8HUWJm9e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/8HUWJm9e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/8HUWJm9e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/Je3lAVxM> .
+        <https://id.parliament.uk/Je3lAVxM> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/Je3lAVxM> <https://id.parliament.uk/schema/layingDate> "2018-06-04+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/Je3lAVxM> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/ez3sdNNT> .
+        <https://id.parliament.uk/ez3sdNNT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/ez3sdNNT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/ez3sdNNT> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 7" .
+        <https://id.parliament.uk/ez3sdNNT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/ez3sdNNT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/ez3sdNNT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/ez3sdNNT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/TZR852WV> .
+        <https://id.parliament.uk/TZR852WV> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/TZR852WV> <https://id.parliament.uk/schema/layingDate> "2018-06-06+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/TZR852WV> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/w3m931qg> .
+        <https://id.parliament.uk/w3m931qg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/w3m931qg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/w3m931qg> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 8" .
+        <https://id.parliament.uk/w3m931qg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/w3m931qg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/w3m931qg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/w3m931qg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/630Ft4k4> .
+        <https://id.parliament.uk/630Ft4k4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/630Ft4k4> <https://id.parliament.uk/schema/layingDate> "2018-06-08+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/630Ft4k4> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/PhwmELqG> .
+        <https://id.parliament.uk/PhwmELqG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/PhwmELqG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/PhwmELqG> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 9" .
+        <https://id.parliament.uk/PhwmELqG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/PhwmELqG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/PhwmELqG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/PhwmELqG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/SKzgadiu> .
+        <https://id.parliament.uk/SKzgadiu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/SKzgadiu> <https://id.parliament.uk/schema/layingDate> "2018-06-13+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/SKzgadiu> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/aQaZuLyK> .
+        <https://id.parliament.uk/aQaZuLyK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/aQaZuLyK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/aQaZuLyK> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 10" .
+        <https://id.parliament.uk/aQaZuLyK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/aQaZuLyK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/aQaZuLyK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/aQaZuLyK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/nBIracyf> .
+        <https://id.parliament.uk/nBIracyf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/nBIracyf> <https://id.parliament.uk/schema/layingDate> "2018-06-13+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/nBIracyf> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/I9rWxORS> .
+        <https://id.parliament.uk/I9rWxORS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/I9rWxORS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/I9rWxORS> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 11" .
+        <https://id.parliament.uk/I9rWxORS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/I9rWxORS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/I9rWxORS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/I9rWxORS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/ktlPPWYD> .
+        <https://id.parliament.uk/ktlPPWYD> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/ktlPPWYD> <https://id.parliament.uk/schema/layingDate> "2018-06-15+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/ktlPPWYD> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/9Nv0gELe> .
+        <https://id.parliament.uk/9Nv0gELe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/9Nv0gELe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/9Nv0gELe> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 12" .
+        <https://id.parliament.uk/9Nv0gELe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/9Nv0gELe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/9Nv0gELe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/9Nv0gELe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/yzmWisVv> .
+        <https://id.parliament.uk/yzmWisVv> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/yzmWisVv> <https://id.parliament.uk/schema/layingDate> "2018-06-18+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/yzmWisVv> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/YhMNMpYo> .
+        <https://id.parliament.uk/YhMNMpYo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/YhMNMpYo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/YhMNMpYo> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 13" .
+        <https://id.parliament.uk/YhMNMpYo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/YhMNMpYo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/YhMNMpYo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/YhMNMpYo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/9UPBD2Md> .
+        <https://id.parliament.uk/9UPBD2Md> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/9UPBD2Md> <https://id.parliament.uk/schema/layingDate> "2018-06-25+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/9UPBD2Md> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/UD4HjKbu> .
+        <https://id.parliament.uk/UD4HjKbu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/UD4HjKbu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/UD4HjKbu> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 14" .
+        <https://id.parliament.uk/UD4HjKbu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/UD4HjKbu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/UD4HjKbu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/UD4HjKbu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/FafO3XiI> .
+        <https://id.parliament.uk/FafO3XiI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/FafO3XiI> <https://id.parliament.uk/schema/layingDate> "2018-06-28+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/FafO3XiI> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/P5Zu6fkP> .
+        <https://id.parliament.uk/P5Zu6fkP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/P5Zu6fkP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/P5Zu6fkP> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 15" .
+        <https://id.parliament.uk/P5Zu6fkP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/P5Zu6fkP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/P5Zu6fkP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/P5Zu6fkP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/Wd3zlHhD> .
+        <https://id.parliament.uk/Wd3zlHhD> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/Wd3zlHhD> <https://id.parliament.uk/schema/layingDate> "2018-07-03+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/Wd3zlHhD> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/JXxhQblu> .
+        <https://id.parliament.uk/JXxhQblu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/JXxhQblu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/JXxhQblu> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 16" .
+        <https://id.parliament.uk/JXxhQblu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/JXxhQblu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/JXxhQblu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/JXxhQblu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/i4m8WLDM> .
+        <https://id.parliament.uk/i4m8WLDM> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/i4m8WLDM> <https://id.parliament.uk/schema/layingDate> "2018-07-02+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/i4m8WLDM> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/IjLgnN8z> .
+        <https://id.parliament.uk/IjLgnN8z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/IjLgnN8z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/IjLgnN8z> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 17" .
+        <https://id.parliament.uk/IjLgnN8z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/IjLgnN8z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/IjLgnN8z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/IjLgnN8z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/JBIhn7el> .
+        <https://id.parliament.uk/JBIhn7el> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/JBIhn7el> <https://id.parliament.uk/schema/layingDate> "2018-07-12+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/JBIhn7el> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/BRZBy463> .
+        <https://id.parliament.uk/BRZBy463> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/BRZBy463> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/BRZBy463> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 18" .
+        <https://id.parliament.uk/BRZBy463> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/BRZBy463> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/BRZBy463> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/BRZBy463> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/MAHrwKV2> .
+        <https://id.parliament.uk/MAHrwKV2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/MAHrwKV2> <https://id.parliament.uk/schema/layingDate> "2018-07-19+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/MAHrwKV2> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/Uhsvsfdn> .
+        <https://id.parliament.uk/Uhsvsfdn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/Uhsvsfdn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/Uhsvsfdn> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 19" .
+        <https://id.parliament.uk/Uhsvsfdn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/Uhsvsfdn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/Uhsvsfdn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/Uhsvsfdn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/vAu6L0Zc> .
+        <https://id.parliament.uk/vAu6L0Zc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/vAu6L0Zc> <https://id.parliament.uk/schema/layingDate> "2018-07-20+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/vAu6L0Zc> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/SbxmGLcR> .
+        <https://id.parliament.uk/SbxmGLcR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/SbxmGLcR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/SbxmGLcR> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 20" .
+        <https://id.parliament.uk/SbxmGLcR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/SbxmGLcR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/SbxmGLcR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/SbxmGLcR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/4mREgKhH> .
+        <https://id.parliament.uk/4mREgKhH> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/4mREgKhH> <https://id.parliament.uk/schema/layingDate> "2018-07-25+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/4mREgKhH> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/W3l3iqIJ> .
+        <https://id.parliament.uk/W3l3iqIJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/W3l3iqIJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/W3l3iqIJ> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 21" .
+        <https://id.parliament.uk/W3l3iqIJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/W3l3iqIJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/W3l3iqIJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/W3l3iqIJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/ProposedNegativeStatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/biZLgqIV> .
+        <https://id.parliament.uk/biZLgqIV> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/biZLgqIV> <https://id.parliament.uk/schema/layingDate> "2018-07-26+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/biZLgqIV> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/hLF7ZU6f> .
+        <https://id.parliament.uk/hLF7ZU6f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/hLF7ZU6f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/hLF7ZU6f> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 22" .
+        <https://id.parliament.uk/hLF7ZU6f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/hLF7ZU6f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/hLF7ZU6f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/hLF7ZU6f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/jNi948H2> .
+        <https://id.parliament.uk/jNi948H2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/jNi948H2> <https://id.parliament.uk/schema/layingDate> "2018-09-06+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/jNi948H2> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/BuMKAKjA> .
+        <https://id.parliament.uk/BuMKAKjA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/BuMKAKjA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/BuMKAKjA> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 23" .
+        <https://id.parliament.uk/BuMKAKjA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/BuMKAKjA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/BuMKAKjA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/BuMKAKjA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/BuMKAKjA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/MadeStatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/yGqCp359> .
+        <https://id.parliament.uk/yGqCp359> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/yGqCp359> <https://id.parliament.uk/schema/layingDate> "2018-09-10+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/yGqCp359> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/WBlaNvyq> .
+        <https://id.parliament.uk/WBlaNvyq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/WBlaNvyq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/WBlaNvyq> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 24" .
+        <https://id.parliament.uk/WBlaNvyq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/WBlaNvyq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/WBlaNvyq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/WBlaNvyq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/WBlaNvyq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/MadeStatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/4JKyg0Au> .
+        <https://id.parliament.uk/4JKyg0Au> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/4JKyg0Au> <https://id.parliament.uk/schema/layingDate> "2018-09-13+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/4JKyg0Au> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/lSRBYtGi> .
+        <https://id.parliament.uk/lSRBYtGi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/lSRBYtGi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/lSRBYtGi> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 25" .
+        <https://id.parliament.uk/lSRBYtGi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/lSRBYtGi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/lSRBYtGi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/lSRBYtGi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/lSRBYtGi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/MadeStatutoryInstrumentPaper> .
+        <https://id.parliament.uk/NDZSYjeE> <https://id.parliament.uk/schema/layingBodyHasLaying> <https://id.parliament.uk/C6qh45v5> .
+        <https://id.parliament.uk/C6qh45v5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying> .
+        <https://id.parliament.uk/C6qh45v5> <https://id.parliament.uk/schema/layingDate> "2018-09-13+00:00"^^<http://www.w3.org/2001/XMLSchema#date> .
+        <https://id.parliament.uk/C6qh45v5> <https://id.parliament.uk/schema/layingHasLaidThing> <https://id.parliament.uk/H1uGO0VI> .
+        <https://id.parliament.uk/H1uGO0VI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing> .
+        <https://id.parliament.uk/H1uGO0VI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+        <https://id.parliament.uk/H1uGO0VI> <https://id.parliament.uk/schema/laidThingName> "laidThingName - 26" .
+        <https://id.parliament.uk/H1uGO0VI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/NamedThing> .
+        <https://id.parliament.uk/H1uGO0VI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WebLinkedThing> .
+        <https://id.parliament.uk/H1uGO0VI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing> .
+        <https://id.parliament.uk/H1uGO0VI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .
+        <https://id.parliament.uk/H1uGO0VI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/MadeStatutoryInstrumentPaper> .
+    http_version: 
+  recorded_at: Mon, 08 Oct 2018 12:24:12 GMT
+recorded_with: VCR 4.0.0

--- a/spec/integration/controllers/groups/layings_controller_spec.rb
+++ b/spec/integration/controllers/groups/layings_controller_spec.rb
@@ -1,0 +1,20 @@
+require_relative '../../../rails_helper'
+
+RSpec.describe Groups::LayingsController, vcr: true do
+  describe 'GET index' do
+    before(:each) do
+      allow_any_instance_of(PageSerializer::ListPageSerializer).to receive(:request_id) { 123456 }
+    end
+
+    context 'navigating to the index page' do
+      it 'renders expected JSON output' do
+        get '/groups/XouN12Ow/made-available/availability-types/layings'
+        filtered_response_body = filter_sensitive_data(response.body)
+
+        expected_json = get_fixture('index', 'fixture')
+
+        expect(JSON.parse(filtered_response_body).to_yaml).to eq(expected_json)
+      end
+    end
+  end
+end

--- a/spec/serializers/component_serializer/heading1_component_serializer_spec.rb
+++ b/spec/serializers/component_serializer/heading1_component_serializer_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe ComponentSerializer::Heading1ComponentSerializer do
   let(:heading_data) { 'www.dianneabbott.com' }
   let(:subheading_content) { 'MP for' }
   let(:subheading_data) { 'www.MP.com' }
+  let(:subheading_link) { '/people/12345678' }
   let(:context_content) { 'Ingelbert and Humperdink' }
   let(:context_data) { 'www.londonborughofingelbertandhumperdink.com' }
   let(:context_hidden) { true }
@@ -20,75 +21,122 @@ RSpec.describe ComponentSerializer::Heading1ComponentSerializer do
       end
     end
 
-      context 'with just subheading content' do
-        it 'returns a hash containing the name and data' do
-          serializer = described_class.new(subheading_content: subheading_content)
+    context 'with just subheading content' do
+      it 'returns a hash containing the name and data' do
+        serializer = described_class.new(subheading_content: subheading_content)
 
-          expected = get_fixture('only_subheading_content')
+        expected = get_fixture('only_subheading_content')
+
+        expect(serializer.to_yaml).to eq expected
+      end
+    end
+
+    context 'with just context content' do
+      it 'returns a hash containing the name and data' do
+        serializer = described_class.new(context_content: context_content)
+
+        expected = get_fixture('only_context_content')
+
+        expect(serializer.to_yaml).to eq expected
+      end
+    end
+
+    context 'with subheading, heading and context content' do
+      it 'returns a hash containing the name and data' do
+        serializer = described_class.new(heading_content: heading_content, subheading_content: subheading_content, context_content: context_content)
+
+        expected = get_fixture('all_content')
+
+        expect(serializer.to_yaml).to eq expected
+      end
+    end
+
+    context 'with all content and heading data' do
+      it 'returns a hash containing the name and data' do
+        serializer = described_class.new(heading_content: heading_content, heading_data: heading_data, subheading_content: subheading_content, context_content: context_content)
+
+        expected = get_fixture('all_content_heading_data')
+
+        expect(serializer.to_yaml).to eq expected
+      end
+    end
+
+    context 'with all content and heading, subheading data' do
+      it 'returns a hash containing the name and data' do
+        serializer = described_class.new(heading_content: heading_content, heading_data: heading_data, subheading_content: subheading_content, subheading_data: subheading_data, context_content: context_content)
+
+        expected = get_fixture('all_content_heading_subheading_data')
+
+        expect(serializer.to_yaml).to eq expected
+      end
+    end
+
+    context 'with all content and all data' do
+      it 'returns a hash containing the name and data' do
+        serializer = described_class.new(heading_content: heading_content, heading_data: heading_data, subheading_content: subheading_content, subheading_data: subheading_data, context_content: context_content, context_data: context_data)
+
+        expected = get_fixture('all_content_all_data')
+
+        expect(serializer.to_yaml).to eq expected
+      end
+    end
+
+    context 'with all content and all data and context hidden' do
+      it 'returns a hash containing the name and data' do
+        serializer = described_class.new(heading_content: heading_content, heading_data: heading_data, subheading_content: subheading_content, subheading_data: subheading_data, context_content: context_content, context_data: context_data, context_hidden: context_hidden)
+
+        expected = get_fixture('all_content_all_data_context_hidden')
+
+        expect(serializer.to_yaml).to eq expected
+      end
+    end
+
+    context 'with a subheading link' do
+      context 'when there is subheading_content and subheading_link' do
+        it 'wraps subheading_content in an href with a link' do
+          serializer = described_class.new(subheading_content: subheading_content, subheading_link: subheading_link)
+
+          expected = get_fixture('subheading_link')
 
           expect(serializer.to_yaml).to eq expected
         end
       end
 
-      context 'with just context content' do
-        it 'returns a hash containing the name and data' do
-          serializer = described_class.new(context_content: context_content)
+      context 'when there is no subheading_link' do
+        it 'does not modify subheading_content' do
+          serializer = described_class.new(subheading_content: subheading_content )
 
-          expected = get_fixture('only_context_content')
-
-          expect(serializer.to_yaml).to eq expected
-        end
-      end
-
-      context 'with subheading, heading and context content' do
-        it 'returns a hash containing the name and data' do
-          serializer = described_class.new(heading_content: heading_content, subheading_content: subheading_content, context_content: context_content)
-
-          expected = get_fixture('all_content')
+          expected = get_fixture('no_subheading_link')
 
           expect(serializer.to_yaml).to eq expected
         end
       end
+    end
+  end
 
-      context 'with all content and heading data' do
-        it 'returns a hash containing the name and data' do
-          serializer = described_class.new(heading_content: heading_content, heading_data: heading_data, subheading_content: subheading_content, context_content: context_content)
+  context '#to_s' do
+    context 'with no subheading content' do
+      it 'returns only the heading content' do
+        serializer = described_class.new(heading_content: 'I am a heading')
 
-          expected = get_fixture('all_content_heading_data')
-
-          expect(serializer.to_yaml).to eq expected
-        end
+        expect(serializer.to_s).to eq 'I am a heading'
       end
+    end
 
-      context 'with all content and heading, subheading data' do
-        it 'returns a hash containing the name and data' do
-          serializer = described_class.new(heading_content: heading_content, heading_data: heading_data, subheading_content: subheading_content, subheading_data: subheading_data, context_content: context_content)
+    context 'with subheading content' do
+      it 'returns the subheading content and heading content with a hyphen in between' do
+        serializer = described_class.new(heading_content: 'I am a heading', subheading_content: 'I am a subheading')
 
-          expected = get_fixture('all_content_heading_subheading_data')
-
-          expect(serializer.to_yaml).to eq expected
-        end
+        expect(serializer.to_s).to eq 'I am a subheading - I am a heading'
       end
+    end
 
-      context 'with all content and all data' do
-        it 'returns a hash containing the name and data' do
-          serializer = described_class.new(heading_content: heading_content, heading_data: heading_data, subheading_content: subheading_content, subheading_data: subheading_data, context_content: context_content, context_data: context_data)
+    context 'with no heading content' do
+      it 'returns [Name unavailable]' do
+        serializer = described_class.new
 
-          expected = get_fixture('all_content_all_data')
-
-          expect(serializer.to_yaml).to eq expected
-        end
+        expect(serializer.to_s).to eq '[Name unavailable]'
       end
-
-      context 'with all content and all data and context hidden' do
-        it 'returns a hash containing the name and data' do
-          serializer = described_class.new(heading_content: heading_content, heading_data: heading_data, subheading_content: subheading_content, subheading_data: subheading_data, context_content: context_content, context_data: context_data, context_hidden: context_hidden)
-
-          expected = get_fixture('all_content_all_data_context_hidden')
-
-          expect(serializer.to_yaml).to eq expected
-        end
-      end
-
+    end
   end
 end

--- a/spec/serializers/component_serializer/paragraph_component_serializer_spec.rb
+++ b/spec/serializers/component_serializer/paragraph_component_serializer_spec.rb
@@ -9,5 +9,15 @@ RSpec.describe ComponentSerializer::ParagraphComponentSerializer do
 
       expect(paragraph_component_serializer.to_yaml).to eq expected
     end
+
+    context 'handling any property' do
+      it 'returns a hash containing the name and data' do
+        serializer = described_class.new(content: [{ content: 'some content', one: 'property', yet: 'another' }])
+
+        expected = get_fixture('any_property')
+
+        expect(serializer.to_yaml).to eq expected
+      end
+    end
   end
 end


### PR DESCRIPTION
**NOTE:**
This PR relies on a merge of https://github.com/ukparliament/thorney/pull/83.
Currently the `FixtureSweeper` is falsely detecting a fixture as unused, which is causing this build to fail in Travis. https://github.com/ukparliament/thorney/pull/83 fixes this issue.

**Update: 17/10/18**
Remove `#linkify_subheading`

This is a relatively big change that can be divided into two parts. 

**1. The modification of `ComponentSerializer::ParagraphComponentSerializer`**

This serializer can now take custom properties that can be used in translations in Augustus. Previously, you could only provide a link to go with a string, but this was limiting as it could only be used with a translation that allowed for a link. With the need for things like `Type: Statutory Instrument` and `Laid Date: 12 May 2018`, I thought it would be nice to be able to add properties other than links. So the translations for the above two in Augustus are something like: `"Type: {{-type}}"` and `"Laid Date: {{-date}}"`, respectively. 

The serializer now works by passing in some content (this is the same as before, which is a translation block you expect to be evaluated in Augustus) and some optional additional data. So the serializer for the above examples could be:

```ruby
ComponentSerializer::ParagraphComponentSerializer.new([{ content: 'layings.type', type: 'Statutory Instrument' }, { content: 'layings.date', date: '12 May 2018' }])
```

**2. The creation of `Groups::LayingsController` and modification of `ComponentSerializer::Heading1ComponentSerializer` and `PageSerializer::ListPageSerializer`**

The group layings page in Thorney is a first of its kind in that it is a subsidiary resource. This involved some thinking about the structure of the page. What stands out as a difference between the existing list pages in Thorney and this one is the heading. Current list page use a Heading1ComponentSerializer to create an H1 in Augustus. There is only one piece of text which is the type of thing, for example 'Statutory Instruments' or 'Groups'. With the new subsidiary resource page, the heading is different. It has the type of thing, but also the name of the thing the resource is subsidiary to. Usman refers to this as the "root". This is presented as a subheading with a link above the heading. 

Previously, `PageSerializer::ListPageSerializer` took a `page_title` and this was assumed to be the same as the title in the head of the page and the heading of the page. With the introduction of subsidiary resource pages, having a `page_title` was not sufficient. The solution to this was to pass in an instance of `ComponentSerializer::Heading1ComponentSerializer` which had information about the heading which could be used both for the title in the head and the heading. It also allows for variations between the existing list pages and subsidiary resource list pages. 

In `ComponentSerializer::Heading1ComponentSerializer`, a method `#linkify_subheading` is implemented. It takes the subheading and wraps it in `<a>` tags. The method was created with the idea that subsidiary resource pages will follow a pattern: a heading with the type of resource, and a link to the "root", which is the subheading.

Currently, the serializer has the ability to send a subheading with a link that `pugin-components` will handle, but this only works if the string is a translation, because `pugin-component` uses `i18next` to put the string into an `<a>` tag with the link. This approach is not ideal as we want the subheading the be data-driven, so it does not make sense to have a translation in the front-end for this. For example, the name "Home Office", a laying body, comes from the data. the `#linkify_subheading` is a workaround to this.

The other issue is, it might be better to use the `ComponentSerializer::LinkComponentSerializer` in the `ComponentSerializer::HeadingComponentSerializer` to create the link. It would be ideal because it would help with abstraction and DRYing out the code. However, the Heading1 in `pugin-component` is quite bespoke and won't simply allow us to pass in a serializer to it. This would involve modifications to the component in `pugin-components`.