### PR TITLE
[WEBDEV-842] Move JS from head to foot

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -283,7 +283,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 2.5.1p57
+   ruby 2.5.3p105
 
 BUNDLED WITH
    1.16.2

--- a/app/serializers/page_serializer/base_page_serializer.rb
+++ b/app/serializers/page_serializer/base_page_serializer.rb
@@ -26,6 +26,7 @@ module PageSerializer
         header_section(hash)
         main_section(hash)
         footer_section(hash)
+        foot_section(hash) if foot_components
       end
     end
 
@@ -56,6 +57,16 @@ module PageSerializer
       hash.tap do |h|
         h[:footer_components] = PartialSerializer::FooterComponentsPartialSerializer.new.to_h
       end
+    end
+
+    def foot_section(hash)
+      hash.tap do |h|
+        h[:foot] = foot_components
+      end
+    end
+
+    def foot_components
+      nil
     end
 
     def meta(title: 'UK Parliament', image_id: nil)

--- a/app/serializers/page_serializer/search_page/results_page_serializer.rb
+++ b/app/serializers/page_serializer/search_page/results_page_serializer.rb
@@ -7,17 +7,12 @@ module PageSerializer
 
       def meta
         super(title: title).tap do |meta|
-          meta[:components] = meta_components if total_results.positive?
           meta[:opensearch_description_url] = opensearch_description_url if opensearch_description_url
         end
       end
 
       def title
         t('search.title.with_query', query: @query)
-      end
-
-      def meta_components
-        [{ name: 'head__search-result-tracking' }]
       end
 
       def content
@@ -41,6 +36,14 @@ module PageSerializer
         return ComponentSerializer::HeadingComponentSerializer.new(content: ['search.no-results'], size: 2).to_h if total_results < 1
 
         ComponentSerializer::HeadingComponentSerializer.new(translation_key: 'search.count', translation_data: translation_data, size: 2).to_h
+      end
+
+      def foot_components
+        return nil unless total_results.positive?
+
+        {}.tap do |hash|
+          hash[:components] = [{ name: 'foot__search-result-tracking' }]
+        end
       end
     end
   end

--- a/spec/fixtures/controllers/search_controller/index/edgecase.yml
+++ b/spec/fixtures/controllers/search_controller/index/edgecase.yml
@@ -12,8 +12,6 @@ meta:
     image-height: '630'
     twitter-card: summary_large_image
   opensearch-description-url: https://www.example.com/search/opensearch
-  components:
-  - name: head__search-result-tracking
 header-components:
 - name: link
   data:
@@ -796,3 +794,6 @@ footer-components:
           data:
             link: "/meta/cookie-policy"
         - content: shared.footer.data-protection-privacy
+foot:
+  components:
+  - name: foot__search-result-tracking

--- a/spec/fixtures/controllers/search_controller/index/last_page.yml
+++ b/spec/fixtures/controllers/search_controller/index/last_page.yml
@@ -12,8 +12,6 @@ meta:
     image-height: '630'
     twitter-card: summary_large_image
   opensearch-description-url: https://www.example.com/search/opensearch
-  components:
-  - name: head__search-result-tracking
 header-components:
 - name: link
   data:
@@ -249,3 +247,6 @@ footer-components:
           data:
             link: "/meta/cookie-policy"
         - content: shared.footer.data-protection-privacy
+foot:
+  components:
+  - name: foot__search-result-tracking

--- a/spec/fixtures/controllers/search_controller/index/linux_first_page.yml
+++ b/spec/fixtures/controllers/search_controller/index/linux_first_page.yml
@@ -12,8 +12,6 @@ meta:
     image-height: '630'
     twitter-card: summary_large_image
   opensearch-description-url: https://www.example.com/search/opensearch
-  components:
-  - name: head__search-result-tracking
 header-components:
 - name: link
   data:
@@ -283,3 +281,6 @@ footer-components:
           data:
             link: "/meta/cookie-policy"
         - content: shared.footer.data-protection-privacy
+foot:
+  components:
+  - name: foot__search-result-tracking

--- a/spec/fixtures/controllers/search_controller/index/linux_last_page.yml
+++ b/spec/fixtures/controllers/search_controller/index/linux_last_page.yml
@@ -12,8 +12,6 @@ meta:
     image-height: '630'
     twitter-card: summary_large_image
   opensearch-description-url: https://www.example.com/search/opensearch
-  components:
-  - name: head__search-result-tracking
 header-components:
 - name: link
   data:
@@ -239,3 +237,6 @@ footer-components:
           data:
             link: "/meta/cookie-policy"
         - content: shared.footer.data-protection-privacy
+foot:
+  components:
+  - name: foot__search-result-tracking

--- a/spec/fixtures/controllers/search_controller/index/second_page.yml
+++ b/spec/fixtures/controllers/search_controller/index/second_page.yml
@@ -12,8 +12,6 @@ meta:
     image-height: '630'
     twitter-card: summary_large_image
   opensearch-description-url: https://www.example.com/search/opensearch
-  components:
-  - name: head__search-result-tracking
 header-components:
 - name: link
   data:
@@ -265,3 +263,6 @@ footer-components:
           data:
             link: "/meta/cookie-policy"
         - content: shared.footer.data-protection-privacy
+foot:
+  components:
+  - name: foot__search-result-tracking

--- a/spec/fixtures/controllers/search_controller/index/with_a_query.yml
+++ b/spec/fixtures/controllers/search_controller/index/with_a_query.yml
@@ -12,8 +12,6 @@ meta:
     image-height: '630'
     twitter-card: summary_large_image
   opensearch-description-url: https://www.example.com/search/opensearch
-  components:
-  - name: head__search-result-tracking
 header-components:
 - name: link
   data:
@@ -296,3 +294,6 @@ footer-components:
           data:
             link: "/meta/cookie-policy"
         - content: shared.footer.data-protection-privacy
+foot:
+  components:
+  - name: foot__search-result-tracking

--- a/spec/fixtures/serializers/page_serializer/search_page/results_page_serializer/with_a_query.yml
+++ b/spec/fixtures/serializers/page_serializer/search_page/results_page_serializer/with_a_query.yml
@@ -12,8 +12,6 @@ meta:
     image-height: '630'
     twitter-card: summary_large_image
   opensearch-description-url: https://example.com/search/opensearch
-  components:
-  - name: head__search-result-tracking
 header-components:
 - name: link
   data:
@@ -183,3 +181,6 @@ footer-components:
           data:
             link: "/meta/cookie-policy"
         - content: shared.footer.data-protection-privacy
+foot:
+  components:
+  - name: foot__search-result-tracking

--- a/spec/serializers/page_serializer/search_page/results_page_serializer_spec.rb
+++ b/spec/serializers/page_serializer/search_page/results_page_serializer_spec.rb
@@ -43,7 +43,6 @@ RSpec.describe PageSerializer::SearchPage::ResultsPageSerializer do
   context '#to_h' do
     context 'with a query' do
       it 'produces the correct hash' do
-
         expected = get_fixture('with_a_query')
 
         expect(subject.to_yaml).to eq(expected)


### PR DESCRIPTION
Introduced abstract method, `#foot_components` to the `BasePageSerializer`. This method is implemented specifically on pages that require JavaScript in the foot of the page. Here we use it in the `ResultsPageSerializer`.