### PR TITLE
[WEBDEV-836] Implemented GroupSortHelper

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::API
   include ActionController::Cookies
   include ApplicationHelper
   include HousesHelper
+  include GroupSortHelper
 
   attr_reader :app_insights_request_id
 

--- a/app/controllers/concerns/group_sort_helper.rb
+++ b/app/controllers/concerns/group_sort_helper.rb
@@ -1,0 +1,82 @@
+module GroupSortHelper
+  class << self
+    # Sorts the array values of a hash of objects.
+    #
+    # @param [Hash<Object, Array>] nodes_hash grouped key value pairs where the values are all arrays.
+    # @param [Array] method_symbols array of methods as symbols to sort the values by.
+    # @param [Block] block block to sort the values by.
+    # @param [Boolean] descending optionally reverses the sort order.
+    #
+    # @return [Array] sorted values flattened into an array.
+    def sort(nodes_hash, method_symbols: nil, block: nil, descending: false)
+      nil_values = nodes_hash.delete(nil) || []
+
+      nodes_hash.each do |key, nodes|
+        sorting_block = get_linked_value(method_symbols) if method_symbols
+
+        sorting_block = block if block
+
+        rejected, cleaned_nodes = nodes.partition { |object| sorting_block.call(object).nil? }
+
+        next if cleaned_nodes.size == 1
+
+        cleaned_nodes.sort! { |node1, node2| sorting_block.call(node1) <=> sorting_block.call(node2) }
+
+        cleaned_nodes.reverse! if descending
+
+        nodes_hash[key] = cleaned_nodes.concat(rejected)
+      end
+
+      nodes_hash.values.flatten.concat(nil_values)
+    end
+
+    # Sorts the keys of a hash.
+    #
+    # @param [Hash<Object, Array>] nodes_hash grouped key value pairs where the values are all arrays.
+    # @param [Boolean] descending optionally reverses the sort order.
+    #
+    # @return [Hash] hash sorted by its keys.
+    def sort_keys(nodes_hash, descending: false)
+      nil_values = nodes_hash.delete(nil)
+
+      nodes_hash = descending ? nodes_hash.sort.reverse.to_h : nodes_hash.sort.to_h
+
+      nodes_hash[nil] = nil_values if nil_values
+
+      nodes_hash
+    end
+
+    # Groups an array into key value pairs.
+    #
+    # @param [Array] nodes array of objects to group.
+    # @param [Array] method_symbols array of methods as symbols to group the objects by.
+    # @param [Block] block block to group the objects by.
+    #
+    # @return [Hash] grouped objects with the key the grouped value and the values the objects.
+    def group(nodes, method_symbols: nil, block: nil)
+      grouped_nodes  = {}
+      grouping_block = nil
+
+      grouping_block = get_linked_value(method_symbols) if method_symbols
+
+      grouping_block = block if block
+
+      nodes.each do |node|
+        key = grouping_block.call(node)
+
+        grouped_nodes[key] = [] unless grouped_nodes[key]
+        grouped_nodes[key] << node
+      end
+
+      grouped_nodes
+    end
+    
+    private
+
+    def get_linked_value(method_symbols)
+      proc do |node|
+        method_symbols.inject(node) { |value, method| value.try(method) }
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/group_sort_helper.rb
+++ b/app/controllers/concerns/group_sort_helper.rb
@@ -5,17 +5,43 @@ module GroupSortHelper
     # @param [Hash<Object, Array>] nodes_hash grouped key value pairs where the values are all arrays.
     # @param [Array] method_symbols array of methods as symbols to sort the values by.
     # @param [Block] block block to sort the values by.
+    # Note: It is only necessary to provide one of method_symbols and block.  If both are given, the block will override the method_symbols.
     # @param [Boolean] descending optionally reverses the sort order.
+    #
+    # @example Sorting a hash with method_symbols.
+    #
+    # hash = {
+    #   '1' => [#<Object @laying: #<Object @date: '21 Jul 2018'>>, #<Object @laying: #<Object @date: '21 Jun 2018'>>,  #<Object @laying: #<Object @date: '21 May 2018'>>, #<Object @laying: #<Object @date: '3 Sep 2018'>>],
+    #   '2' => [#<Object @laying: #<Object @date: '21 Jun 2016'>>, #<Object>, #<Object @laying: #<Object @date: '4 Jan 2016'>>, #<Object @laying: #<Object @date: '7 Sep 2016'>>]
+    #   }
+    #
+    # sort(hash, method_symbols: [:laying, :date])
+    #   #=>
+    #   '1' => [#<Object @laying: #<Object @date: '21 May 2018'>>, #<Object @laying: #<Object @date: '21 Jun 2018'>>, #<Object @laying: #<Object @date: '21 Jul 2018'>>, #<Object @laying: #<Object @date: '3 Sep 2018'>>],
+    #   '2' => [#<Object @laying: #<Object @date: '4 Jan 2016'>>, #<Object @laying: #<Object @date: '21 Jun 2016'>>, #<Object @laying: #<Object @date: '7 Sep 2016'>>, #<Object>]
+    #   }
+    #
+    # @example Sorting a hash with a block (using the previously defined hash)
+    #
+    #   sorting_block = proc { |node| node.try(:laying).try(:date) }
+    #
+    #   sort(hash, block: sorting_block)
+    #      #=>
+    #     '1' => [#<Object @laying: #<Object @date: '21 May 2018'>>, #<Object @laying: #<Object @date: '21 Jun 2018'>>, #<Object @laying: #<Object @date: '21 Jul 2018'>>, #<Object @laying: #<Object @date: '3 Sep 2018'>>],
+    #     '2' => [#<Object @laying: #<Object @date: '4 Jan 2016'>>, #<Object @laying: #<Object @date: '21 Jun 2016'>>, #<Object @laying: #<Object @date: '7 Sep 2016'>>, #<Object>]
+    #     }
     #
     # @return [Array] sorted values flattened into an array.
     def sort(nodes_hash, method_symbols: nil, block: nil, descending: false)
+      return if method_symbols.nil? && block.nil?
+
       nil_values = nodes_hash.delete(nil) || []
 
+      sorting_block = get_linked_value(method_symbols) if method_symbols
+
+      sorting_block = block if block
+
       nodes_hash.each do |key, nodes|
-        sorting_block = get_linked_value(method_symbols) if method_symbols
-
-        sorting_block = block if block
-
         rejected, cleaned_nodes = nodes.partition { |object| sorting_block.call(object).nil? }
 
         next if cleaned_nodes.size == 1
@@ -51,9 +77,38 @@ module GroupSortHelper
     # @param [Array] nodes array of objects to group.
     # @param [Array] method_symbols array of methods as symbols to group the objects by.
     # @param [Block] block block to group the objects by.
+    # Note: It is only necessary to provide one of method_symbols and block.  If both are given, the block will override the method_symbols.
+    #
+    # @example Grouping with method_symbols
+    #
+    #   array = [#<Object:1 @laying: #<Object @date: '21 May 2018'>...>, #<Object:2 @laying: #<Object @date: '21 Jun 2018'>...>, #<Object:3 @laying: #<Object @date: '21 May 2018'>...>, #<Object:4 @laying: #<Object @date: '21 May 2018'>...>, #<Object:5 @laying: #<Object @date: '21 Jan 2018'>...>, #<Object:6 @laying: #<Object @date: '21 Jun 2018'>...>, #<Object:7...>]
+    #
+    #   group(array, method_symbols: [:laying, :date])
+    #     #=>
+    #     {
+    #       '21 May 2018' => [#<Object:1...>, #<Object:3...>, #<Object:4...>],
+    #       '21 Jun 2018' => [#<Object:2...>, #<Object:6...>],
+    #       '21 Jan 2018' => [#<Object:5...>],
+    #        nil => [#<Object:7...>]
+    #     }
+    #
+    # @example Grouping with block (using same array as previous example)
+    #
+    #   grouping_block = proc { |node| node.try(:laying).try(:date) }
+    #
+    #   group(array, block: grouping_block)
+    #     #=>
+    #     {
+    #       '21 May 2018' => [#<Object:1...>, #<Object:3...>, #<Object:4...>],
+    #       '21 Jun 2018' => [#<Object:2...>, #<Object:6...>],
+    #       '21 Jan 2018' => [#<Object:5...>],
+    #        nil => [#<Object:7...>]
+    #     }
     #
     # @return [Hash] grouped objects with the key the grouped value and the values the objects.
     def group(nodes, method_symbols: nil, block: nil)
+      return if method_symbols.nil? && block.nil?
+
       grouped_nodes  = {}
       grouping_block = nil
 
@@ -71,8 +126,15 @@ module GroupSortHelper
       grouped_nodes
     end
 
+    def group_and_sort(nodes, group_method_symbols: nil, group_block: nil, key_sort_descending: false, sort_method_symbols: nil, sort_block: nil, sort_descending: false)
+      grouped_hash = group(nodes, method_symbols: group_method_symbols, block: group_block)
+      sorted_by_keys = sort_keys(grouped_hash, descending: key_sort_descending)
+      sort(sorted_by_keys, method_symbols: sort_method_symbols, block: sort_block, descending: sort_descending)
+    end
+
     private
 
+    # Takes the method symbols provided and calls them in a chain on the node using try to handle nil values.
     def get_linked_value(method_symbols)
       proc do |node|
         method_symbols.inject(node) { |value, method| value.try(method) }

--- a/app/controllers/concerns/group_sort_helper.rb
+++ b/app/controllers/concerns/group_sort_helper.rb
@@ -70,7 +70,7 @@ module GroupSortHelper
 
       grouped_nodes
     end
-    
+
     private
 
     def get_linked_value(method_symbols)

--- a/app/controllers/proposed_negative_statutory_instruments_controller.rb
+++ b/app/controllers/proposed_negative_statutory_instruments_controller.rb
@@ -10,7 +10,7 @@ class ProposedNegativeStatutoryInstrumentsController < ApplicationController
   def index
     @proposed_negative_statutory_instruments = FilterHelper.filter(@api_request, 'ProposedNegativeStatutoryInstrumentPaper')
 
-    sorted_statutory_instruments = GroupSortHelper.group_and_sort(@proposed_negative_statutory_instruments, group_method_symbols: [:laying, :date, :to_date], key_sort_descending: true, sort_method_symbols: [:proposedNegativeStatutoryInstrumentPaperName])
+    sorted_statutory_instruments = GroupSortHelper.group_and_sort(@proposed_negative_statutory_instruments, group_method_symbols: %i[laying date to_date], key_sort_descending: true, sort_method_symbols: [:proposedNegativeStatutoryInstrumentPaperName])
 
     list_components = LaidThingListComponentsFactory.build_components(statutory_instruments: sorted_statutory_instruments, type: :proposed_negative_statutory_instrument)
 

--- a/app/controllers/proposed_negative_statutory_instruments_controller.rb
+++ b/app/controllers/proposed_negative_statutory_instruments_controller.rb
@@ -10,21 +10,9 @@ class ProposedNegativeStatutoryInstrumentsController < ApplicationController
   def index
     @proposed_negative_statutory_instruments = FilterHelper.filter(@api_request, 'ProposedNegativeStatutoryInstrumentPaper')
 
-    grouping_block = proc do |node|
-      value = node.try(:laying).try(:date)
+    sorted_statutory_instruments = GroupSortHelper.group_and_sort(@proposed_negative_statutory_instruments, group_method_symbols: [:laying, :date, :to_date], key_sort_descending: true, sort_method_symbols: [:proposedNegativeStatutoryInstrumentPaperName])
 
-      next nil if value.nil?
-
-      value.to_date
-    end
-
-    grouped_statutory_instruments = GroupSortHelper.group(@proposed_negative_statutory_instruments, block: grouping_block)
-
-    statutory_instruments_sorted_by_keys = GroupSortHelper.sort_keys(grouped_statutory_instruments, descending: true)
-
-    statutory_instruments_sorted = GroupSortHelper.sort(statutory_instruments_sorted_by_keys, method_symbols: [:proposedNegativeStatutoryInstrumentPaperName])
-
-    list_components = LaidThingListComponentsFactory.build_components(statutory_instruments: statutory_instruments_sorted, type: :proposed_negative_statutory_instrument)
+    list_components = LaidThingListComponentsFactory.build_components(statutory_instruments: sorted_statutory_instruments, type: :proposed_negative_statutory_instrument)
 
     heading = ComponentSerializer::Heading1ComponentSerializer.new(heading_content: I18n.t('proposed_negative_statutory_instruments.index.title'))
 

--- a/app/controllers/proposed_negative_statutory_instruments_controller.rb
+++ b/app/controllers/proposed_negative_statutory_instruments_controller.rb
@@ -10,7 +10,21 @@ class ProposedNegativeStatutoryInstrumentsController < ApplicationController
   def index
     @proposed_negative_statutory_instruments = FilterHelper.filter(@api_request, 'ProposedNegativeStatutoryInstrumentPaper')
 
-    list_components = LaidThingListComponentsFactory.build_components(statutory_instruments: @proposed_negative_statutory_instruments, type: :proposed_negative_statutory_instrument)
+    grouping_block = proc do |node|
+      value = node.try(:laying).try(:date)
+
+      next nil if value.nil?
+
+      value.to_date
+    end
+
+    grouped_statutory_instruments = GroupSortHelper.group(@proposed_negative_statutory_instruments, block: grouping_block)
+
+    statutory_instruments_sorted_by_keys = GroupSortHelper.sort_keys(grouped_statutory_instruments, descending: true)
+
+    statutory_instruments_sorted = GroupSortHelper.sort(statutory_instruments_sorted_by_keys, method_symbols: [:proposedNegativeStatutoryInstrumentPaperName])
+
+    list_components = LaidThingListComponentsFactory.build_components(statutory_instruments: statutory_instruments_sorted, type: :proposed_negative_statutory_instrument)
 
     heading = ComponentSerializer::Heading1ComponentSerializer.new(heading_content: I18n.t('proposed_negative_statutory_instruments.index.title'))
 

--- a/app/controllers/statutory_instruments_controller.rb
+++ b/app/controllers/statutory_instruments_controller.rb
@@ -10,21 +10,9 @@ class StatutoryInstrumentsController < ApplicationController
   def index
     @statutory_instruments = FilterHelper.filter(@api_request, 'StatutoryInstrumentPaper')
 
-    grouping_block = proc do |node|
-      value = node.try(:laying).try(:date)
+    sorted_statutory_instruments = GroupSortHelper.group_and_sort(@statutory_instruments, group_method_symbols: [:laying, :date, :to_date], key_sort_descending: true, sort_method_symbols: [:statutoryInstrumentPaperName])
 
-      next nil if value.nil?
-
-      value.to_date
-    end
-
-    grouped_statutory_instruments = GroupSortHelper.group(@statutory_instruments, block: grouping_block)
-
-    statutory_instruments_sorted_by_keys = GroupSortHelper.sort_keys(grouped_statutory_instruments, descending: true)
-
-    statutory_instruments_sorted = GroupSortHelper.sort(statutory_instruments_sorted_by_keys, method_symbols: [:statutoryInstrumentPaperName])
-
-    list_components = LaidThingListComponentsFactory.build_components(statutory_instruments: statutory_instruments_sorted, type: :statutory_instrument)
+    list_components = LaidThingListComponentsFactory.build_components(statutory_instruments: sorted_statutory_instruments, type: :statutory_instrument)
 
     heading = ComponentSerializer::Heading1ComponentSerializer.new(heading_content: I18n.t('statutory_instruments.index.title'))
 

--- a/app/controllers/statutory_instruments_controller.rb
+++ b/app/controllers/statutory_instruments_controller.rb
@@ -10,7 +10,7 @@ class StatutoryInstrumentsController < ApplicationController
   def index
     @statutory_instruments = FilterHelper.filter(@api_request, 'StatutoryInstrumentPaper')
 
-    sorted_statutory_instruments = GroupSortHelper.group_and_sort(@statutory_instruments, group_method_symbols: [:laying, :date, :to_date], key_sort_descending: true, sort_method_symbols: [:statutoryInstrumentPaperName])
+    sorted_statutory_instruments = GroupSortHelper.group_and_sort(@statutory_instruments, group_method_symbols: %i[laying date to_date], key_sort_descending: true, sort_method_symbols: [:statutoryInstrumentPaperName])
 
     list_components = LaidThingListComponentsFactory.build_components(statutory_instruments: sorted_statutory_instruments, type: :statutory_instrument)
 

--- a/spec/controllers/concerns/group_sort_helper_spec.rb
+++ b/spec/controllers/concerns/group_sort_helper_spec.rb
@@ -1,6 +1,8 @@
 require_relative '../../rails_helper'
 
 RSpec.describe GroupSortHelper, type: :helper, vcr: true do
+# The doubles below used together create a data set on which to test the various methods within the module.
+# At the bottom of the file are tests using n-triple data.
 
   let(:object_one) { double('one', date: DateTime.parse('23/12/2016'), person: person_one) }
   let(:object_two) { double('two', date: DateTime.parse('10/08/2009'), person: person_two) }
@@ -79,6 +81,12 @@ RSpec.describe GroupSortHelper, type: :helper, vcr: true do
   end
 
   describe '#group' do
+    context 'with no block or method_symbols' do
+      it 'returns out of the method' do
+        expect(described_class.group(full_data_objects)).to be(nil)
+      end
+    end
+
     context 'with a block' do
       context 'full data' do
         it 'returns the data grouped by the given block' do
@@ -109,6 +117,12 @@ RSpec.describe GroupSortHelper, type: :helper, vcr: true do
   end
 
   describe '#sort' do
+    context 'with no block or method_symbols' do
+      it 'returns out of the method' do
+        expect(described_class.sort(full_data_hash_by_person)).to be(nil)
+      end
+    end
+
     context 'with a block' do
       context 'full data' do
         it 'returns the data sorted by the given block' do
@@ -171,6 +185,14 @@ RSpec.describe GroupSortHelper, type: :helper, vcr: true do
           expect(described_class.sort_keys(hash)).to eq({ 'a' => 2, 'b' => 4, 'c' => 1, 'd' => 3, nil => 5 })
         end
       end
+    end
+  end
+
+  describe '#group_and_sort' do
+    it 'returns the data grouped and sorted' do
+      expected = [object_six, object_nine, object_eight, object_one, object_two, object_eleven, object_four, object_three]
+
+      expect(described_class.group_and_sort(full_data_objects, group_block: block, key_sort_descending: true, sort_method_symbols: [:person, :name])).to eq(expected)
     end
   end
 

--- a/spec/controllers/concerns/group_sort_helper_spec.rb
+++ b/spec/controllers/concerns/group_sort_helper_spec.rb
@@ -1,0 +1,238 @@
+require_relative '../../rails_helper'
+
+RSpec.describe GroupSortHelper, type: :helper, vcr: true do
+
+  let(:object_one) { double('one', date: DateTime.parse('23/12/2016'), person: person_one) }
+  let(:object_two) { double('two', date: DateTime.parse('10/08/2009'), person: person_two) }
+  let(:object_three) { double('three', date: DateTime.parse('10/08/2009'), person: person_three) }
+  let(:object_four) { double('four', date: DateTime.parse('10/08/2009'), person: person_four) }
+  let(:object_five) { double('five', person: person_five) }
+  let(:object_six) { double('six', date: DateTime.parse('03/01/2018'), person: person_six) }
+  let(:object_seven) { double('seven', date: DateTime.parse('03/01/2018')) }
+  let(:object_eight) { double('eight', date: DateTime.parse('03/01/2018'), person: person_eight) }
+  let(:object_nine) { double('nine', date: DateTime.parse('03/01/2018'), person: person_nine) }
+  let(:object_ten) { double('ten', person: person_ten) }
+  let(:object_eleven) { double('eleven', date: DateTime.parse('10/08/2009'), person: person_eleven) }
+  let(:object_twelve) { double('twelve', date: DateTime.parse('10/08/2009'), person: person_twelve) }
+
+  let(:person_one) { double('person_one', name: 'Ann') }
+  let(:person_two) { double('person_two', name: 'Ann') }
+  let(:person_three) { double('person_three', name: 'Theresa') }
+  let(:person_four) { double('person_four', name: 'Hannah') }
+  let(:person_five) { double('person_five', name: 'Sally') }
+  let(:person_six) { double('person_six', name: 'Ann') }
+  let(:person_eight) { double('person_eight', name: 'Theresa') }
+  let(:person_nine) { double('person_nine', name: 'Greta') }
+  let(:person_ten) { double('person_ten', name: 'Zara') }
+  let(:person_eleven) { double('person_eleven', name: 'Greta') }
+  let(:person_twelve) { double('person_twelve', name: 'Zara') }
+
+  let(:full_data_objects) { [object_one, object_eight, object_three, object_six, object_two, object_nine, object_eleven, object_four] }
+  let(:all_objects) { [object_one, object_ten, object_eight, object_five, object_three, object_six, object_two, object_nine, object_eleven, object_seven, object_four, object_twelve] }
+
+  let(:full_data_hash_by_person) do
+    {
+      'Ann' => [object_one, object_six, object_two],
+      'Greta' => [object_nine, object_eleven],
+      'Hannah' => [object_four],
+      'Theresa' => [object_eight, object_three]
+    }
+  end
+
+  let(:all_data_hash_by_person) do
+    {
+      'Ann' => [object_one, object_six, object_two],
+      'Greta' => [object_nine, object_eleven],
+      'Hannah' => [object_four],
+      'Sally' => [object_five],
+      'Theresa' => [object_eight, object_three],
+      'Zara' => [object_ten, object_twelve],
+      nil => [object_seven]
+    }
+  end
+
+  let(:full_data_hash_by_date) do
+    {
+      DateTime.parse('23/12/2016') => [object_one],
+      DateTime.parse('10/08/2009') => [object_three, object_two, object_eleven, object_four],
+      DateTime.parse('03/01/2018') => [object_eight, object_six, object_nine]
+    }
+  end
+
+  let(:all_data_hash_by_date) do
+    {
+      DateTime.parse('23/12/2016') => [object_one],
+      DateTime.parse('10/08/2009') => [object_three, object_two, object_eleven, object_four, object_twelve],
+      DateTime.parse('03/01/2018') => [object_eight, object_six, object_nine, object_seven],
+      nil => [object_ten, object_five]
+    }
+  end
+
+  let(:block) do
+    proc do |object|
+      value = object.try(:date)
+
+      next nil if value.nil?
+
+      value
+    end
+  end
+
+  describe '#group' do
+    context 'with a block' do
+      context 'full data' do
+        it 'returns the data grouped by the given block' do
+          expect(described_class.group(full_data_objects, block: block)).to eq(full_data_hash_by_date)
+        end
+      end
+
+      context 'missing data' do
+        it 'returns the data grouped by the given block' do
+          expect(described_class.group(all_objects, block: block)).to eq(all_data_hash_by_date)
+        end
+      end
+    end
+
+    context 'with method_symbols' do
+      context 'full data' do
+        it 'returns the data grouped by the method symbols' do
+          expect(described_class.group(full_data_objects, method_symbols: [:person, :name])).to eq(full_data_hash_by_person)
+        end
+      end
+
+      context 'missing data' do
+        it 'returns the data grouped by the method symbols' do
+          expect(described_class.group(all_objects, method_symbols: [:person, :name])).to eq(all_data_hash_by_person)
+        end
+      end
+    end
+  end
+
+  describe '#sort' do
+    context 'with a block' do
+      context 'full data' do
+        it 'returns the data sorted by the given block' do
+          expected = [object_two, object_one, object_six, object_eleven, object_nine, object_four, object_three, object_eight]
+
+          expect(described_class.sort(full_data_hash_by_person, block: block)).to eq(expected)
+        end
+      end
+
+      context 'missing data' do
+        it 'returns the data sorted by the given block' do
+          expected = [object_two, object_one, object_six, object_eleven, object_nine, object_four, object_five, object_three, object_eight, object_ten, object_twelve, object_seven]
+
+          expect(described_class.sort(all_data_hash_by_person, block: block)).to eq(expected)
+        end
+      end
+    end
+
+    context 'with method_symbols' do
+      context 'full data' do
+        it 'returns the data sorted by the method symbols' do
+          expected = [object_one, object_two, object_eleven, object_four, object_three, object_six, object_nine, object_eight]
+
+          expect(described_class.sort(full_data_hash_by_date, method_symbols: [:person, :name])).to eq(expected)
+        end
+      end
+
+      context 'missing data' do
+        it 'returns the data sorted by the method symbols' do
+          expected = [object_one, object_two, object_eleven, object_four, object_three, object_twelve, object_six, object_nine, object_eight, object_seven, object_ten, object_five]
+
+          expect(described_class.sort(all_data_hash_by_date, method_symbols: [:person, :name])).to eq(expected)
+        end
+      end
+    end
+
+    context 'with a direction' do
+      it 'returns the data sorted by the method symbols in descending order' do
+        expected = [object_one, object_three, object_four, object_eleven, object_two, object_eight, object_nine, object_six]
+
+        expect(described_class.sort(full_data_hash_by_date, method_symbols: [:person, :name], descending: true)).to eq(expected)
+      end
+    end
+  end
+
+  describe '#sort_keys' do
+    context 'with a block' do
+      context 'full data' do
+        it 'returns the data sorted by the given block' do
+          hash = { 'c' => 1, 'a' => 2, 'd' => 3, 'b' => 4 }
+
+          expect(described_class.sort_keys(hash)).to eq({ 'a' => 2, 'b' => 4, 'c' => 1, 'd' => 3 })
+        end
+      end
+
+      context 'missing data' do
+        it 'returns the data sorted by the given block' do
+          hash = { 'c' => 1, 'a' => 2, nil => 5, 'd' => 3, 'b' => 4 }
+
+          expect(described_class.sort_keys(hash)).to eq({ 'a' => 2, 'b' => 4, 'c' => 1, 'd' => 3, nil => 5 })
+        end
+      end
+    end
+  end
+
+  context 'with real data' do
+    let(:response) { Parliament::Request::UrlRequest.new(base_url:   ENV['PARLIAMENT_BASE_URL'],
+                                                        builder:    Parliament::Builder::NTripleResponseBuilder,
+                                                        decorators: Parliament::Grom::Decorator).statutory_instrument_index.get }
+
+    let(:statutory_instruments) { response.filter('https://id.parliament.uk/schema/StatutoryInstrumentPaper') }
+
+    let(:grouping_block) do
+      proc do |node|
+        value = node.try(:laying).try(:date)
+
+        next nil if value.nil?
+
+        value.to_date
+      end
+    end
+
+    let(:grouped_nodes) { described_class.group(statutory_instruments, block: grouping_block) }
+
+    context '#group' do
+      it 'groups the data correctly' do
+        expect(grouped_nodes.keys.uniq).to eq(grouped_nodes.keys)
+        expect(grouped_nodes.values.first.length).to eq(3)
+
+        grouped_nodes.values.first.each do |node|
+          expect(node).to be_a(Grom::Node)
+        end
+      end
+    end
+
+    context '#sort_keys' do
+      it 'sorts a hash by its keys correctly' do
+        sorted = described_class.sort_keys(grouped_nodes)
+
+        expect(sorted.keys.first).to eq(Date.new(2018, 3, 29))
+        expect(sorted.keys[-2]).to eq(Date.new(2018, 10, 16))
+        expect(sorted.keys.last).to be(nil)
+      end
+    end
+
+    context '#sort' do
+      it 'sorts the data correctly' do
+        sorted = described_class.sort(grouped_nodes, method_symbols: [:statutoryInstrumentPaperName])
+
+        expect(sorted[0].statutoryInstrumentPaperName).to eq('statutoryInstrumentPaperName - 1')
+        expect(sorted[0].laying.date).to eq(DateTime.new(2018, 5, 3, 1, 0))
+
+        expect(sorted[1].statutoryInstrumentPaperName).to eq('statutoryInstrumentPaperName - 22')
+        expect(sorted[1].laying.date).to eq(DateTime.new(2018, 5, 3, 1, 0))
+
+        expect(sorted[2].statutoryInstrumentPaperName).to eq('statutoryInstrumentPaperName - 6')
+        expect(sorted[2].laying.date).to eq(DateTime.new(2018, 5, 3, 1, 0))
+
+        expect(sorted[3].statutoryInstrumentPaperName).to eq('statutoryInstrumentPaperName - 2')
+        expect(sorted[3].laying.date).to eq(DateTime.new(2018, 4, 27, 1, 0))
+
+        expect(sorted.last.statutoryInstrumentPaperName).to eq('statutoryInstrumentPaperName - 278')
+        expect(sorted.last.try(:laying).try(:date)).to be(nil)
+      end
+    end
+  end
+end

--- a/spec/fixtures/controllers/proposed_negative_statutory_instruments_controller/index/fixture.yml
+++ b/spec/fixtures/controllers/proposed_negative_statutory_instruments_controller/index/fixture.yml
@@ -112,9 +112,9 @@ main-components:
             heading:
               name: heading
               data:
-                content: proposedNegativeStatutoryInstrumentPaperName - 1
+                content: proposedNegativeStatutoryInstrumentPaperName - 44
                 size: 2
-                link: "/proposed-negative-statutory-instruments/Tn1xqHc0"
+                link: "/proposed-negative-statutory-instruments/e93zn4Ry"
             list-description:
               name: list__description
               data:
@@ -124,8 +124,8 @@ main-components:
                   description:
                   - content: shared.time-html
                     data:
-                      datetime-value: '2018-07-19'
-                      date: 19 July 2018
+                      datetime-value: '2018-10-15'
+                      date: 15 October 2018
                 - term:
                     content: laid-thing.laying-body
                   description:
@@ -139,9 +139,9 @@ main-components:
             heading:
               name: heading
               data:
-                content: proposedNegativeStatutoryInstrumentPaperName - 2
+                content: proposedNegativeStatutoryInstrumentPaperName - 45
                 size: 2
-                link: "/proposed-negative-statutory-instruments/wzsrSFQP"
+                link: "/proposed-negative-statutory-instruments/sHOlA3ji"
             list-description:
               name: list__description
               data:
@@ -151,8 +151,35 @@ main-components:
                   description:
                   - content: shared.time-html
                     data:
-                      datetime-value: '2018-07-19'
-                      date: 19 July 2018
+                      datetime-value: '2018-10-15'
+                      date: 15 October 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 7
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: proposedNegativeStatutoryInstrumentPaperName - 43
+                size: 2
+                link: "/proposed-negative-statutory-instruments/OqROoJsG"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-10-12'
+                      date: 12 October 2018
                 - term:
                     content: laid-thing.laying-body
                   description:
@@ -166,9 +193,9 @@ main-components:
             heading:
               name: heading
               data:
-                content: proposedNegativeStatutoryInstrumentPaperName - 3
+                content: proposedNegativeStatutoryInstrumentPaperName - 41
                 size: 2
-                link: "/proposed-negative-statutory-instruments/H95FzZVv"
+                link: "/proposed-negative-statutory-instruments/EfjqJrpr"
             list-description:
               name: list__description
               data:
@@ -178,8 +205,8 @@ main-components:
                   description:
                   - content: shared.time-html
                     data:
-                      datetime-value: '2018-07-19'
-                      date: 19 July 2018
+                      datetime-value: '2018-10-10'
+                      date: 10 October 2018
                 - term:
                     content: laid-thing.laying-body
                   description:
@@ -193,9 +220,9 @@ main-components:
             heading:
               name: heading
               data:
-                content: proposedNegativeStatutoryInstrumentPaperName - 4
+                content: proposedNegativeStatutoryInstrumentPaperName - 42
                 size: 2
-                link: "/proposed-negative-statutory-instruments/cL5yuFbG"
+                link: "/proposed-negative-statutory-instruments/JZ7gvDu6"
             list-description:
               name: list__description
               data:
@@ -205,89 +232,8 @@ main-components:
                   description:
                   - content: shared.time-html
                     data:
-                      datetime-value: '2018-07-19'
-                      date: 19 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 1
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: proposedNegativeStatutoryInstrumentPaperName - 5
-                size: 2
-                link: "/proposed-negative-statutory-instruments/mssRQnqj"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-19'
-                      date: 19 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 1
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: proposedNegativeStatutoryInstrumentPaperName - 6
-                size: 2
-                link: "/proposed-negative-statutory-instruments/PkQCvHkT"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-20'
-                      date: 20 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 2
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: proposedNegativeStatutoryInstrumentPaperName - 7
-                size: 2
-                link: "/proposed-negative-statutory-instruments/AcoKsOuw"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-20'
-                      date: 20 July 2018
+                      datetime-value: '2018-10-10'
+                      date: 10 October 2018
                 - term:
                     content: laid-thing.laying-body
                   description:
@@ -301,9 +247,9 @@ main-components:
             heading:
               name: heading
               data:
-                content: proposedNegativeStatutoryInstrumentPaperName - 8
+                content: proposedNegativeStatutoryInstrumentPaperName - 38
                 size: 2
-                link: "/proposed-negative-statutory-instruments/YOGGjydt"
+                link: "/proposed-negative-statutory-instruments/6itOwgLT"
             list-description:
               name: list__description
               data:
@@ -313,12 +259,12 @@ main-components:
                   description:
                   - content: shared.time-html
                     data:
-                      datetime-value: '2018-07-20'
-                      date: 20 July 2018
+                      datetime-value: '2018-10-09'
+                      date: 9 October 2018
                 - term:
                     content: laid-thing.laying-body
                   description:
-                  - content: groupName - 2
+                  - content: groupName - 1
                 - term:
                     content: laid-thing.procedure
                   description:
@@ -328,9 +274,9 @@ main-components:
             heading:
               name: heading
               data:
-                content: proposedNegativeStatutoryInstrumentPaperName - 9
+                content: proposedNegativeStatutoryInstrumentPaperName - 39
                 size: 2
-                link: "/proposed-negative-statutory-instruments/7KgIpwmP"
+                link: "/proposed-negative-statutory-instruments/c9tfxxSG"
             list-description:
               name: list__description
               data:
@@ -340,12 +286,579 @@ main-components:
                   description:
                   - content: shared.time-html
                     data:
-                      datetime-value: '2018-07-20'
-                      date: 20 July 2018
+                      datetime-value: '2018-10-09'
+                      date: 9 October 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 1
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: proposedNegativeStatutoryInstrumentPaperName - 40
+                size: 2
+                link: "/proposed-negative-statutory-instruments/XOLYsYbh"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-10-08'
+                      date: 8 October 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 11
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: proposedNegativeStatutoryInstrumentPaperName - 37
+                size: 2
+                link: "/proposed-negative-statutory-instruments/eS3rrWn2"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-10-03'
+                      date: 3 October 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 7
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: proposedNegativeStatutoryInstrumentPaperName - 36
+                size: 2
+                link: "/proposed-negative-statutory-instruments/XyrWfzSG"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-10-02'
+                      date: 2 October 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 4
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: proposedNegativeStatutoryInstrumentPaperName - 35
+                size: 2
+                link: "/proposed-negative-statutory-instruments/SXtlN96I"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-10-01'
+                      date: 1 October 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 9
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: proposedNegativeStatutoryInstrumentPaperName - 34
+                size: 2
+                link: "/proposed-negative-statutory-instruments/pCTXaGyQ"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-09-28'
+                      date: 28 September 2018
                 - term:
                     content: laid-thing.laying-body
                   description:
                   - content: groupName - 3
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: proposedNegativeStatutoryInstrumentPaperName - 32
+                size: 2
+                link: "/proposed-negative-statutory-instruments/xPakvw9Y"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-09-27'
+                      date: 27 September 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 7
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: proposedNegativeStatutoryInstrumentPaperName - 33
+                size: 2
+                link: "/proposed-negative-statutory-instruments/AHgBl2vF"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-09-27'
+                      date: 27 September 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 7
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: proposedNegativeStatutoryInstrumentPaperName - 31
+                size: 2
+                link: "/proposed-negative-statutory-instruments/eIcl19m5"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-09-18'
+                      date: 18 September 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 1
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: proposedNegativeStatutoryInstrumentPaperName - 29
+                size: 2
+                link: "/proposed-negative-statutory-instruments/u2CkM7KS"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-09-13'
+                      date: 13 September 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 11
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: proposedNegativeStatutoryInstrumentPaperName - 30
+                size: 2
+                link: "/proposed-negative-statutory-instruments/6XjAcXQO"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-09-13'
+                      date: 13 September 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 11
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: proposedNegativeStatutoryInstrumentPaperName - 27
+                size: 2
+                link: "/proposed-negative-statutory-instruments/mPyCVKAK"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-08-31'
+                      date: 31 August 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 3
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: proposedNegativeStatutoryInstrumentPaperName - 28
+                size: 2
+                link: "/proposed-negative-statutory-instruments/thnAcmar"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-08-31'
+                      date: 31 August 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 3
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: proposedNegativeStatutoryInstrumentPaperName - 26
+                size: 2
+                link: "/proposed-negative-statutory-instruments/CSVKuT3Q"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-08-20'
+                      date: 20 August 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 10
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: proposedNegativeStatutoryInstrumentPaperName - 25
+                size: 2
+                link: "/proposed-negative-statutory-instruments/pzau2957"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-08-15'
+                      date: 15 August 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 4
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: proposedNegativeStatutoryInstrumentPaperName - 23
+                size: 2
+                link: "/proposed-negative-statutory-instruments/lTbB3os8"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-27'
+                      date: 27 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 10
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: proposedNegativeStatutoryInstrumentPaperName - 22
+                size: 2
+                link: "/proposed-negative-statutory-instruments/W3l3iqIJ"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-25'
+                      date: 25 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 9
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: proposedNegativeStatutoryInstrumentPaperName - 24
+                size: 2
+                link: "/proposed-negative-statutory-instruments/Xpyq1I4Q"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-25'
+                      date: 25 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 4
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: proposedNegativeStatutoryInstrumentPaperName - 18
+                size: 2
+                link: "/proposed-negative-statutory-instruments/78cgn2Dx"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-24'
+                      date: 24 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 7
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: proposedNegativeStatutoryInstrumentPaperName - 19
+                size: 2
+                link: "/proposed-negative-statutory-instruments/OuKyf9Ne"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-24'
+                      date: 24 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 7
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: proposedNegativeStatutoryInstrumentPaperName - 20
+                size: 2
+                link: "/proposed-negative-statutory-instruments/Ykks9FXW"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-24'
+                      date: 24 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 8
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: proposedNegativeStatutoryInstrumentPaperName - 21
+                size: 2
+                link: "/proposed-negative-statutory-instruments/mEznEN3a"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-24'
+                      date: 24 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 7
                 - term:
                     content: laid-thing.procedure
                   description:
@@ -571,9 +1084,9 @@ main-components:
             heading:
               name: heading
               data:
-                content: proposedNegativeStatutoryInstrumentPaperName - 18
+                content: proposedNegativeStatutoryInstrumentPaperName - 6
                 size: 2
-                link: "/proposed-negative-statutory-instruments/78cgn2Dx"
+                link: "/proposed-negative-statutory-instruments/PkQCvHkT"
             list-description:
               name: list__description
               data:
@@ -583,12 +1096,12 @@ main-components:
                   description:
                   - content: shared.time-html
                     data:
-                      datetime-value: '2018-07-24'
-                      date: 24 July 2018
+                      datetime-value: '2018-07-20'
+                      date: 20 July 2018
                 - term:
                     content: laid-thing.laying-body
                   description:
-                  - content: groupName - 7
+                  - content: groupName - 2
                 - term:
                     content: laid-thing.procedure
                   description:
@@ -598,9 +1111,9 @@ main-components:
             heading:
               name: heading
               data:
-                content: proposedNegativeStatutoryInstrumentPaperName - 19
+                content: proposedNegativeStatutoryInstrumentPaperName - 7
                 size: 2
-                link: "/proposed-negative-statutory-instruments/OuKyf9Ne"
+                link: "/proposed-negative-statutory-instruments/AcoKsOuw"
             list-description:
               name: list__description
               data:
@@ -610,224 +1123,8 @@ main-components:
                   description:
                   - content: shared.time-html
                     data:
-                      datetime-value: '2018-07-24'
-                      date: 24 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 7
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: proposedNegativeStatutoryInstrumentPaperName - 20
-                size: 2
-                link: "/proposed-negative-statutory-instruments/Ykks9FXW"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-24'
-                      date: 24 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 8
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: proposedNegativeStatutoryInstrumentPaperName - 21
-                size: 2
-                link: "/proposed-negative-statutory-instruments/mEznEN3a"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-24'
-                      date: 24 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 7
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: proposedNegativeStatutoryInstrumentPaperName - 22
-                size: 2
-                link: "/proposed-negative-statutory-instruments/W3l3iqIJ"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-25'
-                      date: 25 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 9
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: proposedNegativeStatutoryInstrumentPaperName - 23
-                size: 2
-                link: "/proposed-negative-statutory-instruments/lTbB3os8"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-27'
-                      date: 27 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 10
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: proposedNegativeStatutoryInstrumentPaperName - 24
-                size: 2
-                link: "/proposed-negative-statutory-instruments/Xpyq1I4Q"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-25'
-                      date: 25 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 4
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: proposedNegativeStatutoryInstrumentPaperName - 25
-                size: 2
-                link: "/proposed-negative-statutory-instruments/pzau2957"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-08-15'
-                      date: 15 August 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 4
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: proposedNegativeStatutoryInstrumentPaperName - 26
-                size: 2
-                link: "/proposed-negative-statutory-instruments/CSVKuT3Q"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-08-20'
-                      date: 20 August 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 10
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: proposedNegativeStatutoryInstrumentPaperName - 27
-                size: 2
-                link: "/proposed-negative-statutory-instruments/mPyCVKAK"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-08-31'
-                      date: 31 August 2018
+                      datetime-value: '2018-07-20'
+                      date: 20 July 2018
                 - term:
                     content: laid-thing.laying-body
                   description:
@@ -841,9 +1138,9 @@ main-components:
             heading:
               name: heading
               data:
-                content: proposedNegativeStatutoryInstrumentPaperName - 28
+                content: proposedNegativeStatutoryInstrumentPaperName - 8
                 size: 2
-                link: "/proposed-negative-statutory-instruments/thnAcmar"
+                link: "/proposed-negative-statutory-instruments/YOGGjydt"
             list-description:
               name: list__description
               data:
@@ -853,8 +1150,35 @@ main-components:
                   description:
                   - content: shared.time-html
                     data:
-                      datetime-value: '2018-08-31'
-                      date: 31 August 2018
+                      datetime-value: '2018-07-20'
+                      date: 20 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 2
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: proposedNegativeStatutoryInstrumentPaperName - 9
+                size: 2
+                link: "/proposed-negative-statutory-instruments/7KgIpwmP"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-20'
+                      date: 20 July 2018
                 - term:
                     content: laid-thing.laying-body
                   description:
@@ -868,9 +1192,9 @@ main-components:
             heading:
               name: heading
               data:
-                content: proposedNegativeStatutoryInstrumentPaperName - 29
+                content: proposedNegativeStatutoryInstrumentPaperName - 1
                 size: 2
-                link: "/proposed-negative-statutory-instruments/u2CkM7KS"
+                link: "/proposed-negative-statutory-instruments/Tn1xqHc0"
             list-description:
               name: list__description
               data:
@@ -880,62 +1204,8 @@ main-components:
                   description:
                   - content: shared.time-html
                     data:
-                      datetime-value: '2018-09-13'
-                      date: 13 September 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 11
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: proposedNegativeStatutoryInstrumentPaperName - 30
-                size: 2
-                link: "/proposed-negative-statutory-instruments/6XjAcXQO"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-09-13'
-                      date: 13 September 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 11
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: proposedNegativeStatutoryInstrumentPaperName - 31
-                size: 2
-                link: "/proposed-negative-statutory-instruments/eIcl19m5"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-09-18'
-                      date: 18 September 2018
+                      datetime-value: '2018-07-19'
+                      date: 19 July 2018
                 - term:
                     content: laid-thing.laying-body
                   description:
@@ -949,9 +1219,9 @@ main-components:
             heading:
               name: heading
               data:
-                content: proposedNegativeStatutoryInstrumentPaperName - 32
+                content: proposedNegativeStatutoryInstrumentPaperName - 2
                 size: 2
-                link: "/proposed-negative-statutory-instruments/xPakvw9Y"
+                link: "/proposed-negative-statutory-instruments/wzsrSFQP"
             list-description:
               name: list__description
               data:
@@ -961,170 +1231,8 @@ main-components:
                   description:
                   - content: shared.time-html
                     data:
-                      datetime-value: '2018-09-27'
-                      date: 27 September 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 7
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: proposedNegativeStatutoryInstrumentPaperName - 33
-                size: 2
-                link: "/proposed-negative-statutory-instruments/AHgBl2vF"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-09-27'
-                      date: 27 September 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 7
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: proposedNegativeStatutoryInstrumentPaperName - 34
-                size: 2
-                link: "/proposed-negative-statutory-instruments/pCTXaGyQ"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-09-28'
-                      date: 28 September 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 3
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: proposedNegativeStatutoryInstrumentPaperName - 35
-                size: 2
-                link: "/proposed-negative-statutory-instruments/SXtlN96I"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-10-01'
-                      date: 1 October 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 9
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: proposedNegativeStatutoryInstrumentPaperName - 36
-                size: 2
-                link: "/proposed-negative-statutory-instruments/XyrWfzSG"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-10-02'
-                      date: 2 October 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 4
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: proposedNegativeStatutoryInstrumentPaperName - 37
-                size: 2
-                link: "/proposed-negative-statutory-instruments/eS3rrWn2"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-10-03'
-                      date: 3 October 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 7
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: proposedNegativeStatutoryInstrumentPaperName - 38
-                size: 2
-                link: "/proposed-negative-statutory-instruments/6itOwgLT"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-10-09'
-                      date: 9 October 2018
+                      datetime-value: '2018-07-19'
+                      date: 19 July 2018
                 - term:
                     content: laid-thing.laying-body
                   description:
@@ -1138,9 +1246,9 @@ main-components:
             heading:
               name: heading
               data:
-                content: proposedNegativeStatutoryInstrumentPaperName - 39
+                content: proposedNegativeStatutoryInstrumentPaperName - 3
                 size: 2
-                link: "/proposed-negative-statutory-instruments/c9tfxxSG"
+                link: "/proposed-negative-statutory-instruments/H95FzZVv"
             list-description:
               name: list__description
               data:
@@ -1150,8 +1258,8 @@ main-components:
                   description:
                   - content: shared.time-html
                     data:
-                      datetime-value: '2018-10-09'
-                      date: 9 October 2018
+                      datetime-value: '2018-07-19'
+                      date: 19 July 2018
                 - term:
                     content: laid-thing.laying-body
                   description:
@@ -1165,9 +1273,9 @@ main-components:
             heading:
               name: heading
               data:
-                content: proposedNegativeStatutoryInstrumentPaperName - 40
+                content: proposedNegativeStatutoryInstrumentPaperName - 4
                 size: 2
-                link: "/proposed-negative-statutory-instruments/XOLYsYbh"
+                link: "/proposed-negative-statutory-instruments/cL5yuFbG"
             list-description:
               name: list__description
               data:
@@ -1177,35 +1285,8 @@ main-components:
                   description:
                   - content: shared.time-html
                     data:
-                      datetime-value: '2018-10-08'
-                      date: 8 October 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 11
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: proposedNegativeStatutoryInstrumentPaperName - 41
-                size: 2
-                link: "/proposed-negative-statutory-instruments/EfjqJrpr"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-10-10'
-                      date: 10 October 2018
+                      datetime-value: '2018-07-19'
+                      date: 19 July 2018
                 - term:
                     content: laid-thing.laying-body
                   description:
@@ -1219,9 +1300,9 @@ main-components:
             heading:
               name: heading
               data:
-                content: proposedNegativeStatutoryInstrumentPaperName - 42
+                content: proposedNegativeStatutoryInstrumentPaperName - 5
                 size: 2
-                link: "/proposed-negative-statutory-instruments/JZ7gvDu6"
+                link: "/proposed-negative-statutory-instruments/mssRQnqj"
             list-description:
               name: list__description
               data:
@@ -1231,93 +1312,12 @@ main-components:
                   description:
                   - content: shared.time-html
                     data:
-                      datetime-value: '2018-10-10'
-                      date: 10 October 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 3
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: proposedNegativeStatutoryInstrumentPaperName - 43
-                size: 2
-                link: "/proposed-negative-statutory-instruments/OqROoJsG"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-10-12'
-                      date: 12 October 2018
+                      datetime-value: '2018-07-19'
+                      date: 19 July 2018
                 - term:
                     content: laid-thing.laying-body
                   description:
                   - content: groupName - 1
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: proposedNegativeStatutoryInstrumentPaperName - 44
-                size: 2
-                link: "/proposed-negative-statutory-instruments/e93zn4Ry"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-10-15'
-                      date: 15 October 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 1
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: proposedNegativeStatutoryInstrumentPaperName - 45
-                size: 2
-                link: "/proposed-negative-statutory-instruments/sHOlA3ji"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-10-15'
-                      date: 15 October 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 7
                 - term:
                     content: laid-thing.procedure
                   description:

--- a/spec/fixtures/controllers/statutory_instruments_controller/index/fixture.yml
+++ b/spec/fixtures/controllers/statutory_instruments_controller/index/fixture.yml
@@ -112,9 +112,9 @@ main-components:
             heading:
               name: heading
               data:
-                content: statutoryInstrumentPaperName - 1
+                content: statutoryInstrumentPaperName - 305
                 size: 2
-                link: "/statutory-instruments/5trFJNih"
+                link: "/statutory-instruments/J097gJjm"
             list-description:
               name: list__description
               data:
@@ -124,845 +124,8 @@ main-components:
                   description:
                   - content: shared.time-html
                     data:
-                      datetime-value: '2018-04-23'
-                      date: 23 April 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 1
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 2
-                size: 2
-                link: "/statutory-instruments/VIqyNL58"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-04-16'
-                      date: 16 April 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 2
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 3
-                size: 2
-                link: "/statutory-instruments/LFLdzMuO"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-05-14'
-                      date: 14 May 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 3
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 4
-                size: 2
-                link: "/statutory-instruments/5U4yBcY4"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-05-17'
-                      date: 17 May 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 4
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 5
-                size: 2
-                link: "/statutory-instruments/TKqREWHZ"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-05-03'
-                      date: 3 May 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 5
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 6
-                size: 2
-                link: "/statutory-instruments/bS94erG6"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-05-11'
-                      date: 11 May 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 1
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 7
-                size: 2
-                link: "/statutory-instruments/PqyD6lfd"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-04-16'
-                      date: 16 April 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 1
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 8
-                size: 2
-                link: "/statutory-instruments/QV9rpep6"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-04-27'
-                      date: 27 April 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 6
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 9
-                size: 2
-                link: "/statutory-instruments/GOOyVBR4"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-05-09'
-                      date: 9 May 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 7
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 10
-                size: 2
-                link: "/statutory-instruments/FCcBOrUo"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-04-23'
-                      date: 23 April 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 8
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 11
-                size: 2
-                link: "/statutory-instruments/KZpExrdI"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-04-26'
-                      date: 26 April 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 8
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 12
-                size: 2
-                link: "/statutory-instruments/tjxWFlR2"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-04-30'
-                      date: 30 April 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 1
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 13
-                size: 2
-                link: "/statutory-instruments/yxN0RDlj"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-05-03'
-                      date: 3 May 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 5
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 14
-                size: 2
-                link: "/statutory-instruments/9PuVurua"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-04-30'
-                      date: 30 April 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 9
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 15
-                size: 2
-                link: "/statutory-instruments/Tw34pUb3"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-05-01'
-                      date: 1 May 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 7
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 16
-                size: 2
-                link: "/statutory-instruments/e1nEbjRI"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-04-24'
-                      date: 24 April 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 3
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 17
-                size: 2
-                link: "/statutory-instruments/QmvfCS3N"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-05-03'
-                      date: 3 May 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 5
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 18
-                size: 2
-                link: "/statutory-instruments/YeYkel8w"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-03-29'
-                      date: 29 March 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 3
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 19
-                size: 2
-                link: "/statutory-instruments/1fStCnaK"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-04-16'
-                      date: 16 April 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 7
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 20
-                size: 2
-                link: "/statutory-instruments/tPkKG8ef"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-05-01'
-                      date: 1 May 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 1
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 21
-                size: 2
-                link: "/statutory-instruments/Q2dC6z5O"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-05-14'
-                      date: 14 May 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 8
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 22
-                size: 2
-                link: "/statutory-instruments/uNiGNHey"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-05-24'
-                      date: 24 May 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 6
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 23
-                size: 2
-                link: "/statutory-instruments/9PfnbabC"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-05-16'
-                      date: 16 May 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 10
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 24
-                size: 2
-                link: "/statutory-instruments/ADR23Zyx"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-04-16'
-                      date: 16 April 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 4
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 25
-                size: 2
-                link: "/statutory-instruments/keUmDe6y"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-04-27'
-                      date: 27 April 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 2
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 26
-                size: 2
-                link: "/statutory-instruments/HJ7BlYte"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-05-08'
-                      date: 8 May 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 6
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 27
-                size: 2
-                link: "/statutory-instruments/i9hQEgyv"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-04-16'
-                      date: 16 April 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 3
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 28
-                size: 2
-                link: "/statutory-instruments/lh2dYuHD"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-05-21'
-                      date: 21 May 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 2
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 29
-                size: 2
-                link: "/statutory-instruments/O8GS8jnH"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-04-03'
-                      date: 3 April 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 10
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 30
-                size: 2
-                link: "/statutory-instruments/98FJSLox"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-05-08'
-                      date: 8 May 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 4
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 31
-                size: 2
-                link: "/statutory-instruments/T3N7uNwm"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-04-30'
-                      date: 30 April 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 7
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 32
-                size: 2
-                link: "/statutory-instruments/LxPDdl92"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-04-20'
-                      date: 20 April 2018
+                      datetime-value: '2018-10-15'
+                      date: 15 October 2018
                 - term:
                     content: laid-thing.laying-body
                   description:
@@ -976,9 +139,9 @@ main-components:
             heading:
               name: heading
               data:
-                content: statutoryInstrumentPaperName - 33
+                content: statutoryInstrumentPaperName - 306
                 size: 2
-                link: "/statutory-instruments/8I8GntKQ"
+                link: "/statutory-instruments/PdffL1zZ"
             list-description:
               name: list__description
               data:
@@ -988,35 +151,8 @@ main-components:
                   description:
                   - content: shared.time-html
                     data:
-                      datetime-value: '2018-04-30'
-                      date: 30 April 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 12
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 34
-                size: 2
-                link: "/statutory-instruments/TuBqZl6z"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-04-24'
-                      date: 24 April 2018
+                      datetime-value: '2018-10-15'
+                      date: 15 October 2018
                 - term:
                     content: laid-thing.laying-body
                   description:
@@ -1024,42 +160,15 @@ main-components:
                 - term:
                     content: laid-thing.procedure
                   description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 35
-                size: 2
-                link: "/statutory-instruments/R63aWjPi"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-05-08'
-                      date: 8 May 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 5
-                - term:
-                    content: laid-thing.procedure
-                  description:
                   - content: procedureName - 1
         - name: card__generic
           data:
             heading:
               name: heading
               data:
-                content: statutoryInstrumentPaperName - 36
+                content: statutoryInstrumentPaperName - 308
                 size: 2
-                link: "/statutory-instruments/eD6E73Ne"
+                link: "/statutory-instruments/VQdXrdx2"
             list-description:
               name: list__description
               data:
@@ -1069,224 +178,8 @@ main-components:
                   description:
                   - content: shared.time-html
                     data:
-                      datetime-value: '2018-04-30'
-                      date: 30 April 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 1
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 37
-                size: 2
-                link: "/statutory-instruments/W0xWx2Iu"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-04-20'
-                      date: 20 April 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 1
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 38
-                size: 2
-                link: "/statutory-instruments/On2R0Zeb"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-04-04'
-                      date: 4 April 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 2
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 39
-                size: 2
-                link: "/statutory-instruments/ITuNnxmw"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-04-30'
-                      date: 30 April 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 3
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 40
-                size: 2
-                link: "/statutory-instruments/XGB9Cj8C"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-04-23'
-                      date: 23 April 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 9
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 41
-                size: 2
-                link: "/statutory-instruments/upP2FHa4"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-05-10'
-                      date: 10 May 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 8
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 42
-                size: 2
-                link: "/statutory-instruments/0VJbg1Pa"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-04-17'
-                      date: 17 April 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 7
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 43
-                size: 2
-                link: "/statutory-instruments/XnLvIexa"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-04-13'
-                      date: 13 April 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 2
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 44
-                size: 2
-                link: "/statutory-instruments/RcGToJSJ"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-05-24'
-                      date: 24 May 2018
+                      datetime-value: '2018-10-15'
+                      date: 15 October 2018
                 - term:
                     content: laid-thing.laying-body
                   description:
@@ -1300,9 +193,9 @@ main-components:
             heading:
               name: heading
               data:
-                content: statutoryInstrumentPaperName - 45
+                content: statutoryInstrumentPaperName - 307
                 size: 2
-                link: "/statutory-instruments/hNQPUtRs"
+                link: "/statutory-instruments/4CQsOYHF"
             list-description:
               name: list__description
               data:
@@ -1312,12 +205,39 @@ main-components:
                   description:
                   - content: shared.time-html
                     data:
-                      datetime-value: '2018-04-26'
-                      date: 26 April 2018
+                      datetime-value: '2018-10-12'
+                      date: 12 October 2018
                 - term:
                     content: laid-thing.laying-body
                   description:
-                  - content: groupName - 11
+                  - content: groupName - 6
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 299
+                size: 2
+                link: "/statutory-instruments/qN5SIpKr"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-10-11'
+                      date: 11 October 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 6
                 - term:
                     content: laid-thing.procedure
                   description:
@@ -1327,9 +247,9 @@ main-components:
             heading:
               name: heading
               data:
-                content: statutoryInstrumentPaperName - 46
+                content: statutoryInstrumentPaperName - 300
                 size: 2
-                link: "/statutory-instruments/xic2yu5i"
+                link: "/statutory-instruments/WcxZPA5i"
             list-description:
               name: list__description
               data:
@@ -1339,12 +259,12 @@ main-components:
                   description:
                   - content: shared.time-html
                     data:
-                      datetime-value: '2018-04-20'
-                      date: 20 April 2018
+                      datetime-value: '2018-10-11'
+                      date: 11 October 2018
                 - term:
                     content: laid-thing.laying-body
                   description:
-                  - content: groupName - 10
+                  - content: groupName - 18
                 - term:
                     content: laid-thing.procedure
                   description:
@@ -1354,9 +274,9 @@ main-components:
             heading:
               name: heading
               data:
-                content: statutoryInstrumentPaperName - 47
+                content: statutoryInstrumentPaperName - 301
                 size: 2
-                link: "/statutory-instruments/YFkBxYkE"
+                link: "/statutory-instruments/eOlu960r"
             list-description:
               name: list__description
               data:
@@ -1366,35 +286,8 @@ main-components:
                   description:
                   - content: shared.time-html
                     data:
-                      datetime-value: '2018-04-17'
-                      date: 17 April 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 7
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 48
-                size: 2
-                link: "/statutory-instruments/k6waZgmJ"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-04-19'
-                      date: 19 April 2018
+                      datetime-value: '2018-10-11'
+                      date: 11 October 2018
                 - term:
                     content: laid-thing.laying-body
                   description:
@@ -1408,9 +301,9 @@ main-components:
             heading:
               name: heading
               data:
-                content: statutoryInstrumentPaperName - 49
+                content: statutoryInstrumentPaperName - 302
                 size: 2
-                link: "/statutory-instruments/QbI1sir4"
+                link: "/statutory-instruments/0l2kwZPW"
             list-description:
               name: list__description
               data:
@@ -1420,302 +313,8 @@ main-components:
                   description:
                   - content: shared.time-html
                     data:
-                      datetime-value: '2018-04-30'
-                      date: 30 April 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 7
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 50
-                size: 2
-                link: "/statutory-instruments/C2rRbqeQ"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-04-17'
-                      date: 17 April 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 3
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 51
-                size: 2
-                link: "/statutory-instruments/5urR0FTa"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-04-18'
-                      date: 18 April 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 1
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 52
-                size: 2
-                link: "/statutory-instruments/daySypEn"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-04-03'
-                      date: 3 April 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 10
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 53
-                size: 2
-                link: "/statutory-instruments/FXiTnP7V"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-04-23'
-                      date: 23 April 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 9
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 54
-                size: 2
-                link: "/statutory-instruments/Ly5VtVqc"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-04-04'
-                      date: 4 April 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 2
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 55
-                size: 2
-                link: "/statutory-instruments/z0dWm7t5"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-04-18'
-                      date: 18 April 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 7
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 56
-                size: 2
-                link: "/statutory-instruments/Y70OJpm2"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-05-01'
-                      date: 1 May 2018
-                - 
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 3
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 57
-                size: 2
-                link: "/statutory-instruments/BdanAxAh"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-05-29'
-                      date: 29 May 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 3
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 58
-                size: 2
-                link: "/statutory-instruments/bUEOr4ad"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-05-18'
-                      date: 18 May 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 3
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 59
-                size: 2
-                link: "/statutory-instruments/dNxWbKuU"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-05-23'
-                      date: 23 May 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 2
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 60
-                size: 2
-                link: "/statutory-instruments/8HUWJm9e"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-05-18'
-                      date: 18 May 2018
+                      datetime-value: '2018-10-11'
+                      date: 11 October 2018
                 - term:
                     content: laid-thing.laying-body
                   description:
@@ -1729,9 +328,9 @@ main-components:
             heading:
               name: heading
               data:
-                content: statutoryInstrumentPaperName - 61
+                content: statutoryInstrumentPaperName - 303
                 size: 2
-                link: "/statutory-instruments/ijAPvpBd"
+                link: "/statutory-instruments/CFyWykUZ"
             list-description:
               name: list__description
               data:
@@ -1741,24 +340,24 @@ main-components:
                   description:
                   - content: shared.time-html
                     data:
-                      datetime-value: '2018-05-21'
-                      date: 21 May 2018
+                      datetime-value: '2018-10-11'
+                      date: 11 October 2018
                 - term:
                     content: laid-thing.laying-body
                   description:
-                  - content: groupName - 12
+                  - content: groupName - 2
                 - term:
                     content: laid-thing.procedure
                   description:
-                  - content: procedureName - 2
+                  - content: procedureName - 1
         - name: card__generic
           data:
             heading:
               name: heading
               data:
-                content: statutoryInstrumentPaperName - 62
+                content: statutoryInstrumentPaperName - 304
                 size: 2
-                link: "/statutory-instruments/ZIUjUqOY"
+                link: "/statutory-instruments/d2bXwUKW"
             list-description:
               name: list__description
               data:
@@ -1768,62 +367,8 @@ main-components:
                   description:
                   - content: shared.time-html
                     data:
-                      datetime-value: '2018-05-17'
-                      date: 17 May 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 12
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 63
-                size: 2
-                link: "/statutory-instruments/rAkViDvo"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-04-23'
-                      date: 23 April 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 3
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 64
-                size: 2
-                link: "/statutory-instruments/rjzMGG28"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-05-21'
-                      date: 21 May 2018
+                      datetime-value: '2018-10-11'
+                      date: 11 October 2018
                 - term:
                     content: laid-thing.laying-body
                   description:
@@ -1837,9 +382,9 @@ main-components:
             heading:
               name: heading
               data:
-                content: statutoryInstrumentPaperName - 65
+                content: statutoryInstrumentPaperName - 293
                 size: 2
-                link: "/statutory-instruments/YOVMhcqy"
+                link: "/statutory-instruments/iKgIQsG9"
             list-description:
               name: list__description
               data:
@@ -1849,8 +394,8 @@ main-components:
                   description:
                   - content: shared.time-html
                     data:
-                      datetime-value: '2018-05-30'
-                      date: 30 May 2018
+                      datetime-value: '2018-10-10'
+                      date: 10 October 2018
                 - term:
                     content: laid-thing.laying-body
                   description:
@@ -1858,174 +403,15 @@ main-components:
                 - term:
                     content: laid-thing.procedure
                   description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 66
-                size: 2
-                link: "/statutory-instruments/WSBR9sBz"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-05-01'
-                      date: 1 May 2018
-                - 
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 3
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 67
-                size: 2
-                link: "/statutory-instruments/5pJMwiMT"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-05-25'
-                      date: 25 May 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 8
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 68
-                size: 2
-                link: "/statutory-instruments/3dAYwLoB"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-04-03'
-                      date: 3 April 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 6
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 69
-                size: 2
-                link: "/statutory-instruments/AaXxxzda"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-04-03'
-                      date: 3 April 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 10
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 70
-                size: 2
-                link: "/statutory-instruments/NRSdVnQe"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-04'
-                      date: 4 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 2
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 71
-                size: 2
-                link: "/statutory-instruments/oPe8W6LR"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-04'
-                      date: 4 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 3
-                - term:
-                    content: laid-thing.procedure
-                  description:
                   - content: procedureName - 2
         - name: card__generic
           data:
             heading:
               name: heading
               data:
-                content: statutoryInstrumentPaperName - 72
+                content: statutoryInstrumentPaperName - 294
                 size: 2
-                link: "/statutory-instruments/KUKpCZa3"
+                link: "/statutory-instruments/ogDjrUru"
             list-description:
               name: list__description
               data:
@@ -2035,587 +421,8 @@ main-components:
                   description:
                   - content: shared.time-html
                     data:
-                      datetime-value: '2018-06-04'
-                      date: 4 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 2
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 73
-                size: 2
-                link: "/statutory-instruments/4EdTvost"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-01'
-                      date: 1 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 8
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 74
-                size: 2
-                link: "/statutory-instruments/z0qrw2Ka"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-04'
-                      date: 4 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 5
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 75
-                size: 2
-                link: "/statutory-instruments/181ZoViL"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-04'
-                      date: 4 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 5
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 76
-                size: 2
-                link: "/statutory-instruments/v2fDLDBe"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-04'
-                      date: 4 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 5
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 77
-                size: 2
-                link: "/statutory-instruments/eqmSAYR6"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-01'
-                      date: 1 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 1
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 78
-                size: 2
-                link: "/statutory-instruments/yvJQZWRS"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-01'
-                      date: 1 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 14
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 79
-                size: 2
-                link: "/statutory-instruments/58xXcnw9"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-01'
-                      date: 1 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 2
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 80
-                size: 2
-                link: "/statutory-instruments/cmbxjWzh"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-01'
-                      date: 1 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 8
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 81
-                size: 2
-                link: "/statutory-instruments/ZZqT1pd0"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-01'
-                      date: 1 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 8
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 82
-                size: 2
-                link: "/statutory-instruments/pw7G14pf"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-04'
-                      date: 4 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 15
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 83
-                size: 2
-                link: "/statutory-instruments/9WjR8ian"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-04'
-                      date: 4 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 5
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 84
-                size: 2
-                link: "/statutory-instruments/ez3sdNNT"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-04'
-                      date: 4 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 6
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 85
-                size: 2
-                link: "/statutory-instruments/CHZfxISd"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-05'
-                      date: 5 June 2018
-                - 
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 3
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 86
-                size: 2
-                link: "/statutory-instruments/olhuTQTg"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-05'
-                      date: 5 June 2018
-                - 
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 3
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 87
-                size: 2
-                link: "/statutory-instruments/IYqCRJN5"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-06'
-                      date: 6 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 4
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 88
-                size: 2
-                link: "/statutory-instruments/b9hRtbhC"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-05'
-                      date: 5 June 2018
-                - 
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 3
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 89
-                size: 2
-                link: "/statutory-instruments/T7oi7f0E"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-05'
-                      date: 5 June 2018
-                - 
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 3
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 90
-                size: 2
-                link: "/statutory-instruments/YZnLn72f"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-05'
-                      date: 5 June 2018
-                - 
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 3
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 91
-                size: 2
-                link: "/statutory-instruments/hs0US9Hw"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-06'
-                      date: 6 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 3
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 92
-                size: 2
-                link: "/statutory-instruments/w3m931qg"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-06'
-                      date: 6 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 6
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 93
-                size: 2
-                link: "/statutory-instruments/tiA7a71r"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-07'
-                      date: 7 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 2
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 94
-                size: 2
-                link: "/statutory-instruments/wzOpc7Aj"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-07'
-                      date: 7 June 2018
+                      datetime-value: '2018-10-10'
+                      date: 10 October 2018
                 - term:
                     content: laid-thing.laying-body
                   description:
@@ -2623,69 +430,15 @@ main-components:
                 - term:
                     content: laid-thing.procedure
                   description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 95
-                size: 2
-                link: "/statutory-instruments/8xNcqHgV"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-07'
-                      date: 7 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 10
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 96
-                size: 2
-                link: "/statutory-instruments/Keztycwl"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-07'
-                      date: 7 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 5
-                - term:
-                    content: laid-thing.procedure
-                  description:
                   - content: procedureName - 2
         - name: card__generic
           data:
             heading:
               name: heading
               data:
-                content: statutoryInstrumentPaperName - 97
+                content: statutoryInstrumentPaperName - 295
                 size: 2
-                link: "/statutory-instruments/jKgfbLZG"
+                link: "/statutory-instruments/Y5wgjNCe"
             list-description:
               name: list__description
               data:
@@ -2695,35 +448,8 @@ main-components:
                   description:
                   - content: shared.time-html
                     data:
-                      datetime-value: '2018-06-11'
-                      date: 11 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 7
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 98
-                size: 2
-                link: "/statutory-instruments/LldrrMNS"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-08'
-                      date: 8 June 2018
+                      datetime-value: '2018-10-10'
+                      date: 10 October 2018
                 - term:
                     content: laid-thing.laying-body
                   description:
@@ -2737,9 +463,9 @@ main-components:
             heading:
               name: heading
               data:
-                content: statutoryInstrumentPaperName - 99
+                content: statutoryInstrumentPaperName - 296
                 size: 2
-                link: "/statutory-instruments/nohxpB6K"
+                link: "/statutory-instruments/HDMCkDND"
             list-description:
               name: list__description
               data:
@@ -2749,116 +475,8 @@ main-components:
                   description:
                   - content: shared.time-html
                     data:
-                      datetime-value: '2018-06-08'
-                      date: 8 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 10
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 100
-                size: 2
-                link: "/statutory-instruments/PhwmELqG"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-08'
-                      date: 8 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 6
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 101
-                size: 2
-                link: "/statutory-instruments/PyLlquNq"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-08'
-                      date: 8 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 16
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 102
-                size: 2
-                link: "/statutory-instruments/1IUldWII"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-08'
-                      date: 8 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 5
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 103
-                size: 2
-                link: "/statutory-instruments/Z1VEYuzd"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-11'
-                      date: 11 June 2018
+                      datetime-value: '2018-10-10'
+                      date: 10 October 2018
                 - term:
                     content: laid-thing.laying-body
                   description:
@@ -2872,9 +490,9 @@ main-components:
             heading:
               name: heading
               data:
-                content: statutoryInstrumentPaperName - 104
+                content: statutoryInstrumentPaperName - 297
                 size: 2
-                link: "/statutory-instruments/BN7ucM8o"
+                link: "/statutory-instruments/T8QuQbfp"
             list-description:
               name: list__description
               data:
@@ -2884,35 +502,8 @@ main-components:
                   description:
                   - content: shared.time-html
                     data:
-                      datetime-value: '2018-06-08'
-                      date: 8 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 16
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 105
-                size: 2
-                link: "/statutory-instruments/WOETQ8oL"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-11'
-                      date: 11 June 2018
+                      datetime-value: '2018-10-10'
+                      date: 10 October 2018
                 - term:
                     content: laid-thing.laying-body
                   description:
@@ -2926,9 +517,9 @@ main-components:
             heading:
               name: heading
               data:
-                content: statutoryInstrumentPaperName - 106
+                content: statutoryInstrumentPaperName - 298
                 size: 2
-                link: "/statutory-instruments/aQaZuLyK"
+                link: "/statutory-instruments/90n67zWF"
             list-description:
               name: list__description
               data:
@@ -2938,4695 +529,12 @@ main-components:
                   description:
                   - content: shared.time-html
                     data:
-                      datetime-value: '2018-06-13'
-                      date: 13 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 6
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 107
-                size: 2
-                link: "/statutory-instruments/66skcwzN"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-13'
-                      date: 13 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 3
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 108
-                size: 2
-                link: "/statutory-instruments/nky6NCi1"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-05-31'
-                      date: 31 May 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 5
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 109
-                size: 2
-                link: "/statutory-instruments/I9rWxORS"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-13'
-                      date: 13 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 6
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 110
-                size: 2
-                link: "/statutory-instruments/N3pbTe7F"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-14'
-                      date: 14 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 5
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 111
-                size: 2
-                link: "/statutory-instruments/leJaKS5E"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-14'
-                      date: 14 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 3
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 112
-                size: 2
-                link: "/statutory-instruments/rMrXIRPv"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-04'
-                      date: 4 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 17
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 113
-                size: 2
-                link: "/statutory-instruments/hMaj7XDd"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-04'
-                      date: 4 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 17
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 114
-                size: 2
-                link: "/statutory-instruments/itrbNOwE"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-04'
-                      date: 4 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 17
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 115
-                size: 2
-                link: "/statutory-instruments/Y5ihrxeg"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-04'
-                      date: 4 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 17
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 116
-                size: 2
-                link: "/statutory-instruments/uhL6bPvV"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-04'
-                      date: 4 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 17
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 117
-                size: 2
-                link: "/statutory-instruments/MJRZgm6X"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-04'
-                      date: 4 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 17
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 118
-                size: 2
-                link: "/statutory-instruments/rdYNYrB9"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-15'
-                      date: 15 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 10
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 119
-                size: 2
-                link: "/statutory-instruments/9Nv0gELe"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-15'
-                      date: 15 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 6
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 120
-                size: 2
-                link: "/statutory-instruments/D9vkxjm0"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-15'
-                      date: 15 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 2
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 121
-                size: 2
-                link: "/statutory-instruments/kqzXWiAO"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-04-26'
-                      date: 26 April 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 16
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 122
-                size: 2
-                link: "/statutory-instruments/tZhWfLGW"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-04-23'
-                      date: 23 April 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 9
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 123
-                size: 2
-                link: "/statutory-instruments/vBqvzucr"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-04-26'
-                      date: 26 April 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 16
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 124
-                size: 2
-                link: "/statutory-instruments/GHIocidH"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-04-30'
-                      date: 30 April 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 9
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 125
-                size: 2
-                link: "/statutory-instruments/ITytkRlT"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-05-01'
-                      date: 1 May 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 18
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 126
-                size: 2
-                link: "/statutory-instruments/vPuOxy1B"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-04-23'
-                      date: 23 April 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 9
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 127
-                size: 2
-                link: "/statutory-instruments/avoNURrR"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-04-16'
-                      date: 16 April 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 9
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 128
-                size: 2
-                link: "/statutory-instruments/s75qT4mw"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-04-23'
-                      date: 23 April 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 9
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 129
-                size: 2
-                link: "/statutory-instruments/9S89Uofh"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-05-30'
-                      date: 30 May 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 18
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 130
-                size: 2
-                link: "/statutory-instruments/xa91QFSm"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-05-17'
-                      date: 17 May 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 16
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 131
-                size: 2
-                link: "/statutory-instruments/4bwmdrUh"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-05-30'
-                      date: 30 May 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 18
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 132
-                size: 2
-                link: "/statutory-instruments/X9tJrtug"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-05-21'
-                      date: 21 May 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 19
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 133
-                size: 2
-                link: "/statutory-instruments/YI5L3LfM"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-05-30'
-                      date: 30 May 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 18
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 134
-                size: 2
-                link: "/statutory-instruments/4e7ROEBU"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-05-30'
-                      date: 30 May 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 18
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 135
-                size: 2
-                link: "/statutory-instruments/7uCF2qgm"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-05-01'
-                      date: 1 May 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 18
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 136
-                size: 2
-                link: "/statutory-instruments/YhMNMpYo"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-18'
-                      date: 18 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 6
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 137
-                size: 2
-                link: "/statutory-instruments/GVXkRR2M"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-18'
-                      date: 18 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 4
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 138
-                size: 2
-                link: "/statutory-instruments/N1TcXxev"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-18'
-                      date: 18 June 2018
+                      datetime-value: '2018-10-10'
+                      date: 10 October 2018
                 - term:
                     content: laid-thing.laying-body
                   description:
                   - content: groupName - 8
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 139
-                size: 2
-                link: "/statutory-instruments/YdZGzcJA"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-18'
-                      date: 18 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 5
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 140
-                size: 2
-                link: "/statutory-instruments/u2nfODML"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-18'
-                      date: 18 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 8
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 141
-                size: 2
-                link: "/statutory-instruments/MJ4ILVps"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-19'
-                      date: 19 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 7
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 142
-                size: 2
-                link: "/statutory-instruments/6XQ6ig48"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-18'
-                      date: 18 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 8
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 143
-                size: 2
-                link: "/statutory-instruments/OohXDEMJ"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-20'
-                      date: 20 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 20
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 144
-                size: 2
-                link: "/statutory-instruments/HNjL6uzv"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-20'
-                      date: 20 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 7
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 145
-                size: 2
-                link: "/statutory-instruments/4kSUJ4K2"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-20'
-                      date: 20 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 8
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 146
-                size: 2
-                link: "/statutory-instruments/h8w2BHwS"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-25'
-                      date: 25 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 8
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 147
-                size: 2
-                link: "/statutory-instruments/VdxVTQ0L"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-25'
-                      date: 25 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 2
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 148
-                size: 2
-                link: "/statutory-instruments/UD4HjKbu"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-25'
-                      date: 25 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 6
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 149
-                size: 2
-                link: "/statutory-instruments/CMCJ3a82"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-25'
-                      date: 25 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 7
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 150
-                size: 2
-                link: "/statutory-instruments/mRgc1Qvc"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-25'
-                      date: 25 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 8
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 151
-                size: 2
-                link: "/statutory-instruments/HZod54jz"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-28'
-                      date: 28 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 8
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 152
-                size: 2
-                link: "/statutory-instruments/zfcsMSD3"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-28'
-                      date: 28 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 4
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 153
-                size: 2
-                link: "/statutory-instruments/P5Zu6fkP"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-28'
-                      date: 28 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 6
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 154
-                size: 2
-                link: "/statutory-instruments/5dLGzkeI"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-28'
-                      date: 28 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 1
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 155
-                size: 2
-                link: "/statutory-instruments/NTd30zpo"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-28'
-                      date: 28 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 10
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 156
-                size: 2
-                link: "/statutory-instruments/98auwKwP"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-28'
-                      date: 28 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 1
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 157
-                size: 2
-                link: "/statutory-instruments/m1AZ18wg"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-29'
-                      date: 29 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 16
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 158
-                size: 2
-                link: "/statutory-instruments/Foe6fVxK"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-29'
-                      date: 29 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 16
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 159
-                size: 2
-                link: "/statutory-instruments/c0IpQmwt"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-02'
-                      date: 2 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 2
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 160
-                size: 2
-                link: "/statutory-instruments/RS3W2NQw"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-29'
-                      date: 29 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 16
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 161
-                size: 2
-                link: "/statutory-instruments/BZPGfEza"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-02'
-                      date: 2 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 10
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 162
-                size: 2
-                link: "/statutory-instruments/4GqD7K0p"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-29'
-                      date: 29 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 16
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 163
-                size: 2
-                link: "/statutory-instruments/2KKfR6RI"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-06-29'
-                      date: 29 June 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 7
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 164
-                size: 2
-                link: "/statutory-instruments/JPx0duf2"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-02'
-                      date: 2 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 2
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 165
-                size: 2
-                link: "/statutory-instruments/C8kKvTBL"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-02'
-                      date: 2 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 10
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 166
-                size: 2
-                link: "/statutory-instruments/1aUCYOe7"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-02'
-                      date: 2 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 1
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 167
-                size: 2
-                link: "/statutory-instruments/JXxhQblu"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-03'
-                      date: 3 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 6
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 168
-                size: 2
-                link: "/statutory-instruments/9Brknpn7"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-03'
-                      date: 3 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 3
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 169
-                size: 2
-                link: "/statutory-instruments/IjLgnN8z"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-02'
-                      date: 2 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 6
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 170
-                size: 2
-                link: "/statutory-instruments/YhwigIF6"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-04'
-                      date: 4 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 3
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 171
-                size: 2
-                link: "/statutory-instruments/zd4ymhhN"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-04'
-                      date: 4 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 3
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 172
-                size: 2
-                link: "/statutory-instruments/SUtuR6qs"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-04'
-                      date: 4 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 18
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 173
-                size: 2
-                link: "/statutory-instruments/MIqYKT1i"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-04'
-                      date: 4 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 1
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 174
-                size: 2
-                link: "/statutory-instruments/UBL9i00X"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-06'
-                      date: 6 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 2
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 175
-                size: 2
-                link: "/statutory-instruments/KF90wtY4"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-09'
-                      date: 9 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 10
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 176
-                size: 2
-                link: "/statutory-instruments/gcbZWM8q"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-10'
-                      date: 10 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 16
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 177
-                size: 2
-                link: "/statutory-instruments/Hw2xKRsZ"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-10'
-                      date: 10 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 3
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 178
-                size: 2
-                link: "/statutory-instruments/bYMAmxYQ"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-12'
-                      date: 12 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 5
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 179
-                size: 2
-                link: "/statutory-instruments/vUb6Fcnn"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-12'
-                      date: 12 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 7
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 180
-                size: 2
-                link: "/statutory-instruments/cXKDMYqV"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-12'
-                      date: 12 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 3
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 181
-                size: 2
-                link: "/statutory-instruments/BRZBy463"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-12'
-                      date: 12 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 6
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 182
-                size: 2
-                link: "/statutory-instruments/cDVVk8C2"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-12'
-                      date: 12 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 4
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 183
-                size: 2
-                link: "/statutory-instruments/Qeou2KIY"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-16'
-                      date: 16 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 8
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 184
-                size: 2
-                link: "/statutory-instruments/qSs9kGvu"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-16'
-                      date: 16 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 16
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 185
-                size: 2
-                link: "/statutory-instruments/55gPdheg"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-13'
-                      date: 13 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 10
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 186
-                size: 2
-                link: "/statutory-instruments/JHmYoIfJ"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-16'
-                      date: 16 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 12
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 187
-                size: 2
-                link: "/statutory-instruments/wIlQG2bb"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-16'
-                      date: 16 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 7
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 188
-                size: 2
-                link: "/statutory-instruments/ySndNUxm"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-16'
-                      date: 16 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 1
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 189
-                size: 2
-                link: "/statutory-instruments/QsAJ99E3"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-16'
-                      date: 16 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 8
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 190
-                size: 2
-                link: "/statutory-instruments/zVuPoOWp"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-17'
-                      date: 17 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 7
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 191
-                size: 2
-                link: "/statutory-instruments/m6w1ruLC"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-18'
-                      date: 18 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 15
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 192
-                size: 2
-                link: "/statutory-instruments/VXLHPnoP"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-18'
-                      date: 18 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 18
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 193
-                size: 2
-                link: "/statutory-instruments/DS1GQhA5"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-18'
-                      date: 18 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 3
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 194
-                size: 2
-                link: "/statutory-instruments/QI5WArIQ"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-19'
-                      date: 19 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 10
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 195
-                size: 2
-                link: "/statutory-instruments/a8wT3ym2"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-19'
-                      date: 19 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 11
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 196
-                size: 2
-                link: "/statutory-instruments/uPVA7EvA"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-19'
-                      date: 19 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 19
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 197
-                size: 2
-                link: "/statutory-instruments/EqisWZtW"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-19'
-                      date: 19 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 14
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 198
-                size: 2
-                link: "/statutory-instruments/M3L8iguJ"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-19'
-                      date: 19 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 9
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 199
-                size: 2
-                link: "/statutory-instruments/Uhsvsfdn"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-19'
-                      date: 19 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 6
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 200
-                size: 2
-                link: "/statutory-instruments/BP4IoUgX"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-18'
-                      date: 18 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 7
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 201
-                size: 2
-                link: "/statutory-instruments/pyflzxxb"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-19'
-                      date: 19 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 3
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 202
-                size: 2
-                link: "/statutory-instruments/ORfYwwEX"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-19'
-                      date: 19 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 16
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 203
-                size: 2
-                link: "/statutory-instruments/bnrksmBb"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-19'
-                      date: 19 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 7
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 204
-                size: 2
-                link: "/statutory-instruments/xItHTyZP"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-19'
-                      date: 19 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 21
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 205
-                size: 2
-                link: "/statutory-instruments/SbxmGLcR"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-20'
-                      date: 20 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 6
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 206
-                size: 2
-                link: "/statutory-instruments/ePPVgmgN"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-23'
-                      date: 23 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 10
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 207
-                size: 2
-                link: "/statutory-instruments/dHwDR0Xw"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-23'
-                      date: 23 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 2
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 208
-                size: 2
-                link: "/statutory-instruments/DVgODdNe"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-23'
-                      date: 23 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 2
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 209
-                size: 2
-                link: "/statutory-instruments/pg1MaN6V"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-23'
-                      date: 23 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 21
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 210
-                size: 2
-                link: "/statutory-instruments/2JipSGt3"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-23'
-                      date: 23 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 2
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 211
-                size: 2
-                link: "/statutory-instruments/qRweamaE"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-23'
-                      date: 23 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 10
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 212
-                size: 2
-                link: "/statutory-instruments/zRBB7JhE"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-23'
-                      date: 23 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 2
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 213
-                size: 2
-                link: "/statutory-instruments/xRUG9ARI"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-23'
-                      date: 23 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 2
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 214
-                size: 2
-                link: "/statutory-instruments/j0R3vR5s"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-23'
-                      date: 23 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 2
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 215
-                size: 2
-                link: "/statutory-instruments/YdIWHZS3"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-23'
-                      date: 23 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 10
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 216
-                size: 2
-                link: "/statutory-instruments/tlSbgoyG"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-24'
-                      date: 24 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 19
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 217
-                size: 2
-                link: "/statutory-instruments/I22Wlejq"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-24'
-                      date: 24 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 5
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 218
-                size: 2
-                link: "/statutory-instruments/zo2QN0LF"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-24'
-                      date: 24 July 2018
-                - 
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 3
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 219
-                size: 2
-                link: "/statutory-instruments/3ovJSqCK"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-24'
-                      date: 24 July 2018
-                - 
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 3
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 220
-                size: 2
-                link: "/statutory-instruments/3Iw5OmCs"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-24'
-                      date: 24 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 7
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 221
-                size: 2
-                link: "/statutory-instruments/URYwfkWz"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-24'
-                      date: 24 July 2018
-                - 
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 3
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 222
-                size: 2
-                link: "/statutory-instruments/uIHeCzNz"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-24'
-                      date: 24 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 15
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 223
-                size: 2
-                link: "/statutory-instruments/KKMVpl6g"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-26'
-                      date: 26 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 2
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 224
-                size: 2
-                link: "/statutory-instruments/hLF7ZU6f"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-26'
-                      date: 26 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 6
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 225
-                size: 2
-                link: "/statutory-instruments/2zCfE0jG"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 226
-                size: 2
-                link: "/statutory-instruments/hNYeAr2M"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-27'
-                      date: 27 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 8
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 227
-                size: 2
-                link: "/statutory-instruments/MyKmEbhB"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-07-30'
-                      date: 30 July 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 8
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 228
-                size: 2
-                link: "/statutory-instruments/fqzYAhp8"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 229
-                size: 2
-                link: "/statutory-instruments/VqC2MUZE"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-08-01'
-                      date: 1 August 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 5
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 230
-                size: 2
-                link: "/statutory-instruments/AbFupFPb"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 231
-                size: 2
-                link: "/statutory-instruments/QtfEa5YW"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-08-02'
-                      date: 2 August 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 5
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 232
-                size: 2
-                link: "/statutory-instruments/IlH0bFJC"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-08-06'
-                      date: 6 August 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 5
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 233
-                size: 2
-                link: "/statutory-instruments/evNAwjHg"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-08-08'
-                      date: 8 August 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 2
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 234
-                size: 2
-                link: "/statutory-instruments/qQXoON26"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-08-13'
-                      date: 13 August 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 5
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 235
-                size: 2
-                link: "/statutory-instruments/Wa2pnyo2"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-08-13'
-                      date: 13 August 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 2
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 236
-                size: 2
-                link: "/statutory-instruments/GuV3tchN"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-08-15'
-                      date: 15 August 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 4
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 237
-                size: 2
-                link: "/statutory-instruments/GonuHKX2"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-08-23'
-                      date: 23 August 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 8
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 238
-                size: 2
-                link: "/statutory-instruments/n7DYBZTg"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-08-22'
-                      date: 22 August 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 19
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 239
-                size: 2
-                link: "/statutory-instruments/8NOTbqcG"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-08-30'
-                      date: 30 August 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 5
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 240
-                size: 2
-                link: "/statutory-instruments/nuicNnFk"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-08-31'
-                      date: 31 August 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 2
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 241
-                size: 2
-                link: "/statutory-instruments/peR5eFWQ"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-08-31'
-                      date: 31 August 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 12
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 242
-                size: 2
-                link: "/statutory-instruments/fgDYoYbL"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-09-04'
-                      date: 4 September 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 9
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 243
-                size: 2
-                link: "/statutory-instruments/jKZxBFHe"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-09-04'
-                      date: 4 September 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 9
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 244
-                size: 2
-                link: "/statutory-instruments/QjdlkhkP"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-09-04'
-                      date: 4 September 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 5
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 245
-                size: 2
-                link: "/statutory-instruments/8nULnQBi"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-09-04'
-                      date: 4 September 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 9
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 246
-                size: 2
-                link: "/statutory-instruments/RmycV0kO"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-09-04'
-                      date: 4 September 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 1
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 247
-                size: 2
-                link: "/statutory-instruments/yPyq3chO"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-09-04'
-                      date: 4 September 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 1
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 248
-                size: 2
-                link: "/statutory-instruments/TFdnSOeu"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-09-05'
-                      date: 5 September 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 2
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 249
-                size: 2
-                link: "/statutory-instruments/tRaHj88K"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-09-05'
-                      date: 5 September 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 3
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 250
-                size: 2
-                link: "/statutory-instruments/J8EUQxAg"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-09-05'
-                      date: 5 September 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 7
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 251
-                size: 2
-                link: "/statutory-instruments/9nwPn9YY"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-09-05'
-                      date: 5 September 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 8
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 252
-                size: 2
-                link: "/statutory-instruments/BuMKAKjA"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-09-06'
-                      date: 6 September 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 6
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 253
-                size: 2
-                link: "/statutory-instruments/DcVb33WY"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-09-06'
-                      date: 6 September 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 1
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 254
-                size: 2
-                link: "/statutory-instruments/fUqRRBH5"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-09-06'
-                      date: 6 September 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 3
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 255
-                size: 2
-                link: "/statutory-instruments/EAXHUZt7"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-09-06'
-                      date: 6 September 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 3
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 256
-                size: 2
-                link: "/statutory-instruments/n39tcDnk"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-09-10'
-                      date: 10 September 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 4
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 257
-                size: 2
-                link: "/statutory-instruments/3iuaNj8A"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-09-07'
-                      date: 7 September 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 8
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 258
-                size: 2
-                link: "/statutory-instruments/l05U8jIT"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-09-07'
-                      date: 7 September 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 10
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 259
-                size: 2
-                link: "/statutory-instruments/pGJAClSs"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-09-10'
-                      date: 10 September 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 3
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 260
-                size: 2
-                link: "/statutory-instruments/WBlaNvyq"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-09-10'
-                      date: 10 September 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 6
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 261
-                size: 2
-                link: "/statutory-instruments/dj1ROT0l"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-09-11'
-                      date: 11 September 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 4
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 262
-                size: 2
-                link: "/statutory-instruments/d3F9OZoU"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-09-11'
-                      date: 11 September 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 4
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 263
-                size: 2
-                link: "/statutory-instruments/FoxP8Wi7"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-09-12'
-                      date: 12 September 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 4
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 264
-                size: 2
-                link: "/statutory-instruments/CoWkZnVU"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-09-12'
-                      date: 12 September 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 2
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 265
-                size: 2
-                link: "/statutory-instruments/v9p3YHSe"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-09-12'
-                      date: 12 September 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 3
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 266
-                size: 2
-                link: "/statutory-instruments/lSRBYtGi"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-09-13'
-                      date: 13 September 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 6
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 267
-                size: 2
-                link: "/statutory-instruments/H1uGO0VI"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-09-13'
-                      date: 13 September 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 6
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 268
-                size: 2
-                link: "/statutory-instruments/IyxF7Re7"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-09-13'
-                      date: 13 September 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 10
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 269
-                size: 2
-                link: "/statutory-instruments/vWSvjJPY"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-09-13'
-                      date: 13 September 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 10
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 270
-                size: 2
-                link: "/statutory-instruments/gVLa6U8S"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-09-14'
-                      date: 14 September 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 2
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 271
-                size: 2
-                link: "/statutory-instruments/558R1vHw"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-09-17'
-                      date: 17 September 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 10
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 272
-                size: 2
-                link: "/statutory-instruments/6gNGlxXz"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-09-20'
-                      date: 20 September 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 21
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 273
-                size: 2
-                link: "/statutory-instruments/SSIdUxdK"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-09-20'
-                      date: 20 September 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 21
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 274
-                size: 2
-                link: "/statutory-instruments/WMZkgw45"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-09-26'
-                      date: 26 September 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 8
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 275
-                size: 2
-                link: "/statutory-instruments/sUFFmPCo"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-09-25'
-                      date: 25 September 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 8
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 276
-                size: 2
-                link: "/statutory-instruments/x1lCTIsz"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-09-27'
-                      date: 27 September 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 8
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 277
-                size: 2
-                link: "/statutory-instruments/Ez5LhVPl"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-09-27'
-                      date: 27 September 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 8
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 278
-                size: 2
-                link: "/statutory-instruments/V9OJief9"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-09-28'
-                      date: 28 September 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 7
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 279
-                size: 2
-                link: "/statutory-instruments/LCvP8PWr"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-09-28'
-                      date: 28 September 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 8
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 280
-                size: 2
-                link: "/statutory-instruments/VW7e0Sva"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-09-28'
-                      date: 28 September 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 7
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 281
-                size: 2
-                link: "/statutory-instruments/nmnBg42M"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-10-05'
-                      date: 5 October 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 5
                 - term:
                     content: laid-thing.procedure
                   description:
@@ -7933,9 +841,9 @@ main-components:
             heading:
               name: heading
               data:
-                content: statutoryInstrumentPaperName - 293
+                content: statutoryInstrumentPaperName - 281
                 size: 2
-                link: "/statutory-instruments/iKgIQsG9"
+                link: "/statutory-instruments/nmnBg42M"
             list-description:
               name: list__description
               data:
@@ -7945,224 +853,8 @@ main-components:
                   description:
                   - content: shared.time-html
                     data:
-                      datetime-value: '2018-10-10'
-                      date: 10 October 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 13
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 294
-                size: 2
-                link: "/statutory-instruments/ogDjrUru"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-10-10'
-                      date: 10 October 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 11
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 295
-                size: 2
-                link: "/statutory-instruments/Y5wgjNCe"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-10-10'
-                      date: 10 October 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 10
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 296
-                size: 2
-                link: "/statutory-instruments/HDMCkDND"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-10-10'
-                      date: 10 October 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 8
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 297
-                size: 2
-                link: "/statutory-instruments/T8QuQbfp"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-10-10'
-                      date: 10 October 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 3
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 298
-                size: 2
-                link: "/statutory-instruments/90n67zWF"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-10-10'
-                      date: 10 October 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 8
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 299
-                size: 2
-                link: "/statutory-instruments/qN5SIpKr"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-10-11'
-                      date: 11 October 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 6
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 300
-                size: 2
-                link: "/statutory-instruments/WcxZPA5i"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-10-11'
-                      date: 11 October 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 18
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 1
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 301
-                size: 2
-                link: "/statutory-instruments/eOlu960r"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-10-11'
-                      date: 11 October 2018
+                      datetime-value: '2018-10-05'
+                      date: 5 October 2018
                 - term:
                     content: laid-thing.laying-body
                   description:
@@ -8176,9 +868,9 @@ main-components:
             heading:
               name: heading
               data:
-                content: statutoryInstrumentPaperName - 302
+                content: statutoryInstrumentPaperName - 278
                 size: 2
-                link: "/statutory-instruments/0l2kwZPW"
+                link: "/statutory-instruments/V9OJief9"
             list-description:
               name: list__description
               data:
@@ -8188,12 +880,12 @@ main-components:
                   description:
                   - content: shared.time-html
                     data:
-                      datetime-value: '2018-10-11'
-                      date: 11 October 2018
+                      datetime-value: '2018-09-28'
+                      date: 28 September 2018
                 - term:
                     content: laid-thing.laying-body
                   description:
-                  - content: groupName - 6
+                  - content: groupName - 7
                 - term:
                     content: laid-thing.procedure
                   description:
@@ -8203,9 +895,9 @@ main-components:
             heading:
               name: heading
               data:
-                content: statutoryInstrumentPaperName - 303
+                content: statutoryInstrumentPaperName - 279
                 size: 2
-                link: "/statutory-instruments/CFyWykUZ"
+                link: "/statutory-instruments/LCvP8PWr"
             list-description:
               name: list__description
               data:
@@ -8215,8 +907,251 @@ main-components:
                   description:
                   - content: shared.time-html
                     data:
-                      datetime-value: '2018-10-11'
-                      date: 11 October 2018
+                      datetime-value: '2018-09-28'
+                      date: 28 September 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 8
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 280
+                size: 2
+                link: "/statutory-instruments/VW7e0Sva"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-09-28'
+                      date: 28 September 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 7
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 276
+                size: 2
+                link: "/statutory-instruments/x1lCTIsz"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-09-27'
+                      date: 27 September 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 8
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 277
+                size: 2
+                link: "/statutory-instruments/Ez5LhVPl"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-09-27'
+                      date: 27 September 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 8
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 274
+                size: 2
+                link: "/statutory-instruments/WMZkgw45"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-09-26'
+                      date: 26 September 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 8
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 275
+                size: 2
+                link: "/statutory-instruments/sUFFmPCo"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-09-25'
+                      date: 25 September 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 8
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 272
+                size: 2
+                link: "/statutory-instruments/6gNGlxXz"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-09-20'
+                      date: 20 September 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 21
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 273
+                size: 2
+                link: "/statutory-instruments/SSIdUxdK"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-09-20'
+                      date: 20 September 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 21
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 271
+                size: 2
+                link: "/statutory-instruments/558R1vHw"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-09-17'
+                      date: 17 September 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 10
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 270
+                size: 2
+                link: "/statutory-instruments/gVLa6U8S"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-09-14'
+                      date: 14 September 2018
                 - term:
                     content: laid-thing.laying-body
                   description:
@@ -8230,9 +1165,9 @@ main-components:
             heading:
               name: heading
               data:
-                content: statutoryInstrumentPaperName - 304
+                content: statutoryInstrumentPaperName - 266
                 size: 2
-                link: "/statutory-instruments/d2bXwUKW"
+                link: "/statutory-instruments/lSRBYtGi"
             list-description:
               name: list__description
               data:
@@ -8242,39 +1177,12 @@ main-components:
                   description:
                   - content: shared.time-html
                     data:
-                      datetime-value: '2018-10-11'
-                      date: 11 October 2018
+                      datetime-value: '2018-09-13'
+                      date: 13 September 2018
                 - term:
                     content: laid-thing.laying-body
                   description:
                   - content: groupName - 6
-                - term:
-                    content: laid-thing.procedure
-                  description:
-                  - content: procedureName - 2
-        - name: card__generic
-          data:
-            heading:
-              name: heading
-              data:
-                content: statutoryInstrumentPaperName - 305
-                size: 2
-                link: "/statutory-instruments/J097gJjm"
-            list-description:
-              name: list__description
-              data:
-                items:
-                - term:
-                    content: laid-thing.laid-date
-                  description:
-                  - content: shared.time-html
-                    data:
-                      datetime-value: '2018-10-15'
-                      date: 15 October 2018
-                - term:
-                    content: laid-thing.laying-body
-                  description:
-                  - content: groupName - 11
                 - term:
                     content: laid-thing.procedure
                   description:
@@ -8284,9 +1192,9 @@ main-components:
             heading:
               name: heading
               data:
-                content: statutoryInstrumentPaperName - 306
+                content: statutoryInstrumentPaperName - 267
                 size: 2
-                link: "/statutory-instruments/PdffL1zZ"
+                link: "/statutory-instruments/H1uGO0VI"
             list-description:
               name: list__description
               data:
@@ -8296,8 +1204,143 @@ main-components:
                   description:
                   - content: shared.time-html
                     data:
-                      datetime-value: '2018-10-15'
-                      date: 15 October 2018
+                      datetime-value: '2018-09-13'
+                      date: 13 September 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 6
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 268
+                size: 2
+                link: "/statutory-instruments/IyxF7Re7"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-09-13'
+                      date: 13 September 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 10
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 269
+                size: 2
+                link: "/statutory-instruments/vWSvjJPY"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-09-13'
+                      date: 13 September 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 10
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 263
+                size: 2
+                link: "/statutory-instruments/FoxP8Wi7"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-09-12'
+                      date: 12 September 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 4
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 264
+                size: 2
+                link: "/statutory-instruments/CoWkZnVU"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-09-12'
+                      date: 12 September 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 2
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 265
+                size: 2
+                link: "/statutory-instruments/v9p3YHSe"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-09-12'
+                      date: 12 September 2018
                 - term:
                     content: laid-thing.laying-body
                   description:
@@ -8311,9 +1354,9 @@ main-components:
             heading:
               name: heading
               data:
-                content: statutoryInstrumentPaperName - 307
+                content: statutoryInstrumentPaperName - 261
                 size: 2
-                link: "/statutory-instruments/4CQsOYHF"
+                link: "/statutory-instruments/dj1ROT0l"
             list-description:
               name: list__description
               data:
@@ -8323,8 +1366,116 @@ main-components:
                   description:
                   - content: shared.time-html
                     data:
-                      datetime-value: '2018-10-12'
-                      date: 12 October 2018
+                      datetime-value: '2018-09-11'
+                      date: 11 September 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 4
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 262
+                size: 2
+                link: "/statutory-instruments/d3F9OZoU"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-09-11'
+                      date: 11 September 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 4
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 256
+                size: 2
+                link: "/statutory-instruments/n39tcDnk"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-09-10'
+                      date: 10 September 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 4
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 259
+                size: 2
+                link: "/statutory-instruments/pGJAClSs"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-09-10'
+                      date: 10 September 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 3
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 260
+                size: 2
+                link: "/statutory-instruments/WBlaNvyq"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-09-10'
+                      date: 10 September 2018
                 - term:
                     content: laid-thing.laying-body
                   description:
@@ -8338,9 +1489,9 @@ main-components:
             heading:
               name: heading
               data:
-                content: statutoryInstrumentPaperName - 308
+                content: statutoryInstrumentPaperName - 257
                 size: 2
-                link: "/statutory-instruments/VQdXrdx2"
+                link: "/statutory-instruments/3iuaNj8A"
             list-description:
               name: list__description
               data:
@@ -8350,12 +1501,6861 @@ main-components:
                   description:
                   - content: shared.time-html
                     data:
-                      datetime-value: '2018-10-15'
-                      date: 15 October 2018
+                      datetime-value: '2018-09-07'
+                      date: 7 September 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 8
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 258
+                size: 2
+                link: "/statutory-instruments/l05U8jIT"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-09-07'
+                      date: 7 September 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 10
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 252
+                size: 2
+                link: "/statutory-instruments/BuMKAKjA"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-09-06'
+                      date: 6 September 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 6
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 253
+                size: 2
+                link: "/statutory-instruments/DcVb33WY"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-09-06'
+                      date: 6 September 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 1
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 254
+                size: 2
+                link: "/statutory-instruments/fUqRRBH5"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-09-06'
+                      date: 6 September 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 3
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 255
+                size: 2
+                link: "/statutory-instruments/EAXHUZt7"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-09-06'
+                      date: 6 September 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 3
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 248
+                size: 2
+                link: "/statutory-instruments/TFdnSOeu"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-09-05'
+                      date: 5 September 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 2
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 249
+                size: 2
+                link: "/statutory-instruments/tRaHj88K"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-09-05'
+                      date: 5 September 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 3
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 250
+                size: 2
+                link: "/statutory-instruments/J8EUQxAg"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-09-05'
+                      date: 5 September 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 7
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 251
+                size: 2
+                link: "/statutory-instruments/9nwPn9YY"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-09-05'
+                      date: 5 September 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 8
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 242
+                size: 2
+                link: "/statutory-instruments/fgDYoYbL"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-09-04'
+                      date: 4 September 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 9
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 243
+                size: 2
+                link: "/statutory-instruments/jKZxBFHe"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-09-04'
+                      date: 4 September 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 9
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 244
+                size: 2
+                link: "/statutory-instruments/QjdlkhkP"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-09-04'
+                      date: 4 September 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 5
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 245
+                size: 2
+                link: "/statutory-instruments/8nULnQBi"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-09-04'
+                      date: 4 September 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 9
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 246
+                size: 2
+                link: "/statutory-instruments/RmycV0kO"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-09-04'
+                      date: 4 September 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 1
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 247
+                size: 2
+                link: "/statutory-instruments/yPyq3chO"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-09-04'
+                      date: 4 September 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 1
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 240
+                size: 2
+                link: "/statutory-instruments/nuicNnFk"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-08-31'
+                      date: 31 August 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 2
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 241
+                size: 2
+                link: "/statutory-instruments/peR5eFWQ"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-08-31'
+                      date: 31 August 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 12
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 239
+                size: 2
+                link: "/statutory-instruments/8NOTbqcG"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-08-30'
+                      date: 30 August 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 5
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 237
+                size: 2
+                link: "/statutory-instruments/GonuHKX2"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-08-23'
+                      date: 23 August 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 8
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 238
+                size: 2
+                link: "/statutory-instruments/n7DYBZTg"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-08-22'
+                      date: 22 August 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 19
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 236
+                size: 2
+                link: "/statutory-instruments/GuV3tchN"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-08-15'
+                      date: 15 August 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 4
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 234
+                size: 2
+                link: "/statutory-instruments/qQXoON26"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-08-13'
+                      date: 13 August 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 5
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 235
+                size: 2
+                link: "/statutory-instruments/Wa2pnyo2"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-08-13'
+                      date: 13 August 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 2
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 233
+                size: 2
+                link: "/statutory-instruments/evNAwjHg"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-08-08'
+                      date: 8 August 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 2
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 232
+                size: 2
+                link: "/statutory-instruments/IlH0bFJC"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-08-06'
+                      date: 6 August 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 5
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 231
+                size: 2
+                link: "/statutory-instruments/QtfEa5YW"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-08-02'
+                      date: 2 August 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 5
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 229
+                size: 2
+                link: "/statutory-instruments/VqC2MUZE"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-08-01'
+                      date: 1 August 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 5
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 227
+                size: 2
+                link: "/statutory-instruments/MyKmEbhB"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-30'
+                      date: 30 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 8
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 226
+                size: 2
+                link: "/statutory-instruments/hNYeAr2M"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-27'
+                      date: 27 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 8
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 223
+                size: 2
+                link: "/statutory-instruments/KKMVpl6g"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-26'
+                      date: 26 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 2
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 224
+                size: 2
+                link: "/statutory-instruments/hLF7ZU6f"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-26'
+                      date: 26 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 6
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 216
+                size: 2
+                link: "/statutory-instruments/tlSbgoyG"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-24'
+                      date: 24 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 19
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 217
+                size: 2
+                link: "/statutory-instruments/I22Wlejq"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-24'
+                      date: 24 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 5
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 218
+                size: 2
+                link: "/statutory-instruments/zo2QN0LF"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-24'
+                      date: 24 July 2018
+                - 
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 3
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 219
+                size: 2
+                link: "/statutory-instruments/3ovJSqCK"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-24'
+                      date: 24 July 2018
+                - 
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 3
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 220
+                size: 2
+                link: "/statutory-instruments/3Iw5OmCs"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-24'
+                      date: 24 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 7
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 221
+                size: 2
+                link: "/statutory-instruments/URYwfkWz"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-24'
+                      date: 24 July 2018
+                - 
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 3
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 222
+                size: 2
+                link: "/statutory-instruments/uIHeCzNz"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-24'
+                      date: 24 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 15
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 206
+                size: 2
+                link: "/statutory-instruments/ePPVgmgN"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-23'
+                      date: 23 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 10
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 207
+                size: 2
+                link: "/statutory-instruments/dHwDR0Xw"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-23'
+                      date: 23 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 2
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 208
+                size: 2
+                link: "/statutory-instruments/DVgODdNe"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-23'
+                      date: 23 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 2
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 209
+                size: 2
+                link: "/statutory-instruments/pg1MaN6V"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-23'
+                      date: 23 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 21
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 210
+                size: 2
+                link: "/statutory-instruments/2JipSGt3"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-23'
+                      date: 23 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 2
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 211
+                size: 2
+                link: "/statutory-instruments/qRweamaE"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-23'
+                      date: 23 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 10
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 212
+                size: 2
+                link: "/statutory-instruments/zRBB7JhE"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-23'
+                      date: 23 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 2
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 213
+                size: 2
+                link: "/statutory-instruments/xRUG9ARI"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-23'
+                      date: 23 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 2
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 214
+                size: 2
+                link: "/statutory-instruments/j0R3vR5s"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-23'
+                      date: 23 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 2
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 215
+                size: 2
+                link: "/statutory-instruments/YdIWHZS3"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-23'
+                      date: 23 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 10
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 205
+                size: 2
+                link: "/statutory-instruments/SbxmGLcR"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-20'
+                      date: 20 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 6
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 194
+                size: 2
+                link: "/statutory-instruments/QI5WArIQ"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-19'
+                      date: 19 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 10
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 195
+                size: 2
+                link: "/statutory-instruments/a8wT3ym2"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-19'
+                      date: 19 July 2018
                 - term:
                     content: laid-thing.laying-body
                   description:
                   - content: groupName - 11
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 196
+                size: 2
+                link: "/statutory-instruments/uPVA7EvA"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-19'
+                      date: 19 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 19
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 197
+                size: 2
+                link: "/statutory-instruments/EqisWZtW"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-19'
+                      date: 19 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 14
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 198
+                size: 2
+                link: "/statutory-instruments/M3L8iguJ"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-19'
+                      date: 19 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 9
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 199
+                size: 2
+                link: "/statutory-instruments/Uhsvsfdn"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-19'
+                      date: 19 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 6
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 201
+                size: 2
+                link: "/statutory-instruments/pyflzxxb"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-19'
+                      date: 19 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 3
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 202
+                size: 2
+                link: "/statutory-instruments/ORfYwwEX"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-19'
+                      date: 19 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 16
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 203
+                size: 2
+                link: "/statutory-instruments/bnrksmBb"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-19'
+                      date: 19 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 7
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 204
+                size: 2
+                link: "/statutory-instruments/xItHTyZP"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-19'
+                      date: 19 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 21
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 191
+                size: 2
+                link: "/statutory-instruments/m6w1ruLC"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-18'
+                      date: 18 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 15
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 192
+                size: 2
+                link: "/statutory-instruments/VXLHPnoP"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-18'
+                      date: 18 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 18
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 193
+                size: 2
+                link: "/statutory-instruments/DS1GQhA5"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-18'
+                      date: 18 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 3
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 200
+                size: 2
+                link: "/statutory-instruments/BP4IoUgX"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-18'
+                      date: 18 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 7
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 190
+                size: 2
+                link: "/statutory-instruments/zVuPoOWp"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-17'
+                      date: 17 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 7
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 183
+                size: 2
+                link: "/statutory-instruments/Qeou2KIY"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-16'
+                      date: 16 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 8
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 184
+                size: 2
+                link: "/statutory-instruments/qSs9kGvu"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-16'
+                      date: 16 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 16
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 186
+                size: 2
+                link: "/statutory-instruments/JHmYoIfJ"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-16'
+                      date: 16 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 12
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 187
+                size: 2
+                link: "/statutory-instruments/wIlQG2bb"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-16'
+                      date: 16 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 7
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 188
+                size: 2
+                link: "/statutory-instruments/ySndNUxm"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-16'
+                      date: 16 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 1
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 189
+                size: 2
+                link: "/statutory-instruments/QsAJ99E3"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-16'
+                      date: 16 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 8
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 185
+                size: 2
+                link: "/statutory-instruments/55gPdheg"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-13'
+                      date: 13 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 10
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 178
+                size: 2
+                link: "/statutory-instruments/bYMAmxYQ"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-12'
+                      date: 12 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 5
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 179
+                size: 2
+                link: "/statutory-instruments/vUb6Fcnn"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-12'
+                      date: 12 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 7
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 180
+                size: 2
+                link: "/statutory-instruments/cXKDMYqV"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-12'
+                      date: 12 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 3
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 181
+                size: 2
+                link: "/statutory-instruments/BRZBy463"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-12'
+                      date: 12 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 6
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 182
+                size: 2
+                link: "/statutory-instruments/cDVVk8C2"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-12'
+                      date: 12 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 4
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 176
+                size: 2
+                link: "/statutory-instruments/gcbZWM8q"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-10'
+                      date: 10 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 16
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 177
+                size: 2
+                link: "/statutory-instruments/Hw2xKRsZ"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-10'
+                      date: 10 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 3
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 175
+                size: 2
+                link: "/statutory-instruments/KF90wtY4"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-09'
+                      date: 9 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 10
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 174
+                size: 2
+                link: "/statutory-instruments/UBL9i00X"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-06'
+                      date: 6 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 2
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 170
+                size: 2
+                link: "/statutory-instruments/YhwigIF6"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-04'
+                      date: 4 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 3
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 171
+                size: 2
+                link: "/statutory-instruments/zd4ymhhN"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-04'
+                      date: 4 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 3
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 172
+                size: 2
+                link: "/statutory-instruments/SUtuR6qs"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-04'
+                      date: 4 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 18
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 173
+                size: 2
+                link: "/statutory-instruments/MIqYKT1i"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-04'
+                      date: 4 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 1
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 167
+                size: 2
+                link: "/statutory-instruments/JXxhQblu"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-03'
+                      date: 3 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 6
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 168
+                size: 2
+                link: "/statutory-instruments/9Brknpn7"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-03'
+                      date: 3 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 3
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 159
+                size: 2
+                link: "/statutory-instruments/c0IpQmwt"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-02'
+                      date: 2 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 2
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 161
+                size: 2
+                link: "/statutory-instruments/BZPGfEza"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-02'
+                      date: 2 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 10
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 164
+                size: 2
+                link: "/statutory-instruments/JPx0duf2"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-02'
+                      date: 2 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 2
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 165
+                size: 2
+                link: "/statutory-instruments/C8kKvTBL"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-02'
+                      date: 2 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 10
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 166
+                size: 2
+                link: "/statutory-instruments/1aUCYOe7"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-02'
+                      date: 2 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 1
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 169
+                size: 2
+                link: "/statutory-instruments/IjLgnN8z"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-07-02'
+                      date: 2 July 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 6
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 157
+                size: 2
+                link: "/statutory-instruments/m1AZ18wg"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-29'
+                      date: 29 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 16
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 158
+                size: 2
+                link: "/statutory-instruments/Foe6fVxK"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-29'
+                      date: 29 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 16
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 160
+                size: 2
+                link: "/statutory-instruments/RS3W2NQw"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-29'
+                      date: 29 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 16
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 162
+                size: 2
+                link: "/statutory-instruments/4GqD7K0p"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-29'
+                      date: 29 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 16
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 163
+                size: 2
+                link: "/statutory-instruments/2KKfR6RI"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-29'
+                      date: 29 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 7
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 151
+                size: 2
+                link: "/statutory-instruments/HZod54jz"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-28'
+                      date: 28 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 8
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 152
+                size: 2
+                link: "/statutory-instruments/zfcsMSD3"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-28'
+                      date: 28 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 4
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 153
+                size: 2
+                link: "/statutory-instruments/P5Zu6fkP"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-28'
+                      date: 28 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 6
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 154
+                size: 2
+                link: "/statutory-instruments/5dLGzkeI"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-28'
+                      date: 28 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 1
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 155
+                size: 2
+                link: "/statutory-instruments/NTd30zpo"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-28'
+                      date: 28 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 10
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 156
+                size: 2
+                link: "/statutory-instruments/98auwKwP"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-28'
+                      date: 28 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 1
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 146
+                size: 2
+                link: "/statutory-instruments/h8w2BHwS"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-25'
+                      date: 25 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 8
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 147
+                size: 2
+                link: "/statutory-instruments/VdxVTQ0L"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-25'
+                      date: 25 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 2
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 148
+                size: 2
+                link: "/statutory-instruments/UD4HjKbu"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-25'
+                      date: 25 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 6
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 149
+                size: 2
+                link: "/statutory-instruments/CMCJ3a82"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-25'
+                      date: 25 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 7
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 150
+                size: 2
+                link: "/statutory-instruments/mRgc1Qvc"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-25'
+                      date: 25 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 8
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 143
+                size: 2
+                link: "/statutory-instruments/OohXDEMJ"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-20'
+                      date: 20 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 20
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 144
+                size: 2
+                link: "/statutory-instruments/HNjL6uzv"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-20'
+                      date: 20 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 7
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 145
+                size: 2
+                link: "/statutory-instruments/4kSUJ4K2"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-20'
+                      date: 20 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 8
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 141
+                size: 2
+                link: "/statutory-instruments/MJ4ILVps"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-19'
+                      date: 19 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 7
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 136
+                size: 2
+                link: "/statutory-instruments/YhMNMpYo"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-18'
+                      date: 18 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 6
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 137
+                size: 2
+                link: "/statutory-instruments/GVXkRR2M"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-18'
+                      date: 18 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 4
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 138
+                size: 2
+                link: "/statutory-instruments/N1TcXxev"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-18'
+                      date: 18 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 8
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 139
+                size: 2
+                link: "/statutory-instruments/YdZGzcJA"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-18'
+                      date: 18 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 5
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 140
+                size: 2
+                link: "/statutory-instruments/u2nfODML"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-18'
+                      date: 18 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 8
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 142
+                size: 2
+                link: "/statutory-instruments/6XQ6ig48"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-18'
+                      date: 18 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 8
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 118
+                size: 2
+                link: "/statutory-instruments/rdYNYrB9"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-15'
+                      date: 15 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 10
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 119
+                size: 2
+                link: "/statutory-instruments/9Nv0gELe"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-15'
+                      date: 15 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 6
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 120
+                size: 2
+                link: "/statutory-instruments/D9vkxjm0"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-15'
+                      date: 15 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 2
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 110
+                size: 2
+                link: "/statutory-instruments/N3pbTe7F"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-14'
+                      date: 14 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 5
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 111
+                size: 2
+                link: "/statutory-instruments/leJaKS5E"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-14'
+                      date: 14 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 3
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 106
+                size: 2
+                link: "/statutory-instruments/aQaZuLyK"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-13'
+                      date: 13 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 6
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 107
+                size: 2
+                link: "/statutory-instruments/66skcwzN"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-13'
+                      date: 13 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 3
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 109
+                size: 2
+                link: "/statutory-instruments/I9rWxORS"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-13'
+                      date: 13 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 6
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 103
+                size: 2
+                link: "/statutory-instruments/Z1VEYuzd"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-11'
+                      date: 11 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 8
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 105
+                size: 2
+                link: "/statutory-instruments/WOETQ8oL"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-11'
+                      date: 11 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 3
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 97
+                size: 2
+                link: "/statutory-instruments/jKgfbLZG"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-11'
+                      date: 11 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 7
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 100
+                size: 2
+                link: "/statutory-instruments/PhwmELqG"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-08'
+                      date: 8 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 6
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 101
+                size: 2
+                link: "/statutory-instruments/PyLlquNq"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-08'
+                      date: 8 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 16
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 102
+                size: 2
+                link: "/statutory-instruments/1IUldWII"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-08'
+                      date: 8 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 5
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 104
+                size: 2
+                link: "/statutory-instruments/BN7ucM8o"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-08'
+                      date: 8 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 16
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 98
+                size: 2
+                link: "/statutory-instruments/LldrrMNS"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-08'
+                      date: 8 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 10
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 99
+                size: 2
+                link: "/statutory-instruments/nohxpB6K"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-08'
+                      date: 8 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 10
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 93
+                size: 2
+                link: "/statutory-instruments/tiA7a71r"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-07'
+                      date: 7 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 2
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 94
+                size: 2
+                link: "/statutory-instruments/wzOpc7Aj"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-07'
+                      date: 7 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 11
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 95
+                size: 2
+                link: "/statutory-instruments/8xNcqHgV"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-07'
+                      date: 7 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 10
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 96
+                size: 2
+                link: "/statutory-instruments/Keztycwl"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-07'
+                      date: 7 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 5
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 87
+                size: 2
+                link: "/statutory-instruments/IYqCRJN5"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-06'
+                      date: 6 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 4
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 91
+                size: 2
+                link: "/statutory-instruments/hs0US9Hw"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-06'
+                      date: 6 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 3
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 92
+                size: 2
+                link: "/statutory-instruments/w3m931qg"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-06'
+                      date: 6 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 6
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 85
+                size: 2
+                link: "/statutory-instruments/CHZfxISd"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-05'
+                      date: 5 June 2018
+                - 
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 3
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 86
+                size: 2
+                link: "/statutory-instruments/olhuTQTg"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-05'
+                      date: 5 June 2018
+                - 
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 3
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 88
+                size: 2
+                link: "/statutory-instruments/b9hRtbhC"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-05'
+                      date: 5 June 2018
+                - 
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 3
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 89
+                size: 2
+                link: "/statutory-instruments/T7oi7f0E"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-05'
+                      date: 5 June 2018
+                - 
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 3
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 90
+                size: 2
+                link: "/statutory-instruments/YZnLn72f"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-05'
+                      date: 5 June 2018
+                - 
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 3
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 112
+                size: 2
+                link: "/statutory-instruments/rMrXIRPv"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-04'
+                      date: 4 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 17
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 113
+                size: 2
+                link: "/statutory-instruments/hMaj7XDd"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-04'
+                      date: 4 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 17
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 114
+                size: 2
+                link: "/statutory-instruments/itrbNOwE"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-04'
+                      date: 4 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 17
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 115
+                size: 2
+                link: "/statutory-instruments/Y5ihrxeg"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-04'
+                      date: 4 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 17
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 116
+                size: 2
+                link: "/statutory-instruments/uhL6bPvV"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-04'
+                      date: 4 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 17
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 117
+                size: 2
+                link: "/statutory-instruments/MJRZgm6X"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-04'
+                      date: 4 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 17
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 70
+                size: 2
+                link: "/statutory-instruments/NRSdVnQe"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-04'
+                      date: 4 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 2
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 71
+                size: 2
+                link: "/statutory-instruments/oPe8W6LR"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-04'
+                      date: 4 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 3
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 72
+                size: 2
+                link: "/statutory-instruments/KUKpCZa3"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-04'
+                      date: 4 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 2
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 74
+                size: 2
+                link: "/statutory-instruments/z0qrw2Ka"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-04'
+                      date: 4 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 5
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 75
+                size: 2
+                link: "/statutory-instruments/181ZoViL"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-04'
+                      date: 4 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 5
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 76
+                size: 2
+                link: "/statutory-instruments/v2fDLDBe"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-04'
+                      date: 4 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 5
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 82
+                size: 2
+                link: "/statutory-instruments/pw7G14pf"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-04'
+                      date: 4 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 15
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 83
+                size: 2
+                link: "/statutory-instruments/9WjR8ian"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-04'
+                      date: 4 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 5
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 84
+                size: 2
+                link: "/statutory-instruments/ez3sdNNT"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-04'
+                      date: 4 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 6
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 73
+                size: 2
+                link: "/statutory-instruments/4EdTvost"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-01'
+                      date: 1 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 8
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 77
+                size: 2
+                link: "/statutory-instruments/eqmSAYR6"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-01'
+                      date: 1 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 1
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 78
+                size: 2
+                link: "/statutory-instruments/yvJQZWRS"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-01'
+                      date: 1 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 14
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 79
+                size: 2
+                link: "/statutory-instruments/58xXcnw9"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-01'
+                      date: 1 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 2
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 80
+                size: 2
+                link: "/statutory-instruments/cmbxjWzh"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-01'
+                      date: 1 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 8
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 81
+                size: 2
+                link: "/statutory-instruments/ZZqT1pd0"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-06-01'
+                      date: 1 June 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 8
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 108
+                size: 2
+                link: "/statutory-instruments/nky6NCi1"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-05-31'
+                      date: 31 May 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 5
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 129
+                size: 2
+                link: "/statutory-instruments/9S89Uofh"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-05-30'
+                      date: 30 May 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 18
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 131
+                size: 2
+                link: "/statutory-instruments/4bwmdrUh"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-05-30'
+                      date: 30 May 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 18
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 133
+                size: 2
+                link: "/statutory-instruments/YI5L3LfM"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-05-30'
+                      date: 30 May 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 18
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 134
+                size: 2
+                link: "/statutory-instruments/4e7ROEBU"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-05-30'
+                      date: 30 May 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 18
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 65
+                size: 2
+                link: "/statutory-instruments/YOVMhcqy"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-05-30'
+                      date: 30 May 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 13
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 57
+                size: 2
+                link: "/statutory-instruments/BdanAxAh"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-05-29'
+                      date: 29 May 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 3
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 67
+                size: 2
+                link: "/statutory-instruments/5pJMwiMT"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-05-25'
+                      date: 25 May 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 8
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 22
+                size: 2
+                link: "/statutory-instruments/uNiGNHey"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-05-24'
+                      date: 24 May 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 6
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 44
+                size: 2
+                link: "/statutory-instruments/RcGToJSJ"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-05-24'
+                      date: 24 May 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 11
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 59
+                size: 2
+                link: "/statutory-instruments/dNxWbKuU"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-05-23'
+                      date: 23 May 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 2
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 132
+                size: 2
+                link: "/statutory-instruments/X9tJrtug"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-05-21'
+                      date: 21 May 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 19
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 28
+                size: 2
+                link: "/statutory-instruments/lh2dYuHD"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-05-21'
+                      date: 21 May 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 2
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 61
+                size: 2
+                link: "/statutory-instruments/ijAPvpBd"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-05-21'
+                      date: 21 May 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 12
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 64
+                size: 2
+                link: "/statutory-instruments/rjzMGG28"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-05-21'
+                      date: 21 May 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 6
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 58
+                size: 2
+                link: "/statutory-instruments/bUEOr4ad"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-05-18'
+                      date: 18 May 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 3
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 60
+                size: 2
+                link: "/statutory-instruments/8HUWJm9e"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-05-18'
+                      date: 18 May 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 6
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 130
+                size: 2
+                link: "/statutory-instruments/xa91QFSm"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-05-17'
+                      date: 17 May 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 16
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 4
+                size: 2
+                link: "/statutory-instruments/5U4yBcY4"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-05-17'
+                      date: 17 May 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 4
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 62
+                size: 2
+                link: "/statutory-instruments/ZIUjUqOY"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-05-17'
+                      date: 17 May 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 12
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 23
+                size: 2
+                link: "/statutory-instruments/9PfnbabC"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-05-16'
+                      date: 16 May 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 10
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 21
+                size: 2
+                link: "/statutory-instruments/Q2dC6z5O"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-05-14'
+                      date: 14 May 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 8
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 3
+                size: 2
+                link: "/statutory-instruments/LFLdzMuO"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-05-14'
+                      date: 14 May 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 3
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 6
+                size: 2
+                link: "/statutory-instruments/bS94erG6"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-05-11'
+                      date: 11 May 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 1
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 41
+                size: 2
+                link: "/statutory-instruments/upP2FHa4"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-05-10'
+                      date: 10 May 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 8
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 9
+                size: 2
+                link: "/statutory-instruments/GOOyVBR4"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-05-09'
+                      date: 9 May 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 7
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 26
+                size: 2
+                link: "/statutory-instruments/HJ7BlYte"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-05-08'
+                      date: 8 May 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 6
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 30
+                size: 2
+                link: "/statutory-instruments/98FJSLox"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-05-08'
+                      date: 8 May 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 4
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 35
+                size: 2
+                link: "/statutory-instruments/R63aWjPi"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-05-08'
+                      date: 8 May 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 5
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 13
+                size: 2
+                link: "/statutory-instruments/yxN0RDlj"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-05-03'
+                      date: 3 May 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 5
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 17
+                size: 2
+                link: "/statutory-instruments/QmvfCS3N"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-05-03'
+                      date: 3 May 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 5
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 5
+                size: 2
+                link: "/statutory-instruments/TKqREWHZ"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-05-03'
+                      date: 3 May 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 5
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 125
+                size: 2
+                link: "/statutory-instruments/ITytkRlT"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-05-01'
+                      date: 1 May 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 18
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 135
+                size: 2
+                link: "/statutory-instruments/7uCF2qgm"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-05-01'
+                      date: 1 May 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 18
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 15
+                size: 2
+                link: "/statutory-instruments/Tw34pUb3"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-05-01'
+                      date: 1 May 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 7
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 20
+                size: 2
+                link: "/statutory-instruments/tPkKG8ef"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-05-01'
+                      date: 1 May 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 1
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 56
+                size: 2
+                link: "/statutory-instruments/Y70OJpm2"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-05-01'
+                      date: 1 May 2018
+                - 
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 3
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 66
+                size: 2
+                link: "/statutory-instruments/WSBR9sBz"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-05-01'
+                      date: 1 May 2018
+                - 
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 3
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 12
+                size: 2
+                link: "/statutory-instruments/tjxWFlR2"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-30'
+                      date: 30 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 1
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 124
+                size: 2
+                link: "/statutory-instruments/GHIocidH"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-30'
+                      date: 30 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 9
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 14
+                size: 2
+                link: "/statutory-instruments/9PuVurua"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-30'
+                      date: 30 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 9
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 31
+                size: 2
+                link: "/statutory-instruments/T3N7uNwm"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-30'
+                      date: 30 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 7
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 33
+                size: 2
+                link: "/statutory-instruments/8I8GntKQ"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-30'
+                      date: 30 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 12
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 36
+                size: 2
+                link: "/statutory-instruments/eD6E73Ne"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-30'
+                      date: 30 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 1
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 39
+                size: 2
+                link: "/statutory-instruments/ITuNnxmw"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-30'
+                      date: 30 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 3
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 49
+                size: 2
+                link: "/statutory-instruments/QbI1sir4"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-30'
+                      date: 30 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 7
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 25
+                size: 2
+                link: "/statutory-instruments/keUmDe6y"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-27'
+                      date: 27 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 2
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 8
+                size: 2
+                link: "/statutory-instruments/QV9rpep6"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-27'
+                      date: 27 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 6
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 11
+                size: 2
+                link: "/statutory-instruments/KZpExrdI"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-26'
+                      date: 26 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 8
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 121
+                size: 2
+                link: "/statutory-instruments/kqzXWiAO"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-26'
+                      date: 26 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 16
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 123
+                size: 2
+                link: "/statutory-instruments/vBqvzucr"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-26'
+                      date: 26 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 16
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 45
+                size: 2
+                link: "/statutory-instruments/hNQPUtRs"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-26'
+                      date: 26 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 11
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 16
+                size: 2
+                link: "/statutory-instruments/e1nEbjRI"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-24'
+                      date: 24 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 3
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 34
+                size: 2
+                link: "/statutory-instruments/TuBqZl6z"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-24'
+                      date: 24 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 3
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 1
+                size: 2
+                link: "/statutory-instruments/5trFJNih"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-23'
+                      date: 23 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 1
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 10
+                size: 2
+                link: "/statutory-instruments/FCcBOrUo"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-23'
+                      date: 23 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 8
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 122
+                size: 2
+                link: "/statutory-instruments/tZhWfLGW"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-23'
+                      date: 23 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 9
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 126
+                size: 2
+                link: "/statutory-instruments/vPuOxy1B"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-23'
+                      date: 23 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 9
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 128
+                size: 2
+                link: "/statutory-instruments/s75qT4mw"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-23'
+                      date: 23 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 9
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 40
+                size: 2
+                link: "/statutory-instruments/XGB9Cj8C"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-23'
+                      date: 23 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 9
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 53
+                size: 2
+                link: "/statutory-instruments/FXiTnP7V"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-23'
+                      date: 23 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 9
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 63
+                size: 2
+                link: "/statutory-instruments/rAkViDvo"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-23'
+                      date: 23 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 3
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 32
+                size: 2
+                link: "/statutory-instruments/LxPDdl92"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-20'
+                      date: 20 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 11
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 37
+                size: 2
+                link: "/statutory-instruments/W0xWx2Iu"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-20'
+                      date: 20 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 1
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 46
+                size: 2
+                link: "/statutory-instruments/xic2yu5i"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-20'
+                      date: 20 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 10
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 48
+                size: 2
+                link: "/statutory-instruments/k6waZgmJ"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-19'
+                      date: 19 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 5
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 51
+                size: 2
+                link: "/statutory-instruments/5urR0FTa"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-18'
+                      date: 18 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 1
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 55
+                size: 2
+                link: "/statutory-instruments/z0dWm7t5"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-18'
+                      date: 18 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 7
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 42
+                size: 2
+                link: "/statutory-instruments/0VJbg1Pa"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-17'
+                      date: 17 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 7
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 47
+                size: 2
+                link: "/statutory-instruments/YFkBxYkE"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-17'
+                      date: 17 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 7
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 50
+                size: 2
+                link: "/statutory-instruments/C2rRbqeQ"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-17'
+                      date: 17 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 3
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 127
+                size: 2
+                link: "/statutory-instruments/avoNURrR"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-16'
+                      date: 16 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 9
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 19
+                size: 2
+                link: "/statutory-instruments/1fStCnaK"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-16'
+                      date: 16 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 7
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 2
+                size: 2
+                link: "/statutory-instruments/VIqyNL58"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-16'
+                      date: 16 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 2
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 24
+                size: 2
+                link: "/statutory-instruments/ADR23Zyx"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-16'
+                      date: 16 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 4
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 27
+                size: 2
+                link: "/statutory-instruments/i9hQEgyv"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-16'
+                      date: 16 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 3
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 7
+                size: 2
+                link: "/statutory-instruments/PqyD6lfd"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-16'
+                      date: 16 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 1
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 43
+                size: 2
+                link: "/statutory-instruments/XnLvIexa"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-13'
+                      date: 13 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 2
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 38
+                size: 2
+                link: "/statutory-instruments/On2R0Zeb"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-04'
+                      date: 4 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 2
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 54
+                size: 2
+                link: "/statutory-instruments/Ly5VtVqc"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-04'
+                      date: 4 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 2
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 29
+                size: 2
+                link: "/statutory-instruments/O8GS8jnH"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-03'
+                      date: 3 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 10
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 52
+                size: 2
+                link: "/statutory-instruments/daySypEn"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-03'
+                      date: 3 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 10
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 68
+                size: 2
+                link: "/statutory-instruments/3dAYwLoB"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-03'
+                      date: 3 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 6
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 69
+                size: 2
+                link: "/statutory-instruments/AaXxxzda"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-04-03'
+                      date: 3 April 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 10
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 18
+                size: 2
+                link: "/statutory-instruments/YeYkel8w"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.laid-date
+                  description:
+                  - content: shared.time-html
+                    data:
+                      datetime-value: '2018-03-29'
+                      date: 29 March 2018
+                - term:
+                    content: laid-thing.laying-body
+                  description:
+                  - content: groupName - 3
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 2
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 225
+                size: 2
+                link: "/statutory-instruments/2zCfE0jG"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 228
+                size: 2
+                link: "/statutory-instruments/fqzYAhp8"
+            list-description:
+              name: list__description
+              data:
+                items:
+                - term:
+                    content: laid-thing.procedure
+                  description:
+                  - content: procedureName - 1
+        - name: card__generic
+          data:
+            heading:
+              name: heading
+              data:
+                content: statutoryInstrumentPaperName - 230
+                size: 2
+                link: "/statutory-instruments/AbFupFPb"
+            list-description:
+              name: list__description
+              data:
+                items:
                 - term:
                     content: laid-thing.procedure
                   description:

--- a/spec/fixtures/vcr_cassettes/GroupSortHelper/with_real_data/_group/groups_the_data_correctly.yml
+++ b/spec/fixtures/vcr_cassettes/GroupSortHelper/with_real_data/_group/groups_the_data_correctly.yml
@@ -1,0 +1,1561 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3030/statutory_instrument_index
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      - application/n-triples
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '40684'
+      Content-Type:
+      - application/n-triples
+      Expires:
+      - Thu, 25 Oct 2018 10:39:07 GMT
+      Request-Context:
+      - appId=cid-v1:330aa411-57af-491f-b22a-1cab7d08a6a9
+      Access-Control-Expose-Headers:
+      - Request-Context
+      Set-Cookie:
+      - ARRAffinity=77b2b22b62b6e0d158b9023c2ed0c9ea4be870072240a45c1bef0e3480502c58;Path=/;HttpOnly;Domain=fixedquery201810051005.azurewebsites.net
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Thu, 25 Oct 2018 10:39:07 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "<https://id.parliament.uk/QmvfCS3N> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/QmvfCS3N>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/QmvfCS3N> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/QmvfCS3N>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 1\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/QmvfCS3N>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 1\" .\r\n<https://id.parliament.uk/QmvfCS3N> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"751\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/QmvfCS3N>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 1\" .\r\n<https://id.parliament.uk/QmvfCS3N> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/Mcvmer52> .\r\n<https://id.parliament.uk/QmvfCS3N>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/tVWVmTCL>
+        .\r\n<https://id.parliament.uk/Mcvmer52> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/Mcvmer52>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-03+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/Mcvmer52> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fKqMNz79> .\r\n<https://id.parliament.uk/fKqMNz79>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Group>
+        .\r\n<https://id.parliament.uk/fKqMNz79> <https://id.parliament.uk/schema/groupName>
+        \"groupName - 1\" .\r\n<https://id.parliament.uk/tVWVmTCL> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/tVWVmTCL>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/H5YJQsK2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Procedure> .\r\n<https://id.parliament.uk/H5YJQsK2>
+        <https://id.parliament.uk/schema/procedureName> \"procedureName - 1\" .\r\n<https://id.parliament.uk/keUmDe6y>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/keUmDe6y> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/keUmDe6y>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/keUmDe6y> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 2\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/keUmDe6y> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 2\" .\r\n<https://id.parliament.uk/keUmDe6y>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"517\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/keUmDe6y> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 2\" .\r\n<https://id.parliament.uk/keUmDe6y>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/qaT30ffk>
+        .\r\n<https://id.parliament.uk/keUmDe6y> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/e8079KjV> .\r\n<https://id.parliament.uk/qaT30ffk>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/qaT30ffk> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-27+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/qaT30ffk>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/7dSvuueH>
+        .\r\n<https://id.parliament.uk/7dSvuueH> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Group> .\r\n<https://id.parliament.uk/7dSvuueH>
+        <https://id.parliament.uk/schema/groupName> \"groupName - 2\" .\r\n<https://id.parliament.uk/e8079KjV>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/e8079KjV> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/5S6p4YsP>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Procedure>
+        .\r\n<https://id.parliament.uk/5S6p4YsP> <https://id.parliament.uk/schema/procedureName>
+        \"procedureName - 2\" .\r\n<https://id.parliament.uk/R63aWjPi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/R63aWjPi>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/R63aWjPi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/R63aWjPi>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 3\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/R63aWjPi>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 3\" .\r\n<https://id.parliament.uk/R63aWjPi> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"566\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/R63aWjPi>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 3\" .\r\n<https://id.parliament.uk/R63aWjPi> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/NPExPXay> .\r\n<https://id.parliament.uk/R63aWjPi>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/lon9Uu05>
+        .\r\n<https://id.parliament.uk/NPExPXay> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/NPExPXay>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-08+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/NPExPXay> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fKqMNz79> .\r\n<https://id.parliament.uk/lon9Uu05>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/lon9Uu05> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/W0xWx2Iu>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/W0xWx2Iu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/W0xWx2Iu>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/W0xWx2Iu> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 4\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/W0xWx2Iu> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 4\" .\r\n<https://id.parliament.uk/W0xWx2Iu>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"498\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/W0xWx2Iu> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 4\" .\r\n<https://id.parliament.uk/W0xWx2Iu>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/QzUSqeLr>
+        .\r\n<https://id.parliament.uk/W0xWx2Iu> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/9XxmwGtU> .\r\n<https://id.parliament.uk/QzUSqeLr>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/QzUSqeLr> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-20+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/QzUSqeLr>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/BRTNQywN>
+        .\r\n<https://id.parliament.uk/BRTNQywN> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Group> .\r\n<https://id.parliament.uk/BRTNQywN>
+        <https://id.parliament.uk/schema/groupName> \"groupName - 3\" .\r\n<https://id.parliament.uk/9XxmwGtU>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/9XxmwGtU> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/On2R0Zeb>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/On2R0Zeb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/On2R0Zeb>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/On2R0Zeb> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 5\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/On2R0Zeb> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 5\" .\r\n<https://id.parliament.uk/On2R0Zeb>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"466\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/On2R0Zeb> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 5\" .\r\n<https://id.parliament.uk/On2R0Zeb>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/TQQt5wkr>
+        .\r\n<https://id.parliament.uk/On2R0Zeb> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/40Yq0PnR> .\r\n<https://id.parliament.uk/TQQt5wkr>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/TQQt5wkr> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/TQQt5wkr>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/7dSvuueH>
+        .\r\n<https://id.parliament.uk/40Yq0PnR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/40Yq0PnR>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/yxN0RDlj> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/yxN0RDlj>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/yxN0RDlj> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/yxN0RDlj>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 6\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/yxN0RDlj>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 6\" .\r\n<https://id.parliament.uk/yxN0RDlj> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"553\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/yxN0RDlj>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 6\" .\r\n<https://id.parliament.uk/yxN0RDlj> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/3ZbbcnKj> .\r\n<https://id.parliament.uk/yxN0RDlj>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/PjQFqiyZ>
+        .\r\n<https://id.parliament.uk/3ZbbcnKj> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/3ZbbcnKj>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-03+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/3ZbbcnKj> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fKqMNz79> .\r\n<https://id.parliament.uk/PjQFqiyZ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/PjQFqiyZ> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/tPkKG8ef>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/tPkKG8ef> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/tPkKG8ef>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/tPkKG8ef> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 7\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/tPkKG8ef> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 7\" .\r\n<https://id.parliament.uk/tPkKG8ef>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"549\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/tPkKG8ef> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 7\" .\r\n<https://id.parliament.uk/tPkKG8ef>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/uprc8alP>
+        .\r\n<https://id.parliament.uk/tPkKG8ef> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/9bXhF8oV> .\r\n<https://id.parliament.uk/uprc8alP>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/uprc8alP> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-01+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/uprc8alP>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/BRTNQywN>
+        .\r\n<https://id.parliament.uk/9bXhF8oV> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/9bXhF8oV>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/9PuVurua> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/9PuVurua>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/9PuVurua> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/9PuVurua>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 8\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/9PuVurua>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 8\" .\r\n<https://id.parliament.uk/9PuVurua> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"538\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/9PuVurua>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 8\" .\r\n<https://id.parliament.uk/9PuVurua> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/2iDuQtrK> .\r\n<https://id.parliament.uk/9PuVurua>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/zhi6ZHnQ>
+        .\r\n<https://id.parliament.uk/2iDuQtrK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/2iDuQtrK>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-30+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/2iDuQtrK> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/79sn5e3n> .\r\n<https://id.parliament.uk/79sn5e3n>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Group>
+        .\r\n<https://id.parliament.uk/79sn5e3n> <https://id.parliament.uk/schema/groupName>
+        \"groupName - 4\" .\r\n<https://id.parliament.uk/zhi6ZHnQ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/zhi6ZHnQ>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/ITuNnxmw> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/ITuNnxmw>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/ITuNnxmw> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/ITuNnxmw>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 9\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/ITuNnxmw>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 9\" .\r\n<https://id.parliament.uk/ITuNnxmw> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"797\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/ITuNnxmw>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 9\" .\r\n<https://id.parliament.uk/ITuNnxmw> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/1AR7f0NW> .\r\n<https://id.parliament.uk/ITuNnxmw>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/PsB0pq0l>
+        .\r\n<https://id.parliament.uk/1AR7f0NW> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/1AR7f0NW>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-30+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/1AR7f0NW> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/yiuTaSI4> .\r\n<https://id.parliament.uk/yiuTaSI4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Group>
+        .\r\n<https://id.parliament.uk/yiuTaSI4> <https://id.parliament.uk/schema/groupName>
+        \"groupName - 5\" .\r\n<https://id.parliament.uk/PsB0pq0l> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/PsB0pq0l>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/bS94erG6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/bS94erG6>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/bS94erG6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/bS94erG6>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 10\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/bS94erG6>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 10\" .\r\n<https://id.parliament.uk/bS94erG6> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"587\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/bS94erG6>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 10\" .\r\n<https://id.parliament.uk/bS94erG6> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/NagVnt8h> .\r\n<https://id.parliament.uk/bS94erG6>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/I4duwcuB>
+        .\r\n<https://id.parliament.uk/NagVnt8h> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/NagVnt8h>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-11+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/NagVnt8h> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/BRTNQywN> .\r\n<https://id.parliament.uk/I4duwcuB>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/I4duwcuB> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/upP2FHa4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/upP2FHa4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/upP2FHa4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/upP2FHa4> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 11\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/upP2FHa4> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 11\" .\r\n<https://id.parliament.uk/upP2FHa4>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"575\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/upP2FHa4> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 11\" .\r\n<https://id.parliament.uk/upP2FHa4>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/cfbEYJ86>
+        .\r\n<https://id.parliament.uk/upP2FHa4> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/KAaIQyCC> .\r\n<https://id.parliament.uk/cfbEYJ86>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/cfbEYJ86> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-10+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/cfbEYJ86>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/5LQ5Ar74>
+        .\r\n<https://id.parliament.uk/5LQ5Ar74> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Group> .\r\n<https://id.parliament.uk/5LQ5Ar74>
+        <https://id.parliament.uk/schema/groupName> \"groupName - 6\" .\r\n<https://id.parliament.uk/KAaIQyCC>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/KAaIQyCC> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/0VJbg1Pa>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/0VJbg1Pa> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/0VJbg1Pa>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/0VJbg1Pa> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 12\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/0VJbg1Pa> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 12\" .\r\n<https://id.parliament.uk/0VJbg1Pa>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"485\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/0VJbg1Pa> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 12\" .\r\n<https://id.parliament.uk/0VJbg1Pa>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/auOf4Epa>
+        .\r\n<https://id.parliament.uk/auOf4Epa> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/auOf4Epa>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/XnLvIexa> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/XnLvIexa>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/XnLvIexa> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/XnLvIexa>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 13\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/XnLvIexa>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 13\" .\r\n<https://id.parliament.uk/XnLvIexa> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"472\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/XnLvIexa>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 13\" .\r\n<https://id.parliament.uk/XnLvIexa> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/f9w5NpTb> .\r\n<https://id.parliament.uk/XnLvIexa>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/WmlTLQiJ>
+        .\r\n<https://id.parliament.uk/f9w5NpTb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/f9w5NpTb>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-13+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/f9w5NpTb> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/7dSvuueH> .\r\n<https://id.parliament.uk/WmlTLQiJ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/WmlTLQiJ> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/GOOyVBR4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/GOOyVBR4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/GOOyVBR4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/GOOyVBR4> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 14\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/GOOyVBR4> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 14\" .\r\n<https://id.parliament.uk/GOOyVBR4>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"831\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/GOOyVBR4> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 14\" .\r\n<https://id.parliament.uk/GOOyVBR4>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/v6kwIWtt>
+        .\r\n<https://id.parliament.uk/GOOyVBR4> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/zJLB2rbN> .\r\n<https://id.parliament.uk/v6kwIWtt>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/v6kwIWtt> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-09+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/v6kwIWtt>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/HYfypSOE>
+        .\r\n<https://id.parliament.uk/HYfypSOE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Group> .\r\n<https://id.parliament.uk/HYfypSOE>
+        <https://id.parliament.uk/schema/groupName> \"groupName - 7\" .\r\n<https://id.parliament.uk/zJLB2rbN>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/zJLB2rbN> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/8I8GntKQ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/8I8GntKQ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/8I8GntKQ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/8I8GntKQ> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 15\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/8I8GntKQ> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 15\" .\r\n<https://id.parliament.uk/8I8GntKQ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"537\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/8I8GntKQ> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 15\" .\r\n<https://id.parliament.uk/8I8GntKQ>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/3dED0LgI>
+        .\r\n<https://id.parliament.uk/8I8GntKQ> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/PwLQp4Rk> .\r\n<https://id.parliament.uk/3dED0LgI>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/3dED0LgI> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-30+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/3dED0LgI>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/7gnSwbLO>
+        .\r\n<https://id.parliament.uk/7gnSwbLO> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Group> .\r\n<https://id.parliament.uk/7gnSwbLO>
+        <https://id.parliament.uk/schema/groupName> \"groupName - 8\" .\r\n<https://id.parliament.uk/PwLQp4Rk>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/PwLQp4Rk> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/Tw34pUb3>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/Tw34pUb3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/Tw34pUb3>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/Tw34pUb3> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 16\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/Tw34pUb3> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 16\" .\r\n<https://id.parliament.uk/Tw34pUb3>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"546\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/Tw34pUb3> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 16\" .\r\n<https://id.parliament.uk/Tw34pUb3>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/QRLFhjUD>
+        .\r\n<https://id.parliament.uk/Tw34pUb3> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/F3ClsH20> .\r\n<https://id.parliament.uk/QRLFhjUD>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/QRLFhjUD> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-01+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/QRLFhjUD>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/HYfypSOE>
+        .\r\n<https://id.parliament.uk/F3ClsH20> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/F3ClsH20>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/rAkViDvo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/rAkViDvo>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/rAkViDvo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/rAkViDvo>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 17\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/rAkViDvo>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 17\" .\r\n<https://id.parliament.uk/rAkViDvo> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"800\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/rAkViDvo>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 17\" .\r\n<https://id.parliament.uk/rAkViDvo> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/AtyGfoYi> .\r\n<https://id.parliament.uk/rAkViDvo>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/c8P8nJgq>
+        .\r\n<https://id.parliament.uk/AtyGfoYi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/AtyGfoYi>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/AtyGfoYi> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/yiuTaSI4> .\r\n<https://id.parliament.uk/c8P8nJgq>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/c8P8nJgq> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/FCcBOrUo>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/FCcBOrUo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/FCcBOrUo>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/FCcBOrUo> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 18\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/FCcBOrUo> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 18\" .\r\n<https://id.parliament.uk/FCcBOrUo>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"510\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/FCcBOrUo> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 18\" .\r\n<https://id.parliament.uk/FCcBOrUo>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/Nhuev5Ry>
+        .\r\n<https://id.parliament.uk/FCcBOrUo> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/Ic57bsvz> .\r\n<https://id.parliament.uk/Nhuev5Ry>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/Nhuev5Ry> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/Nhuev5Ry>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/5LQ5Ar74>
+        .\r\n<https://id.parliament.uk/Ic57bsvz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/Ic57bsvz>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/tjxWFlR2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/tjxWFlR2>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/tjxWFlR2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/tjxWFlR2>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 19\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/tjxWFlR2>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 19\" .\r\n<https://id.parliament.uk/tjxWFlR2> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"541\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/tjxWFlR2>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 19\" .\r\n<https://id.parliament.uk/tjxWFlR2> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/FcPf17jF> .\r\n<https://id.parliament.uk/tjxWFlR2>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/diYZkVb4>
+        .\r\n<https://id.parliament.uk/FcPf17jF> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/FcPf17jF>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-30+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/FcPf17jF> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/BRTNQywN> .\r\n<https://id.parliament.uk/diYZkVb4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/diYZkVb4> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/e1nEbjRI>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/e1nEbjRI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/e1nEbjRI>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/e1nEbjRI> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 20\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/e1nEbjRI> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 20\" .\r\n<https://id.parliament.uk/e1nEbjRI>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"514\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/e1nEbjRI> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 20\" .\r\n<https://id.parliament.uk/e1nEbjRI>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/HkngXyxl>
+        .\r\n<https://id.parliament.uk/e1nEbjRI> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/dFnbME4A> .\r\n<https://id.parliament.uk/HkngXyxl>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/HkngXyxl> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-24+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/HkngXyxl>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/yiuTaSI4>
+        .\r\n<https://id.parliament.uk/dFnbME4A> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/dFnbME4A>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/xic2yu5i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/xic2yu5i>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/xic2yu5i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/xic2yu5i>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 21\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/xic2yu5i>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 21\" .\r\n<https://id.parliament.uk/xic2yu5i> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"488\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/xic2yu5i>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 21\" .\r\n<https://id.parliament.uk/xic2yu5i> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/c240s9cD> .\r\n<https://id.parliament.uk/xic2yu5i>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/EgDK23iB>
+        .\r\n<https://id.parliament.uk/c240s9cD> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/c240s9cD>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-20+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/c240s9cD> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XouN12Ow> .\r\n<https://id.parliament.uk/XouN12Ow>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Group>
+        .\r\n<https://id.parliament.uk/XouN12Ow> <https://id.parliament.uk/schema/groupName>
+        \"groupName - 9\" .\r\n<https://id.parliament.uk/EgDK23iB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/EgDK23iB>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/TKqREWHZ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/TKqREWHZ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/TKqREWHZ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/TKqREWHZ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 22\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/TKqREWHZ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 22\" .\r\n<https://id.parliament.uk/TKqREWHZ> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 22\" .\r\n<https://id.parliament.uk/TKqREWHZ>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/Mw7umRDD>
+        .\r\n<https://id.parliament.uk/TKqREWHZ> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/eCsYdAM3> .\r\n<https://id.parliament.uk/Mw7umRDD>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/Mw7umRDD> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-03+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/Mw7umRDD>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/fKqMNz79>
+        .\r\n<https://id.parliament.uk/eCsYdAM3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/eCsYdAM3>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/ADR23Zyx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/ADR23Zyx>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/ADR23Zyx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/ADR23Zyx>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 23\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/ADR23Zyx>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 23\" .\r\n<https://id.parliament.uk/ADR23Zyx> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"92\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/ADR23Zyx>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 23\" .\r\n<https://id.parliament.uk/ADR23Zyx> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/OSdTYDeS> .\r\n<https://id.parliament.uk/ADR23Zyx>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/EdGVZDEz>
+        .\r\n<https://id.parliament.uk/OSdTYDeS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/OSdTYDeS>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-16+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/OSdTYDeS> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XbTBTDMo> .\r\n<https://id.parliament.uk/XbTBTDMo>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Group>
+        .\r\n<https://id.parliament.uk/XbTBTDMo> <https://id.parliament.uk/schema/groupName>
+        \"groupName - 10\" .\r\n<https://id.parliament.uk/EdGVZDEz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/EdGVZDEz>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/hNQPUtRs> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/hNQPUtRs>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/hNQPUtRs> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/hNQPUtRs>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 24\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/hNQPUtRs>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 24\" .\r\n<https://id.parliament.uk/hNQPUtRs> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"735\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/hNQPUtRs>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 24\" .\r\n<https://id.parliament.uk/hNQPUtRs> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/njlVbk2J> .\r\n<https://id.parliament.uk/hNQPUtRs>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/W7YZ1i4T>
+        .\r\n<https://id.parliament.uk/njlVbk2J> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/njlVbk2J>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-26+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/njlVbk2J> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/ZU3IXBtP> .\r\n<https://id.parliament.uk/ZU3IXBtP>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Group>
+        .\r\n<https://id.parliament.uk/ZU3IXBtP> <https://id.parliament.uk/schema/groupName>
+        \"groupName - 11\" .\r\n<https://id.parliament.uk/W7YZ1i4T> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/W7YZ1i4T>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/YFkBxYkE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/YFkBxYkE>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/YFkBxYkE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/YFkBxYkE>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 25\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/YFkBxYkE>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 25\" .\r\n<https://id.parliament.uk/YFkBxYkE> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"483\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/YFkBxYkE>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 25\" .\r\n<https://id.parliament.uk/YFkBxYkE> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/nrMzeLJ5> .\r\n<https://id.parliament.uk/YFkBxYkE>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/IHy5RkQv>
+        .\r\n<https://id.parliament.uk/nrMzeLJ5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/nrMzeLJ5>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-17+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/nrMzeLJ5> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/HYfypSOE> .\r\n<https://id.parliament.uk/IHy5RkQv>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/IHy5RkQv> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/k6waZgmJ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/k6waZgmJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/k6waZgmJ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/k6waZgmJ> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 26\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/k6waZgmJ> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 26\" .\r\n<https://id.parliament.uk/k6waZgmJ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"493\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/k6waZgmJ> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 26\" .\r\n<https://id.parliament.uk/k6waZgmJ>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/H3U1WIOm>
+        .\r\n<https://id.parliament.uk/k6waZgmJ> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/XDilT5Ce> .\r\n<https://id.parliament.uk/H3U1WIOm>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/H3U1WIOm> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-19+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/H3U1WIOm>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/fKqMNz79>
+        .\r\n<https://id.parliament.uk/XDilT5Ce> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/XDilT5Ce>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/O8GS8jnH> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/O8GS8jnH>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/O8GS8jnH> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/O8GS8jnH>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 27\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/O8GS8jnH>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 27\" .\r\n<https://id.parliament.uk/O8GS8jnH> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"423\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/O8GS8jnH>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 27\" .\r\n<https://id.parliament.uk/O8GS8jnH> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/KgB4r60a> .\r\n<https://id.parliament.uk/O8GS8jnH>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/QN1c7sKE>
+        .\r\n<https://id.parliament.uk/KgB4r60a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/KgB4r60a>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-03+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/KgB4r60a> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XouN12Ow> .\r\n<https://id.parliament.uk/QN1c7sKE>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/QN1c7sKE> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/WSBR9sBz>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/WSBR9sBz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/WSBR9sBz>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/WSBR9sBz> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 28\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/WSBR9sBz> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 28\" .\r\n<https://id.parliament.uk/WSBR9sBz>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 28\" .\r\n<https://id.parliament.uk/WSBR9sBz> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/SildA8v4> .\r\n<https://id.parliament.uk/WSBR9sBz>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/7qN3AkCI>
+        .\r\n<https://id.parliament.uk/SildA8v4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/SildA8v4>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-01+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/SildA8v4> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/eup4DwE5> .\r\n<https://id.parliament.uk/eup4DwE5>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Group>
+        .\r\n<https://id.parliament.uk/eup4DwE5> <https://id.parliament.uk/schema/groupName>
+        \"groupName - 12\" .\r\n<https://id.parliament.uk/7qN3AkCI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/7qN3AkCI>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/gTgidljI>
+        .\r\n<https://id.parliament.uk/gTgidljI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Procedure> .\r\n<https://id.parliament.uk/gTgidljI>
+        <https://id.parliament.uk/schema/procedureName> \"procedureName - 3\" .\r\n<https://id.parliament.uk/QbI1sir4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/QbI1sir4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/QbI1sir4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/QbI1sir4> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 29\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/QbI1sir4> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 29\" .\r\n<https://id.parliament.uk/QbI1sir4>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"832\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/QbI1sir4> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 29\" .\r\n<https://id.parliament.uk/QbI1sir4>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/xCcwgdvQ>
+        .\r\n<https://id.parliament.uk/QbI1sir4> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/bONPJ56c> .\r\n<https://id.parliament.uk/xCcwgdvQ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/xCcwgdvQ> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-30+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/xCcwgdvQ>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/HYfypSOE>
+        .\r\n<https://id.parliament.uk/bONPJ56c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/bONPJ56c>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/VIqyNL58> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/VIqyNL58>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/VIqyNL58> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/VIqyNL58>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 30\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/VIqyNL58>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 30\" .\r\n<https://id.parliament.uk/VIqyNL58> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"674\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/VIqyNL58>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 30\" .\r\n<https://id.parliament.uk/VIqyNL58> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/FvuNhGmO> .\r\n<https://id.parliament.uk/VIqyNL58>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/zlDxL3xS>
+        .\r\n<https://id.parliament.uk/FvuNhGmO> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/FvuNhGmO>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-16+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/FvuNhGmO> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/7dSvuueH> .\r\n<https://id.parliament.uk/zlDxL3xS>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/zlDxL3xS> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/AaXxxzda>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/AaXxxzda> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/AaXxxzda>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/AaXxxzda> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 31\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/AaXxxzda> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 31\" .\r\n<https://id.parliament.uk/AaXxxzda>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"406\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/AaXxxzda> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 31\" .\r\n<https://id.parliament.uk/AaXxxzda>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/Phw9bTAd>
+        .\r\n<https://id.parliament.uk/AaXxxzda> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/KGrfWbku> .\r\n<https://id.parliament.uk/Phw9bTAd>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/Phw9bTAd> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-03+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/Phw9bTAd>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/XouN12Ow>
+        .\r\n<https://id.parliament.uk/KGrfWbku> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/KGrfWbku>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/C2rRbqeQ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/C2rRbqeQ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/C2rRbqeQ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/C2rRbqeQ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 32\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/C2rRbqeQ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 32\" .\r\n<https://id.parliament.uk/C2rRbqeQ> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"482\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/C2rRbqeQ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 32\" .\r\n<https://id.parliament.uk/C2rRbqeQ> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/tSHwlzxI> .\r\n<https://id.parliament.uk/C2rRbqeQ>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/UsdZhECl>
+        .\r\n<https://id.parliament.uk/tSHwlzxI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/tSHwlzxI>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-17+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/tSHwlzxI> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/yiuTaSI4> .\r\n<https://id.parliament.uk/UsdZhECl>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/UsdZhECl> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/5urR0FTa>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/5urR0FTa> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/5urR0FTa>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/5urR0FTa> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 33\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/5urR0FTa> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 33\" .\r\n<https://id.parliament.uk/5urR0FTa>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"489\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/5urR0FTa> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 33\" .\r\n<https://id.parliament.uk/5urR0FTa>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/GydEOlpQ>
+        .\r\n<https://id.parliament.uk/5urR0FTa> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/BBNF0hzl> .\r\n<https://id.parliament.uk/GydEOlpQ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/GydEOlpQ> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-18+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/GydEOlpQ>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/BRTNQywN>
+        .\r\n<https://id.parliament.uk/BBNF0hzl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/BBNF0hzl>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/KZpExrdI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/KZpExrdI>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/KZpExrdI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/KZpExrdI>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 34\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/KZpExrdI>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 34\" .\r\n<https://id.parliament.uk/KZpExrdI> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"527\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/KZpExrdI>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 34\" .\r\n<https://id.parliament.uk/KZpExrdI> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/AvYw0KZ2> .\r\n<https://id.parliament.uk/KZpExrdI>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/K8jg57DX>
+        .\r\n<https://id.parliament.uk/AvYw0KZ2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/AvYw0KZ2>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-26+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/AvYw0KZ2> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/5LQ5Ar74> .\r\n<https://id.parliament.uk/K8jg57DX>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/K8jg57DX> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/daySypEn>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/daySypEn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/daySypEn>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/daySypEn> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 35\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/daySypEn> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 35\" .\r\n<https://id.parliament.uk/daySypEn>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"439\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/daySypEn> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 35\" .\r\n<https://id.parliament.uk/daySypEn>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/pg0TWSqT>
+        .\r\n<https://id.parliament.uk/daySypEn> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/5wUN28za> .\r\n<https://id.parliament.uk/pg0TWSqT>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/pg0TWSqT> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-03+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/pg0TWSqT>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/XouN12Ow>
+        .\r\n<https://id.parliament.uk/5wUN28za> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/5wUN28za>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/i9hQEgyv> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/i9hQEgyv>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/i9hQEgyv> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/i9hQEgyv>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 36\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/i9hQEgyv>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 36\" .\r\n<https://id.parliament.uk/i9hQEgyv> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"634\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/i9hQEgyv>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 36\" .\r\n<https://id.parliament.uk/i9hQEgyv> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/nsrSFKGl> .\r\n<https://id.parliament.uk/i9hQEgyv>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/QXHttLOh>
+        .\r\n<https://id.parliament.uk/nsrSFKGl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/nsrSFKGl>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-16+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/nsrSFKGl> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/yiuTaSI4> .\r\n<https://id.parliament.uk/QXHttLOh>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/QXHttLOh> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/QV9rpep6>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/QV9rpep6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/QV9rpep6>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/QV9rpep6> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 37\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/QV9rpep6> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 37\" .\r\n<https://id.parliament.uk/QV9rpep6>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"530\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/QV9rpep6> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 37\" .\r\n<https://id.parliament.uk/QV9rpep6>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/FrRQLlKT>
+        .\r\n<https://id.parliament.uk/QV9rpep6> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/i5LP8krv> .\r\n<https://id.parliament.uk/FrRQLlKT>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/FrRQLlKT> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-27+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/FrRQLlKT>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/NDZSYjeE>
+        .\r\n<https://id.parliament.uk/NDZSYjeE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Group> .\r\n<https://id.parliament.uk/NDZSYjeE>
+        <https://id.parliament.uk/schema/groupName> \"groupName - 13\" .\r\n<https://id.parliament.uk/i5LP8krv>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/i5LP8krv> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/1fStCnaK>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/1fStCnaK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/1fStCnaK>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/1fStCnaK> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 38\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/1fStCnaK> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 38\" .\r\n<https://id.parliament.uk/1fStCnaK>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"633\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/1fStCnaK> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 38\" .\r\n<https://id.parliament.uk/1fStCnaK>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/gnxq0RIe>
+        .\r\n<https://id.parliament.uk/1fStCnaK> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/ku4HUUqp> .\r\n<https://id.parliament.uk/gnxq0RIe>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/gnxq0RIe> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-16+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/gnxq0RIe>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/HYfypSOE>
+        .\r\n<https://id.parliament.uk/ku4HUUqp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/ku4HUUqp>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/PqyD6lfd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/PqyD6lfd>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/PqyD6lfd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/PqyD6lfd>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 39\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/PqyD6lfd>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 39\" .\r\n<https://id.parliament.uk/PqyD6lfd> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"479\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/PqyD6lfd>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 39\" .\r\n<https://id.parliament.uk/PqyD6lfd> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/EbKNmOQl> .\r\n<https://id.parliament.uk/PqyD6lfd>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/uBG5MdZZ>
+        .\r\n<https://id.parliament.uk/EbKNmOQl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/EbKNmOQl>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-16+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/EbKNmOQl> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/BRTNQywN> .\r\n<https://id.parliament.uk/uBG5MdZZ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/uBG5MdZZ> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/FXiTnP7V>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/FXiTnP7V> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/FXiTnP7V>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/FXiTnP7V> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 40\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/FXiTnP7V> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 40\" .\r\n<https://id.parliament.uk/FXiTnP7V>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"511\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/FXiTnP7V> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 40\" .\r\n<https://id.parliament.uk/FXiTnP7V>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/B1ZazNey>
+        .\r\n<https://id.parliament.uk/FXiTnP7V> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/JsU0fHFW> .\r\n<https://id.parliament.uk/B1ZazNey>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/B1ZazNey> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/B1ZazNey>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/79sn5e3n>
+        .\r\n<https://id.parliament.uk/JsU0fHFW> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/JsU0fHFW>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/Y70OJpm2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/Y70OJpm2>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/Y70OJpm2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/Y70OJpm2>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 41\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/Y70OJpm2>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 41\" .\r\n<https://id.parliament.uk/Y70OJpm2> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 41\" .\r\n<https://id.parliament.uk/Y70OJpm2>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/qqCvPYtF>
+        .\r\n<https://id.parliament.uk/Y70OJpm2> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/0zyGzme2> .\r\n<https://id.parliament.uk/qqCvPYtF>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/qqCvPYtF> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-01+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/qqCvPYtF>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/eup4DwE5>
+        .\r\n<https://id.parliament.uk/0zyGzme2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/0zyGzme2>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/gTgidljI>
+        .\r\n<https://id.parliament.uk/LxPDdl92> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/LxPDdl92>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/LxPDdl92> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/LxPDdl92>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 42\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/LxPDdl92>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 42\" .\r\n<https://id.parliament.uk/LxPDdl92> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"506\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/LxPDdl92>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 42\" .\r\n<https://id.parliament.uk/LxPDdl92> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/HAkdtnsW> .\r\n<https://id.parliament.uk/LxPDdl92>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/JJ45Soew>
+        .\r\n<https://id.parliament.uk/HAkdtnsW> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/HAkdtnsW>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-20+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/HAkdtnsW> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/ZU3IXBtP> .\r\n<https://id.parliament.uk/JJ45Soew>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/JJ45Soew> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/HJ7BlYte>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/HJ7BlYte> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/HJ7BlYte>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/HJ7BlYte> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 43\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/HJ7BlYte> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 43\" .\r\n<https://id.parliament.uk/HJ7BlYte>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"560\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/HJ7BlYte> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 43\" .\r\n<https://id.parliament.uk/HJ7BlYte>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/p064wsz5>
+        .\r\n<https://id.parliament.uk/HJ7BlYte> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/E5XlAFS8> .\r\n<https://id.parliament.uk/p064wsz5>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/p064wsz5> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-08+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/p064wsz5>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/NDZSYjeE>
+        .\r\n<https://id.parliament.uk/E5XlAFS8> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/E5XlAFS8>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/Ly5VtVqc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/Ly5VtVqc>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/Ly5VtVqc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/Ly5VtVqc>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 44\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/Ly5VtVqc>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 44\" .\r\n<https://id.parliament.uk/Ly5VtVqc> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"465\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/Ly5VtVqc>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 44\" .\r\n<https://id.parliament.uk/Ly5VtVqc> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/AqPd0Iyl> .\r\n<https://id.parliament.uk/Ly5VtVqc>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/y5Pki10i>
+        .\r\n<https://id.parliament.uk/AqPd0Iyl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/AqPd0Iyl>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/AqPd0Iyl> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/7dSvuueH> .\r\n<https://id.parliament.uk/y5Pki10i>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/y5Pki10i> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/T3N7uNwm>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/T3N7uNwm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/T3N7uNwm>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/T3N7uNwm> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 45\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/T3N7uNwm> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 45\" .\r\n<https://id.parliament.uk/T3N7uNwm>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"539\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/T3N7uNwm> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 45\" .\r\n<https://id.parliament.uk/T3N7uNwm>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/fVAUVm37>
+        .\r\n<https://id.parliament.uk/T3N7uNwm> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/cfS0QBck> .\r\n<https://id.parliament.uk/fVAUVm37>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/fVAUVm37> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-30+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/fVAUVm37>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/HYfypSOE>
+        .\r\n<https://id.parliament.uk/cfS0QBck> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/cfS0QBck>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/5trFJNih> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/5trFJNih>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/5trFJNih> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/5trFJNih>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 46\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/5trFJNih>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 46\" .\r\n<https://id.parliament.uk/5trFJNih> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"509\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/5trFJNih>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 46\" .\r\n<https://id.parliament.uk/5trFJNih> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/PSi2j23h> .\r\n<https://id.parliament.uk/5trFJNih>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/rlJaCEwJ>
+        .\r\n<https://id.parliament.uk/PSi2j23h> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/PSi2j23h>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/PSi2j23h> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/BRTNQywN> .\r\n<https://id.parliament.uk/rlJaCEwJ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/rlJaCEwJ> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/z0dWm7t5>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/z0dWm7t5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/z0dWm7t5>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/z0dWm7t5> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 47\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/z0dWm7t5> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 47\" .\r\n<https://id.parliament.uk/z0dWm7t5>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"490\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/z0dWm7t5> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 47\" .\r\n<https://id.parliament.uk/z0dWm7t5>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/BPlGOTOt>
+        .\r\n<https://id.parliament.uk/z0dWm7t5> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/vJoUN8Af> .\r\n<https://id.parliament.uk/BPlGOTOt>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/BPlGOTOt> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-18+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/BPlGOTOt>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/HYfypSOE>
+        .\r\n<https://id.parliament.uk/vJoUN8Af> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/vJoUN8Af>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/98FJSLox> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/98FJSLox>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/98FJSLox> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/98FJSLox>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 48\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/98FJSLox>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 48\" .\r\n<https://id.parliament.uk/98FJSLox> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 48\" .\r\n<https://id.parliament.uk/98FJSLox>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/iikpYh7G>
+        .\r\n<https://id.parliament.uk/98FJSLox> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/Gcba35Qd> .\r\n<https://id.parliament.uk/iikpYh7G>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/iikpYh7G> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-08+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/iikpYh7G>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/XbTBTDMo>
+        .\r\n<https://id.parliament.uk/Gcba35Qd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/Gcba35Qd>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/3dAYwLoB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/3dAYwLoB>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/3dAYwLoB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/3dAYwLoB>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 49\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/3dAYwLoB>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 49\" .\r\n<https://id.parliament.uk/3dAYwLoB> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"451\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/3dAYwLoB>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 49\" .\r\n<https://id.parliament.uk/3dAYwLoB> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/ZQsu6c18> .\r\n<https://id.parliament.uk/3dAYwLoB>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/DRTwwjtS>
+        .\r\n<https://id.parliament.uk/ZQsu6c18> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/ZQsu6c18>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-03+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/ZQsu6c18> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/NDZSYjeE> .\r\n<https://id.parliament.uk/DRTwwjtS>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/DRTwwjtS> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/eD6E73Ne>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/eD6E73Ne> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/eD6E73Ne>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/eD6E73Ne> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 50\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/eD6E73Ne> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 50\" .\r\n<https://id.parliament.uk/eD6E73Ne>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"540\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/eD6E73Ne> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 50\" .\r\n<https://id.parliament.uk/eD6E73Ne>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/VHI2llf1>
+        .\r\n<https://id.parliament.uk/eD6E73Ne> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/9Zgnj98t> .\r\n<https://id.parliament.uk/VHI2llf1>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/VHI2llf1> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-30+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/VHI2llf1>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/BRTNQywN>
+        .\r\n<https://id.parliament.uk/9Zgnj98t> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/9Zgnj98t>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/TuBqZl6z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/TuBqZl6z>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/TuBqZl6z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/TuBqZl6z>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 51\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/TuBqZl6z>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 51\" .\r\n<https://id.parliament.uk/TuBqZl6z> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"798\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/TuBqZl6z>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 51\" .\r\n<https://id.parliament.uk/TuBqZl6z> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/40fYpO9c> .\r\n<https://id.parliament.uk/TuBqZl6z>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/k5jw9Nhv>
+        .\r\n<https://id.parliament.uk/40fYpO9c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/40fYpO9c>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-24+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/40fYpO9c> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/yiuTaSI4> .\r\n<https://id.parliament.uk/k5jw9Nhv>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/k5jw9Nhv> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/5U4yBcY4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/5U4yBcY4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/5U4yBcY4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/5U4yBcY4> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 52\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/5U4yBcY4> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 52\" .\r\n<https://id.parliament.uk/5U4yBcY4>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"121\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/5U4yBcY4> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 52\" .\r\n<https://id.parliament.uk/5U4yBcY4>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/sPjZPCb0>
+        .\r\n<https://id.parliament.uk/5U4yBcY4> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/0ifq7ERi> .\r\n<https://id.parliament.uk/sPjZPCb0>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/sPjZPCb0> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-17+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/sPjZPCb0>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/XbTBTDMo>
+        .\r\n<https://id.parliament.uk/0ifq7ERi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/0ifq7ERi>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/dNxWbKuU> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/dNxWbKuU>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/dNxWbKuU> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/dNxWbKuU>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 53\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/dNxWbKuU>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 53\" .\r\n<https://id.parliament.uk/dNxWbKuU> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"607\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/dNxWbKuU>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 53\" .\r\n<https://id.parliament.uk/dNxWbKuU> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/E5mpMWcg> .\r\n<https://id.parliament.uk/dNxWbKuU>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/yuPpm1jw>
+        .\r\n<https://id.parliament.uk/E5mpMWcg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/E5mpMWcg>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/E5mpMWcg> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/7dSvuueH> .\r\n<https://id.parliament.uk/yuPpm1jw>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/yuPpm1jw> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/rjzMGG28>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/rjzMGG28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/rjzMGG28>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/rjzMGG28> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 54\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/rjzMGG28> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 54\" .\r\n<https://id.parliament.uk/rjzMGG28>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"829\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/rjzMGG28> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 54\" .\r\n<https://id.parliament.uk/rjzMGG28>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/rWaK4CZm>
+        .\r\n<https://id.parliament.uk/rjzMGG28> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/wMkdwlCh> .\r\n<https://id.parliament.uk/rWaK4CZm>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/rWaK4CZm> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-21+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/rWaK4CZm>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/NDZSYjeE>
+        .\r\n<https://id.parliament.uk/wMkdwlCh> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/wMkdwlCh>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/9PfnbabC> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/9PfnbabC>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/9PfnbabC> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/9PfnbabC>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 55\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/9PfnbabC>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 55\" .\r\n<https://id.parliament.uk/9PfnbabC> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"592\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/9PfnbabC>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 55\" .\r\n<https://id.parliament.uk/9PfnbabC> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/4ckl6Ecn> .\r\n<https://id.parliament.uk/9PfnbabC>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/Ix8dPawU>
+        .\r\n<https://id.parliament.uk/4ckl6Ecn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/4ckl6Ecn>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-16+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/4ckl6Ecn> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XouN12Ow> .\r\n<https://id.parliament.uk/Ix8dPawU>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/Ix8dPawU> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/uNiGNHey>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/uNiGNHey> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/uNiGNHey>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/uNiGNHey> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 56\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/uNiGNHey> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 56\" .\r\n<https://id.parliament.uk/uNiGNHey>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"618\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/uNiGNHey> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 56\" .\r\n<https://id.parliament.uk/uNiGNHey>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/8nTtARxa>
+        .\r\n<https://id.parliament.uk/uNiGNHey> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/A3hB6Aj4> .\r\n<https://id.parliament.uk/8nTtARxa>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/8nTtARxa> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-24+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/8nTtARxa>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/NDZSYjeE>
+        .\r\n<https://id.parliament.uk/A3hB6Aj4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/A3hB6Aj4>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/LFLdzMuO> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/LFLdzMuO>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/LFLdzMuO> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/LFLdzMuO>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 57\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/LFLdzMuO>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 57\" .\r\n<https://id.parliament.uk/LFLdzMuO> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"593\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/LFLdzMuO>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 57\" .\r\n<https://id.parliament.uk/LFLdzMuO> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/2i869NR9> .\r\n<https://id.parliament.uk/LFLdzMuO>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/lq49zoKs>
+        .\r\n<https://id.parliament.uk/2i869NR9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/2i869NR9>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-14+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/2i869NR9> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/yiuTaSI4> .\r\n<https://id.parliament.uk/lq49zoKs>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/lq49zoKs> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/lh2dYuHD>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/lh2dYuHD> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/lh2dYuHD>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/lh2dYuHD> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 58\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/lh2dYuHD> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 58\" .\r\n<https://id.parliament.uk/lh2dYuHD>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"599\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/lh2dYuHD> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 58\" .\r\n<https://id.parliament.uk/lh2dYuHD>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/F6QnrHlj>
+        .\r\n<https://id.parliament.uk/lh2dYuHD> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/jvQpwIVt> .\r\n<https://id.parliament.uk/F6QnrHlj>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/F6QnrHlj> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-21+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/F6QnrHlj>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/7dSvuueH>
+        .\r\n<https://id.parliament.uk/jvQpwIVt> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/jvQpwIVt>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/8HUWJm9e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/8HUWJm9e>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/8HUWJm9e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/8HUWJm9e>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 59\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/8HUWJm9e>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 59\" .\r\n<https://id.parliament.uk/8HUWJm9e> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"598\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/8HUWJm9e>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 59\" .\r\n<https://id.parliament.uk/8HUWJm9e> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/S0ebryc4> .\r\n<https://id.parliament.uk/8HUWJm9e>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/0A9lArUa>
+        .\r\n<https://id.parliament.uk/S0ebryc4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/S0ebryc4>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-18+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/S0ebryc4> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/NDZSYjeE> .\r\n<https://id.parliament.uk/0A9lArUa>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/0A9lArUa> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/BdanAxAh>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/BdanAxAh> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/BdanAxAh>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/BdanAxAh> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 60\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/BdanAxAh> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 60\" .\r\n<https://id.parliament.uk/BdanAxAh>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"635\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/BdanAxAh> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 60\" .\r\n<https://id.parliament.uk/BdanAxAh>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/5fbXtiCF>
+        .\r\n<https://id.parliament.uk/BdanAxAh> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/TvrrHZTL> .\r\n<https://id.parliament.uk/5fbXtiCF>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/5fbXtiCF> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-29+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/5fbXtiCF>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/yiuTaSI4>
+        .\r\n<https://id.parliament.uk/TvrrHZTL> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/TvrrHZTL>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/bUEOr4ad> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/bUEOr4ad>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/bUEOr4ad> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/bUEOr4ad>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 61\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/bUEOr4ad>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 61\" .\r\n<https://id.parliament.uk/bUEOr4ad> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"597\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/bUEOr4ad>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 61\" .\r\n<https://id.parliament.uk/bUEOr4ad> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/WX7uzApY> .\r\n<https://id.parliament.uk/bUEOr4ad>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/Xd5yfp3V>
+        .\r\n<https://id.parliament.uk/WX7uzApY> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/WX7uzApY>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-18+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/WX7uzApY> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/yiuTaSI4> .\r\n<https://id.parliament.uk/Xd5yfp3V>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/Xd5yfp3V> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/Q2dC6z5O>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/Q2dC6z5O> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/Q2dC6z5O>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/Q2dC6z5O> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 62\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/Q2dC6z5O> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 62\" .\r\n<https://id.parliament.uk/Q2dC6z5O>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"591\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/Q2dC6z5O> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 62\" .\r\n<https://id.parliament.uk/Q2dC6z5O>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/5QMvNHCV>
+        .\r\n<https://id.parliament.uk/Q2dC6z5O> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/26Y9ftes> .\r\n<https://id.parliament.uk/5QMvNHCV>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/5QMvNHCV> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-14+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/5QMvNHCV>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/5LQ5Ar74>
+        .\r\n<https://id.parliament.uk/26Y9ftes> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/26Y9ftes>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/RcGToJSJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/RcGToJSJ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/RcGToJSJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/RcGToJSJ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 63\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/RcGToJSJ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 63\" .\r\n<https://id.parliament.uk/RcGToJSJ> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"629\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/RcGToJSJ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 63\" .\r\n<https://id.parliament.uk/RcGToJSJ> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/4DXV4KGc> .\r\n<https://id.parliament.uk/RcGToJSJ>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/cWSEaAzA>
+        .\r\n<https://id.parliament.uk/4DXV4KGc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/4DXV4KGc>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-24+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/4DXV4KGc> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/ZU3IXBtP> .\r\n<https://id.parliament.uk/cWSEaAzA>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/cWSEaAzA> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/YOVMhcqy>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/YOVMhcqy> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/YOVMhcqy>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/YOVMhcqy> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 64\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/YOVMhcqy> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 64\" .\r\n<https://id.parliament.uk/YOVMhcqy>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"647\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/YOVMhcqy> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 64\" .\r\n<https://id.parliament.uk/YOVMhcqy>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/uJMNrUDs>
+        .\r\n<https://id.parliament.uk/YOVMhcqy> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/K83vusrm> .\r\n<https://id.parliament.uk/uJMNrUDs>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/uJMNrUDs> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-30+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/uJMNrUDs>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/kv2Qqfn9>
+        .\r\n<https://id.parliament.uk/kv2Qqfn9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Group> .\r\n<https://id.parliament.uk/kv2Qqfn9>
+        <https://id.parliament.uk/schema/groupName> \"groupName - 14\" .\r\n<https://id.parliament.uk/K83vusrm>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/K83vusrm> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/5pJMwiMT>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/5pJMwiMT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/5pJMwiMT>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/5pJMwiMT> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 65\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/5pJMwiMT> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 65\" .\r\n<https://id.parliament.uk/5pJMwiMT>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"643\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/5pJMwiMT> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 65\" .\r\n<https://id.parliament.uk/5pJMwiMT>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/zTdUgdFx>
+        .\r\n<https://id.parliament.uk/5pJMwiMT> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/t070fIUe> .\r\n<https://id.parliament.uk/zTdUgdFx>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/zTdUgdFx> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-25+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/zTdUgdFx>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/5LQ5Ar74>
+        .\r\n<https://id.parliament.uk/t070fIUe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/t070fIUe>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/ZIUjUqOY> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/ZIUjUqOY>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/ZIUjUqOY> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/ZIUjUqOY>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 66\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/ZIUjUqOY>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 66\" .\r\n<https://id.parliament.uk/ZIUjUqOY> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"912\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/ZIUjUqOY>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 66\" .\r\n<https://id.parliament.uk/ZIUjUqOY> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/vgTfN5KX> .\r\n<https://id.parliament.uk/ZIUjUqOY>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/imgmtCq9>
+        .\r\n<https://id.parliament.uk/vgTfN5KX> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/vgTfN5KX>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-17+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/vgTfN5KX> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/7gnSwbLO> .\r\n<https://id.parliament.uk/imgmtCq9>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/imgmtCq9> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/ijAPvpBd>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/ijAPvpBd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/ijAPvpBd>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/ijAPvpBd> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 67\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/ijAPvpBd> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 67\" .\r\n<https://id.parliament.uk/ijAPvpBd>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"888\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/ijAPvpBd> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 67\" .\r\n<https://id.parliament.uk/ijAPvpBd>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/26Qu3wQF>
+        .\r\n<https://id.parliament.uk/ijAPvpBd> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/2hbUBGLm> .\r\n<https://id.parliament.uk/26Qu3wQF>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/26Qu3wQF> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-21+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/26Qu3wQF>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/7gnSwbLO>
+        .\r\n<https://id.parliament.uk/2hbUBGLm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/2hbUBGLm>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/4EdTvost> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/4EdTvost>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/4EdTvost> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/4EdTvost>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 68\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/4EdTvost>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 68\" .\r\n<https://id.parliament.uk/4EdTvost> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"664\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/4EdTvost>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 68\" .\r\n<https://id.parliament.uk/4EdTvost> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/lmZu2cSE> .\r\n<https://id.parliament.uk/4EdTvost>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/Th3KBYE1>
+        .\r\n<https://id.parliament.uk/lmZu2cSE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/lmZu2cSE>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-01+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/lmZu2cSE> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/5LQ5Ar74> .\r\n<https://id.parliament.uk/Th3KBYE1>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/Th3KBYE1> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/v2fDLDBe>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/v2fDLDBe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/v2fDLDBe>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/v2fDLDBe> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 69\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/v2fDLDBe> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 69\" .\r\n<https://id.parliament.uk/v2fDLDBe>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"879\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/v2fDLDBe> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 69\" .\r\n<https://id.parliament.uk/v2fDLDBe>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/dFKcNjk8>
+        .\r\n<https://id.parliament.uk/v2fDLDBe> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/F1z92xaj> .\r\n<https://id.parliament.uk/dFKcNjk8>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/dFKcNjk8> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/dFKcNjk8>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/fKqMNz79>
+        .\r\n<https://id.parliament.uk/F1z92xaj> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/F1z92xaj>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n"
+    http_version: 
+  recorded_at: Thu, 25 Oct 2018 10:39:07 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/GroupSortHelper/with_real_data/_sort/sorts_the_data_correctly.yml
+++ b/spec/fixtures/vcr_cassettes/GroupSortHelper/with_real_data/_sort/sorts_the_data_correctly.yml
@@ -1,0 +1,6755 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3030/statutory_instrument_index
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      - application/n-triples
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '40684'
+      Content-Type:
+      - application/n-triples
+      Expires:
+      - Thu, 25 Oct 2018 11:24:20 GMT
+      Request-Context:
+      - appId=cid-v1:330aa411-57af-491f-b22a-1cab7d08a6a9
+      Access-Control-Expose-Headers:
+      - Request-Context
+      Set-Cookie:
+      - ARRAffinity=77b2b22b62b6e0d158b9023c2ed0c9ea4be870072240a45c1bef0e3480502c58;Path=/;HttpOnly;Domain=fixedquery201810051005.azurewebsites.net
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Thu, 25 Oct 2018 11:24:19 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "<https://id.parliament.uk/QmvfCS3N> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/QmvfCS3N>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/QmvfCS3N> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/QmvfCS3N>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 1\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/QmvfCS3N>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 1\" .\r\n<https://id.parliament.uk/QmvfCS3N> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"751\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/QmvfCS3N>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 1\" .\r\n<https://id.parliament.uk/QmvfCS3N> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/Mcvmer52> .\r\n<https://id.parliament.uk/QmvfCS3N>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/tVWVmTCL>
+        .\r\n<https://id.parliament.uk/Mcvmer52> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/Mcvmer52>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-03+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/Mcvmer52> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fKqMNz79> .\r\n<https://id.parliament.uk/fKqMNz79>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Group>
+        .\r\n<https://id.parliament.uk/fKqMNz79> <https://id.parliament.uk/schema/groupName>
+        \"groupName - 1\" .\r\n<https://id.parliament.uk/tVWVmTCL> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/tVWVmTCL>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/H5YJQsK2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Procedure> .\r\n<https://id.parliament.uk/H5YJQsK2>
+        <https://id.parliament.uk/schema/procedureName> \"procedureName - 1\" .\r\n<https://id.parliament.uk/keUmDe6y>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/keUmDe6y> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/keUmDe6y>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/keUmDe6y> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 2\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/keUmDe6y> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 2\" .\r\n<https://id.parliament.uk/keUmDe6y>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"517\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/keUmDe6y> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 2\" .\r\n<https://id.parliament.uk/keUmDe6y>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/qaT30ffk>
+        .\r\n<https://id.parliament.uk/keUmDe6y> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/e8079KjV> .\r\n<https://id.parliament.uk/qaT30ffk>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/qaT30ffk> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-27+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/qaT30ffk>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/7dSvuueH>
+        .\r\n<https://id.parliament.uk/7dSvuueH> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Group> .\r\n<https://id.parliament.uk/7dSvuueH>
+        <https://id.parliament.uk/schema/groupName> \"groupName - 2\" .\r\n<https://id.parliament.uk/e8079KjV>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/e8079KjV> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/5S6p4YsP>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Procedure>
+        .\r\n<https://id.parliament.uk/5S6p4YsP> <https://id.parliament.uk/schema/procedureName>
+        \"procedureName - 2\" .\r\n<https://id.parliament.uk/R63aWjPi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/R63aWjPi>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/R63aWjPi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/R63aWjPi>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 3\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/R63aWjPi>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 3\" .\r\n<https://id.parliament.uk/R63aWjPi> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"566\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/R63aWjPi>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 3\" .\r\n<https://id.parliament.uk/R63aWjPi> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/NPExPXay> .\r\n<https://id.parliament.uk/R63aWjPi>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/lon9Uu05>
+        .\r\n<https://id.parliament.uk/NPExPXay> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/NPExPXay>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-08+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/NPExPXay> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fKqMNz79> .\r\n<https://id.parliament.uk/lon9Uu05>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/lon9Uu05> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/W0xWx2Iu>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/W0xWx2Iu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/W0xWx2Iu>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/W0xWx2Iu> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 4\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/W0xWx2Iu> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 4\" .\r\n<https://id.parliament.uk/W0xWx2Iu>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"498\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/W0xWx2Iu> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 4\" .\r\n<https://id.parliament.uk/W0xWx2Iu>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/QzUSqeLr>
+        .\r\n<https://id.parliament.uk/W0xWx2Iu> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/9XxmwGtU> .\r\n<https://id.parliament.uk/QzUSqeLr>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/QzUSqeLr> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-20+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/QzUSqeLr>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/BRTNQywN>
+        .\r\n<https://id.parliament.uk/BRTNQywN> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Group> .\r\n<https://id.parliament.uk/BRTNQywN>
+        <https://id.parliament.uk/schema/groupName> \"groupName - 3\" .\r\n<https://id.parliament.uk/9XxmwGtU>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/9XxmwGtU> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/On2R0Zeb>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/On2R0Zeb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/On2R0Zeb>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/On2R0Zeb> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 5\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/On2R0Zeb> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 5\" .\r\n<https://id.parliament.uk/On2R0Zeb>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"466\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/On2R0Zeb> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 5\" .\r\n<https://id.parliament.uk/On2R0Zeb>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/TQQt5wkr>
+        .\r\n<https://id.parliament.uk/On2R0Zeb> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/40Yq0PnR> .\r\n<https://id.parliament.uk/TQQt5wkr>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/TQQt5wkr> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/TQQt5wkr>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/7dSvuueH>
+        .\r\n<https://id.parliament.uk/40Yq0PnR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/40Yq0PnR>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/yxN0RDlj> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/yxN0RDlj>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/yxN0RDlj> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/yxN0RDlj>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 6\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/yxN0RDlj>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 6\" .\r\n<https://id.parliament.uk/yxN0RDlj> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"553\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/yxN0RDlj>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 6\" .\r\n<https://id.parliament.uk/yxN0RDlj> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/3ZbbcnKj> .\r\n<https://id.parliament.uk/yxN0RDlj>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/PjQFqiyZ>
+        .\r\n<https://id.parliament.uk/3ZbbcnKj> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/3ZbbcnKj>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-03+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/3ZbbcnKj> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fKqMNz79> .\r\n<https://id.parliament.uk/PjQFqiyZ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/PjQFqiyZ> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/tPkKG8ef>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/tPkKG8ef> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/tPkKG8ef>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/tPkKG8ef> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 7\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/tPkKG8ef> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 7\" .\r\n<https://id.parliament.uk/tPkKG8ef>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"549\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/tPkKG8ef> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 7\" .\r\n<https://id.parliament.uk/tPkKG8ef>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/uprc8alP>
+        .\r\n<https://id.parliament.uk/tPkKG8ef> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/9bXhF8oV> .\r\n<https://id.parliament.uk/uprc8alP>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/uprc8alP> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-01+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/uprc8alP>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/BRTNQywN>
+        .\r\n<https://id.parliament.uk/9bXhF8oV> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/9bXhF8oV>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/9PuVurua> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/9PuVurua>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/9PuVurua> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/9PuVurua>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 8\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/9PuVurua>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 8\" .\r\n<https://id.parliament.uk/9PuVurua> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"538\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/9PuVurua>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 8\" .\r\n<https://id.parliament.uk/9PuVurua> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/2iDuQtrK> .\r\n<https://id.parliament.uk/9PuVurua>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/zhi6ZHnQ>
+        .\r\n<https://id.parliament.uk/2iDuQtrK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/2iDuQtrK>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-30+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/2iDuQtrK> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/79sn5e3n> .\r\n<https://id.parliament.uk/79sn5e3n>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Group>
+        .\r\n<https://id.parliament.uk/79sn5e3n> <https://id.parliament.uk/schema/groupName>
+        \"groupName - 4\" .\r\n<https://id.parliament.uk/zhi6ZHnQ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/zhi6ZHnQ>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/ITuNnxmw> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/ITuNnxmw>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/ITuNnxmw> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/ITuNnxmw>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 9\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/ITuNnxmw>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 9\" .\r\n<https://id.parliament.uk/ITuNnxmw> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"797\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/ITuNnxmw>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 9\" .\r\n<https://id.parliament.uk/ITuNnxmw> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/1AR7f0NW> .\r\n<https://id.parliament.uk/ITuNnxmw>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/PsB0pq0l>
+        .\r\n<https://id.parliament.uk/1AR7f0NW> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/1AR7f0NW>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-30+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/1AR7f0NW> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/yiuTaSI4> .\r\n<https://id.parliament.uk/yiuTaSI4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Group>
+        .\r\n<https://id.parliament.uk/yiuTaSI4> <https://id.parliament.uk/schema/groupName>
+        \"groupName - 5\" .\r\n<https://id.parliament.uk/PsB0pq0l> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/PsB0pq0l>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/bS94erG6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/bS94erG6>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/bS94erG6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/bS94erG6>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 10\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/bS94erG6>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 10\" .\r\n<https://id.parliament.uk/bS94erG6> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"587\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/bS94erG6>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 10\" .\r\n<https://id.parliament.uk/bS94erG6> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/NagVnt8h> .\r\n<https://id.parliament.uk/bS94erG6>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/I4duwcuB>
+        .\r\n<https://id.parliament.uk/NagVnt8h> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/NagVnt8h>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-11+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/NagVnt8h> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/BRTNQywN> .\r\n<https://id.parliament.uk/I4duwcuB>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/I4duwcuB> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/upP2FHa4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/upP2FHa4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/upP2FHa4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/upP2FHa4> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 11\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/upP2FHa4> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 11\" .\r\n<https://id.parliament.uk/upP2FHa4>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"575\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/upP2FHa4> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 11\" .\r\n<https://id.parliament.uk/upP2FHa4>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/cfbEYJ86>
+        .\r\n<https://id.parliament.uk/upP2FHa4> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/KAaIQyCC> .\r\n<https://id.parliament.uk/cfbEYJ86>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/cfbEYJ86> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-10+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/cfbEYJ86>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/5LQ5Ar74>
+        .\r\n<https://id.parliament.uk/5LQ5Ar74> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Group> .\r\n<https://id.parliament.uk/5LQ5Ar74>
+        <https://id.parliament.uk/schema/groupName> \"groupName - 6\" .\r\n<https://id.parliament.uk/KAaIQyCC>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/KAaIQyCC> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/0VJbg1Pa>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/0VJbg1Pa> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/0VJbg1Pa>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/0VJbg1Pa> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 12\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/0VJbg1Pa> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 12\" .\r\n<https://id.parliament.uk/0VJbg1Pa>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"485\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/0VJbg1Pa> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 12\" .\r\n<https://id.parliament.uk/0VJbg1Pa>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/auOf4Epa>
+        .\r\n<https://id.parliament.uk/auOf4Epa> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/auOf4Epa>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/XnLvIexa> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/XnLvIexa>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/XnLvIexa> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/XnLvIexa>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 13\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/XnLvIexa>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 13\" .\r\n<https://id.parliament.uk/XnLvIexa> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"472\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/XnLvIexa>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 13\" .\r\n<https://id.parliament.uk/XnLvIexa> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/f9w5NpTb> .\r\n<https://id.parliament.uk/XnLvIexa>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/WmlTLQiJ>
+        .\r\n<https://id.parliament.uk/f9w5NpTb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/f9w5NpTb>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-13+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/f9w5NpTb> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/7dSvuueH> .\r\n<https://id.parliament.uk/WmlTLQiJ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/WmlTLQiJ> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/GOOyVBR4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/GOOyVBR4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/GOOyVBR4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/GOOyVBR4> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 14\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/GOOyVBR4> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 14\" .\r\n<https://id.parliament.uk/GOOyVBR4>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"831\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/GOOyVBR4> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 14\" .\r\n<https://id.parliament.uk/GOOyVBR4>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/v6kwIWtt>
+        .\r\n<https://id.parliament.uk/GOOyVBR4> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/zJLB2rbN> .\r\n<https://id.parliament.uk/v6kwIWtt>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/v6kwIWtt> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-09+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/v6kwIWtt>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/HYfypSOE>
+        .\r\n<https://id.parliament.uk/HYfypSOE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Group> .\r\n<https://id.parliament.uk/HYfypSOE>
+        <https://id.parliament.uk/schema/groupName> \"groupName - 7\" .\r\n<https://id.parliament.uk/zJLB2rbN>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/zJLB2rbN> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/8I8GntKQ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/8I8GntKQ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/8I8GntKQ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/8I8GntKQ> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 15\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/8I8GntKQ> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 15\" .\r\n<https://id.parliament.uk/8I8GntKQ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"537\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/8I8GntKQ> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 15\" .\r\n<https://id.parliament.uk/8I8GntKQ>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/3dED0LgI>
+        .\r\n<https://id.parliament.uk/8I8GntKQ> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/PwLQp4Rk> .\r\n<https://id.parliament.uk/3dED0LgI>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/3dED0LgI> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-30+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/3dED0LgI>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/7gnSwbLO>
+        .\r\n<https://id.parliament.uk/7gnSwbLO> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Group> .\r\n<https://id.parliament.uk/7gnSwbLO>
+        <https://id.parliament.uk/schema/groupName> \"groupName - 8\" .\r\n<https://id.parliament.uk/PwLQp4Rk>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/PwLQp4Rk> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/Tw34pUb3>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/Tw34pUb3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/Tw34pUb3>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/Tw34pUb3> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 16\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/Tw34pUb3> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 16\" .\r\n<https://id.parliament.uk/Tw34pUb3>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"546\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/Tw34pUb3> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 16\" .\r\n<https://id.parliament.uk/Tw34pUb3>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/QRLFhjUD>
+        .\r\n<https://id.parliament.uk/Tw34pUb3> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/F3ClsH20> .\r\n<https://id.parliament.uk/QRLFhjUD>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/QRLFhjUD> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-01+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/QRLFhjUD>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/HYfypSOE>
+        .\r\n<https://id.parliament.uk/F3ClsH20> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/F3ClsH20>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/rAkViDvo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/rAkViDvo>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/rAkViDvo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/rAkViDvo>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 17\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/rAkViDvo>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 17\" .\r\n<https://id.parliament.uk/rAkViDvo> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"800\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/rAkViDvo>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 17\" .\r\n<https://id.parliament.uk/rAkViDvo> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/AtyGfoYi> .\r\n<https://id.parliament.uk/rAkViDvo>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/c8P8nJgq>
+        .\r\n<https://id.parliament.uk/AtyGfoYi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/AtyGfoYi>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/AtyGfoYi> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/yiuTaSI4> .\r\n<https://id.parliament.uk/c8P8nJgq>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/c8P8nJgq> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/FCcBOrUo>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/FCcBOrUo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/FCcBOrUo>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/FCcBOrUo> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 18\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/FCcBOrUo> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 18\" .\r\n<https://id.parliament.uk/FCcBOrUo>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"510\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/FCcBOrUo> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 18\" .\r\n<https://id.parliament.uk/FCcBOrUo>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/Nhuev5Ry>
+        .\r\n<https://id.parliament.uk/FCcBOrUo> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/Ic57bsvz> .\r\n<https://id.parliament.uk/Nhuev5Ry>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/Nhuev5Ry> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/Nhuev5Ry>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/5LQ5Ar74>
+        .\r\n<https://id.parliament.uk/Ic57bsvz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/Ic57bsvz>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/tjxWFlR2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/tjxWFlR2>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/tjxWFlR2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/tjxWFlR2>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 19\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/tjxWFlR2>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 19\" .\r\n<https://id.parliament.uk/tjxWFlR2> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"541\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/tjxWFlR2>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 19\" .\r\n<https://id.parliament.uk/tjxWFlR2> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/FcPf17jF> .\r\n<https://id.parliament.uk/tjxWFlR2>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/diYZkVb4>
+        .\r\n<https://id.parliament.uk/FcPf17jF> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/FcPf17jF>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-30+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/FcPf17jF> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/BRTNQywN> .\r\n<https://id.parliament.uk/diYZkVb4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/diYZkVb4> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/e1nEbjRI>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/e1nEbjRI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/e1nEbjRI>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/e1nEbjRI> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 20\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/e1nEbjRI> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 20\" .\r\n<https://id.parliament.uk/e1nEbjRI>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"514\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/e1nEbjRI> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 20\" .\r\n<https://id.parliament.uk/e1nEbjRI>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/HkngXyxl>
+        .\r\n<https://id.parliament.uk/e1nEbjRI> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/dFnbME4A> .\r\n<https://id.parliament.uk/HkngXyxl>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/HkngXyxl> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-24+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/HkngXyxl>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/yiuTaSI4>
+        .\r\n<https://id.parliament.uk/dFnbME4A> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/dFnbME4A>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/xic2yu5i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/xic2yu5i>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/xic2yu5i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/xic2yu5i>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 21\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/xic2yu5i>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 21\" .\r\n<https://id.parliament.uk/xic2yu5i> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"488\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/xic2yu5i>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 21\" .\r\n<https://id.parliament.uk/xic2yu5i> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/c240s9cD> .\r\n<https://id.parliament.uk/xic2yu5i>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/EgDK23iB>
+        .\r\n<https://id.parliament.uk/c240s9cD> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/c240s9cD>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-20+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/c240s9cD> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XouN12Ow> .\r\n<https://id.parliament.uk/XouN12Ow>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Group>
+        .\r\n<https://id.parliament.uk/XouN12Ow> <https://id.parliament.uk/schema/groupName>
+        \"groupName - 9\" .\r\n<https://id.parliament.uk/EgDK23iB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/EgDK23iB>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/TKqREWHZ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/TKqREWHZ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/TKqREWHZ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/TKqREWHZ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 22\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/TKqREWHZ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 22\" .\r\n<https://id.parliament.uk/TKqREWHZ> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 22\" .\r\n<https://id.parliament.uk/TKqREWHZ>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/Mw7umRDD>
+        .\r\n<https://id.parliament.uk/TKqREWHZ> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/eCsYdAM3> .\r\n<https://id.parliament.uk/Mw7umRDD>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/Mw7umRDD> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-03+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/Mw7umRDD>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/fKqMNz79>
+        .\r\n<https://id.parliament.uk/eCsYdAM3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/eCsYdAM3>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/ADR23Zyx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/ADR23Zyx>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/ADR23Zyx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/ADR23Zyx>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 23\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/ADR23Zyx>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 23\" .\r\n<https://id.parliament.uk/ADR23Zyx> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"92\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/ADR23Zyx>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 23\" .\r\n<https://id.parliament.uk/ADR23Zyx> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/OSdTYDeS> .\r\n<https://id.parliament.uk/ADR23Zyx>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/EdGVZDEz>
+        .\r\n<https://id.parliament.uk/OSdTYDeS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/OSdTYDeS>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-16+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/OSdTYDeS> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XbTBTDMo> .\r\n<https://id.parliament.uk/XbTBTDMo>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Group>
+        .\r\n<https://id.parliament.uk/XbTBTDMo> <https://id.parliament.uk/schema/groupName>
+        \"groupName - 10\" .\r\n<https://id.parliament.uk/EdGVZDEz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/EdGVZDEz>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/hNQPUtRs> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/hNQPUtRs>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/hNQPUtRs> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/hNQPUtRs>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 24\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/hNQPUtRs>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 24\" .\r\n<https://id.parliament.uk/hNQPUtRs> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"735\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/hNQPUtRs>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 24\" .\r\n<https://id.parliament.uk/hNQPUtRs> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/njlVbk2J> .\r\n<https://id.parliament.uk/hNQPUtRs>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/W7YZ1i4T>
+        .\r\n<https://id.parliament.uk/njlVbk2J> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/njlVbk2J>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-26+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/njlVbk2J> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/ZU3IXBtP> .\r\n<https://id.parliament.uk/ZU3IXBtP>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Group>
+        .\r\n<https://id.parliament.uk/ZU3IXBtP> <https://id.parliament.uk/schema/groupName>
+        \"groupName - 11\" .\r\n<https://id.parliament.uk/W7YZ1i4T> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/W7YZ1i4T>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/YFkBxYkE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/YFkBxYkE>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/YFkBxYkE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/YFkBxYkE>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 25\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/YFkBxYkE>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 25\" .\r\n<https://id.parliament.uk/YFkBxYkE> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"483\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/YFkBxYkE>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 25\" .\r\n<https://id.parliament.uk/YFkBxYkE> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/nrMzeLJ5> .\r\n<https://id.parliament.uk/YFkBxYkE>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/IHy5RkQv>
+        .\r\n<https://id.parliament.uk/nrMzeLJ5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/nrMzeLJ5>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-17+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/nrMzeLJ5> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/HYfypSOE> .\r\n<https://id.parliament.uk/IHy5RkQv>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/IHy5RkQv> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/k6waZgmJ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/k6waZgmJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/k6waZgmJ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/k6waZgmJ> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 26\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/k6waZgmJ> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 26\" .\r\n<https://id.parliament.uk/k6waZgmJ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"493\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/k6waZgmJ> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 26\" .\r\n<https://id.parliament.uk/k6waZgmJ>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/H3U1WIOm>
+        .\r\n<https://id.parliament.uk/k6waZgmJ> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/XDilT5Ce> .\r\n<https://id.parliament.uk/H3U1WIOm>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/H3U1WIOm> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-19+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/H3U1WIOm>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/fKqMNz79>
+        .\r\n<https://id.parliament.uk/XDilT5Ce> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/XDilT5Ce>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/O8GS8jnH> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/O8GS8jnH>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/O8GS8jnH> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/O8GS8jnH>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 27\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/O8GS8jnH>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 27\" .\r\n<https://id.parliament.uk/O8GS8jnH> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"423\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/O8GS8jnH>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 27\" .\r\n<https://id.parliament.uk/O8GS8jnH> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/KgB4r60a> .\r\n<https://id.parliament.uk/O8GS8jnH>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/QN1c7sKE>
+        .\r\n<https://id.parliament.uk/KgB4r60a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/KgB4r60a>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-03+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/KgB4r60a> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XouN12Ow> .\r\n<https://id.parliament.uk/QN1c7sKE>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/QN1c7sKE> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/WSBR9sBz>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/WSBR9sBz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/WSBR9sBz>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/WSBR9sBz> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 28\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/WSBR9sBz> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 28\" .\r\n<https://id.parliament.uk/WSBR9sBz>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 28\" .\r\n<https://id.parliament.uk/WSBR9sBz> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/SildA8v4> .\r\n<https://id.parliament.uk/WSBR9sBz>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/7qN3AkCI>
+        .\r\n<https://id.parliament.uk/SildA8v4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/SildA8v4>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-01+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/SildA8v4> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/eup4DwE5> .\r\n<https://id.parliament.uk/eup4DwE5>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Group>
+        .\r\n<https://id.parliament.uk/eup4DwE5> <https://id.parliament.uk/schema/groupName>
+        \"groupName - 12\" .\r\n<https://id.parliament.uk/7qN3AkCI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/7qN3AkCI>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/gTgidljI>
+        .\r\n<https://id.parliament.uk/gTgidljI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Procedure> .\r\n<https://id.parliament.uk/gTgidljI>
+        <https://id.parliament.uk/schema/procedureName> \"procedureName - 3\" .\r\n<https://id.parliament.uk/QbI1sir4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/QbI1sir4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/QbI1sir4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/QbI1sir4> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 29\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/QbI1sir4> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 29\" .\r\n<https://id.parliament.uk/QbI1sir4>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"832\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/QbI1sir4> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 29\" .\r\n<https://id.parliament.uk/QbI1sir4>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/xCcwgdvQ>
+        .\r\n<https://id.parliament.uk/QbI1sir4> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/bONPJ56c> .\r\n<https://id.parliament.uk/xCcwgdvQ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/xCcwgdvQ> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-30+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/xCcwgdvQ>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/HYfypSOE>
+        .\r\n<https://id.parliament.uk/bONPJ56c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/bONPJ56c>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/VIqyNL58> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/VIqyNL58>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/VIqyNL58> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/VIqyNL58>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 30\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/VIqyNL58>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 30\" .\r\n<https://id.parliament.uk/VIqyNL58> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"674\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/VIqyNL58>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 30\" .\r\n<https://id.parliament.uk/VIqyNL58> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/FvuNhGmO> .\r\n<https://id.parliament.uk/VIqyNL58>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/zlDxL3xS>
+        .\r\n<https://id.parliament.uk/FvuNhGmO> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/FvuNhGmO>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-16+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/FvuNhGmO> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/7dSvuueH> .\r\n<https://id.parliament.uk/zlDxL3xS>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/zlDxL3xS> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/AaXxxzda>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/AaXxxzda> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/AaXxxzda>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/AaXxxzda> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 31\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/AaXxxzda> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 31\" .\r\n<https://id.parliament.uk/AaXxxzda>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"406\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/AaXxxzda> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 31\" .\r\n<https://id.parliament.uk/AaXxxzda>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/Phw9bTAd>
+        .\r\n<https://id.parliament.uk/AaXxxzda> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/KGrfWbku> .\r\n<https://id.parliament.uk/Phw9bTAd>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/Phw9bTAd> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-03+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/Phw9bTAd>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/XouN12Ow>
+        .\r\n<https://id.parliament.uk/KGrfWbku> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/KGrfWbku>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/C2rRbqeQ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/C2rRbqeQ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/C2rRbqeQ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/C2rRbqeQ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 32\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/C2rRbqeQ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 32\" .\r\n<https://id.parliament.uk/C2rRbqeQ> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"482\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/C2rRbqeQ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 32\" .\r\n<https://id.parliament.uk/C2rRbqeQ> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/tSHwlzxI> .\r\n<https://id.parliament.uk/C2rRbqeQ>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/UsdZhECl>
+        .\r\n<https://id.parliament.uk/tSHwlzxI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/tSHwlzxI>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-17+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/tSHwlzxI> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/yiuTaSI4> .\r\n<https://id.parliament.uk/UsdZhECl>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/UsdZhECl> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/5urR0FTa>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/5urR0FTa> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/5urR0FTa>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/5urR0FTa> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 33\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/5urR0FTa> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 33\" .\r\n<https://id.parliament.uk/5urR0FTa>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"489\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/5urR0FTa> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 33\" .\r\n<https://id.parliament.uk/5urR0FTa>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/GydEOlpQ>
+        .\r\n<https://id.parliament.uk/5urR0FTa> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/BBNF0hzl> .\r\n<https://id.parliament.uk/GydEOlpQ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/GydEOlpQ> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-18+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/GydEOlpQ>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/BRTNQywN>
+        .\r\n<https://id.parliament.uk/BBNF0hzl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/BBNF0hzl>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/KZpExrdI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/KZpExrdI>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/KZpExrdI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/KZpExrdI>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 34\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/KZpExrdI>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 34\" .\r\n<https://id.parliament.uk/KZpExrdI> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"527\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/KZpExrdI>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 34\" .\r\n<https://id.parliament.uk/KZpExrdI> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/AvYw0KZ2> .\r\n<https://id.parliament.uk/KZpExrdI>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/K8jg57DX>
+        .\r\n<https://id.parliament.uk/AvYw0KZ2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/AvYw0KZ2>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-26+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/AvYw0KZ2> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/5LQ5Ar74> .\r\n<https://id.parliament.uk/K8jg57DX>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/K8jg57DX> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/daySypEn>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/daySypEn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/daySypEn>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/daySypEn> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 35\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/daySypEn> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 35\" .\r\n<https://id.parliament.uk/daySypEn>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"439\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/daySypEn> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 35\" .\r\n<https://id.parliament.uk/daySypEn>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/pg0TWSqT>
+        .\r\n<https://id.parliament.uk/daySypEn> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/5wUN28za> .\r\n<https://id.parliament.uk/pg0TWSqT>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/pg0TWSqT> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-03+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/pg0TWSqT>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/XouN12Ow>
+        .\r\n<https://id.parliament.uk/5wUN28za> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/5wUN28za>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/i9hQEgyv> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/i9hQEgyv>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/i9hQEgyv> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/i9hQEgyv>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 36\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/i9hQEgyv>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 36\" .\r\n<https://id.parliament.uk/i9hQEgyv> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"634\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/i9hQEgyv>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 36\" .\r\n<https://id.parliament.uk/i9hQEgyv> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/nsrSFKGl> .\r\n<https://id.parliament.uk/i9hQEgyv>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/QXHttLOh>
+        .\r\n<https://id.parliament.uk/nsrSFKGl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/nsrSFKGl>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-16+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/nsrSFKGl> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/yiuTaSI4> .\r\n<https://id.parliament.uk/QXHttLOh>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/QXHttLOh> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/QV9rpep6>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/QV9rpep6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/QV9rpep6>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/QV9rpep6> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 37\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/QV9rpep6> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 37\" .\r\n<https://id.parliament.uk/QV9rpep6>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"530\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/QV9rpep6> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 37\" .\r\n<https://id.parliament.uk/QV9rpep6>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/FrRQLlKT>
+        .\r\n<https://id.parliament.uk/QV9rpep6> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/i5LP8krv> .\r\n<https://id.parliament.uk/FrRQLlKT>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/FrRQLlKT> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-27+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/FrRQLlKT>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/NDZSYjeE>
+        .\r\n<https://id.parliament.uk/NDZSYjeE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Group> .\r\n<https://id.parliament.uk/NDZSYjeE>
+        <https://id.parliament.uk/schema/groupName> \"groupName - 13\" .\r\n<https://id.parliament.uk/i5LP8krv>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/i5LP8krv> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/1fStCnaK>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/1fStCnaK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/1fStCnaK>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/1fStCnaK> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 38\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/1fStCnaK> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 38\" .\r\n<https://id.parliament.uk/1fStCnaK>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"633\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/1fStCnaK> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 38\" .\r\n<https://id.parliament.uk/1fStCnaK>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/gnxq0RIe>
+        .\r\n<https://id.parliament.uk/1fStCnaK> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/ku4HUUqp> .\r\n<https://id.parliament.uk/gnxq0RIe>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/gnxq0RIe> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-16+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/gnxq0RIe>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/HYfypSOE>
+        .\r\n<https://id.parliament.uk/ku4HUUqp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/ku4HUUqp>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/PqyD6lfd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/PqyD6lfd>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/PqyD6lfd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/PqyD6lfd>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 39\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/PqyD6lfd>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 39\" .\r\n<https://id.parliament.uk/PqyD6lfd> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"479\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/PqyD6lfd>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 39\" .\r\n<https://id.parliament.uk/PqyD6lfd> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/EbKNmOQl> .\r\n<https://id.parliament.uk/PqyD6lfd>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/uBG5MdZZ>
+        .\r\n<https://id.parliament.uk/EbKNmOQl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/EbKNmOQl>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-16+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/EbKNmOQl> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/BRTNQywN> .\r\n<https://id.parliament.uk/uBG5MdZZ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/uBG5MdZZ> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/FXiTnP7V>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/FXiTnP7V> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/FXiTnP7V>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/FXiTnP7V> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 40\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/FXiTnP7V> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 40\" .\r\n<https://id.parliament.uk/FXiTnP7V>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"511\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/FXiTnP7V> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 40\" .\r\n<https://id.parliament.uk/FXiTnP7V>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/B1ZazNey>
+        .\r\n<https://id.parliament.uk/FXiTnP7V> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/JsU0fHFW> .\r\n<https://id.parliament.uk/B1ZazNey>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/B1ZazNey> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/B1ZazNey>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/79sn5e3n>
+        .\r\n<https://id.parliament.uk/JsU0fHFW> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/JsU0fHFW>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/Y70OJpm2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/Y70OJpm2>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/Y70OJpm2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/Y70OJpm2>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 41\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/Y70OJpm2>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 41\" .\r\n<https://id.parliament.uk/Y70OJpm2> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 41\" .\r\n<https://id.parliament.uk/Y70OJpm2>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/qqCvPYtF>
+        .\r\n<https://id.parliament.uk/Y70OJpm2> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/0zyGzme2> .\r\n<https://id.parliament.uk/qqCvPYtF>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/qqCvPYtF> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-01+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/qqCvPYtF>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/eup4DwE5>
+        .\r\n<https://id.parliament.uk/0zyGzme2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/0zyGzme2>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/gTgidljI>
+        .\r\n<https://id.parliament.uk/LxPDdl92> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/LxPDdl92>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/LxPDdl92> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/LxPDdl92>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 42\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/LxPDdl92>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 42\" .\r\n<https://id.parliament.uk/LxPDdl92> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"506\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/LxPDdl92>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 42\" .\r\n<https://id.parliament.uk/LxPDdl92> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/HAkdtnsW> .\r\n<https://id.parliament.uk/LxPDdl92>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/JJ45Soew>
+        .\r\n<https://id.parliament.uk/HAkdtnsW> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/HAkdtnsW>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-20+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/HAkdtnsW> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/ZU3IXBtP> .\r\n<https://id.parliament.uk/JJ45Soew>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/JJ45Soew> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/HJ7BlYte>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/HJ7BlYte> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/HJ7BlYte>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/HJ7BlYte> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 43\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/HJ7BlYte> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 43\" .\r\n<https://id.parliament.uk/HJ7BlYte>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"560\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/HJ7BlYte> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 43\" .\r\n<https://id.parliament.uk/HJ7BlYte>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/p064wsz5>
+        .\r\n<https://id.parliament.uk/HJ7BlYte> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/E5XlAFS8> .\r\n<https://id.parliament.uk/p064wsz5>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/p064wsz5> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-08+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/p064wsz5>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/NDZSYjeE>
+        .\r\n<https://id.parliament.uk/E5XlAFS8> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/E5XlAFS8>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/Ly5VtVqc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/Ly5VtVqc>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/Ly5VtVqc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/Ly5VtVqc>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 44\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/Ly5VtVqc>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 44\" .\r\n<https://id.parliament.uk/Ly5VtVqc> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"465\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/Ly5VtVqc>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 44\" .\r\n<https://id.parliament.uk/Ly5VtVqc> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/AqPd0Iyl> .\r\n<https://id.parliament.uk/Ly5VtVqc>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/y5Pki10i>
+        .\r\n<https://id.parliament.uk/AqPd0Iyl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/AqPd0Iyl>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/AqPd0Iyl> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/7dSvuueH> .\r\n<https://id.parliament.uk/y5Pki10i>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/y5Pki10i> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/T3N7uNwm>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/T3N7uNwm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/T3N7uNwm>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/T3N7uNwm> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 45\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/T3N7uNwm> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 45\" .\r\n<https://id.parliament.uk/T3N7uNwm>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"539\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/T3N7uNwm> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 45\" .\r\n<https://id.parliament.uk/T3N7uNwm>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/fVAUVm37>
+        .\r\n<https://id.parliament.uk/T3N7uNwm> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/cfS0QBck> .\r\n<https://id.parliament.uk/fVAUVm37>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/fVAUVm37> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-30+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/fVAUVm37>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/HYfypSOE>
+        .\r\n<https://id.parliament.uk/cfS0QBck> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/cfS0QBck>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/5trFJNih> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/5trFJNih>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/5trFJNih> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/5trFJNih>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 46\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/5trFJNih>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 46\" .\r\n<https://id.parliament.uk/5trFJNih> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"509\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/5trFJNih>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 46\" .\r\n<https://id.parliament.uk/5trFJNih> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/PSi2j23h> .\r\n<https://id.parliament.uk/5trFJNih>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/rlJaCEwJ>
+        .\r\n<https://id.parliament.uk/PSi2j23h> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/PSi2j23h>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/PSi2j23h> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/BRTNQywN> .\r\n<https://id.parliament.uk/rlJaCEwJ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/rlJaCEwJ> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/z0dWm7t5>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/z0dWm7t5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/z0dWm7t5>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/z0dWm7t5> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 47\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/z0dWm7t5> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 47\" .\r\n<https://id.parliament.uk/z0dWm7t5>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"490\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/z0dWm7t5> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 47\" .\r\n<https://id.parliament.uk/z0dWm7t5>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/BPlGOTOt>
+        .\r\n<https://id.parliament.uk/z0dWm7t5> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/vJoUN8Af> .\r\n<https://id.parliament.uk/BPlGOTOt>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/BPlGOTOt> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-18+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/BPlGOTOt>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/HYfypSOE>
+        .\r\n<https://id.parliament.uk/vJoUN8Af> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/vJoUN8Af>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/98FJSLox> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/98FJSLox>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/98FJSLox> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/98FJSLox>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 48\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/98FJSLox>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 48\" .\r\n<https://id.parliament.uk/98FJSLox> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 48\" .\r\n<https://id.parliament.uk/98FJSLox>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/iikpYh7G>
+        .\r\n<https://id.parliament.uk/98FJSLox> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/Gcba35Qd> .\r\n<https://id.parliament.uk/iikpYh7G>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/iikpYh7G> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-08+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/iikpYh7G>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/XbTBTDMo>
+        .\r\n<https://id.parliament.uk/Gcba35Qd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/Gcba35Qd>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/3dAYwLoB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/3dAYwLoB>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/3dAYwLoB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/3dAYwLoB>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 49\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/3dAYwLoB>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 49\" .\r\n<https://id.parliament.uk/3dAYwLoB> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"451\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/3dAYwLoB>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 49\" .\r\n<https://id.parliament.uk/3dAYwLoB> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/ZQsu6c18> .\r\n<https://id.parliament.uk/3dAYwLoB>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/DRTwwjtS>
+        .\r\n<https://id.parliament.uk/ZQsu6c18> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/ZQsu6c18>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-03+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/ZQsu6c18> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/NDZSYjeE> .\r\n<https://id.parliament.uk/DRTwwjtS>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/DRTwwjtS> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/eD6E73Ne>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/eD6E73Ne> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/eD6E73Ne>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/eD6E73Ne> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 50\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/eD6E73Ne> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 50\" .\r\n<https://id.parliament.uk/eD6E73Ne>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"540\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/eD6E73Ne> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 50\" .\r\n<https://id.parliament.uk/eD6E73Ne>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/VHI2llf1>
+        .\r\n<https://id.parliament.uk/eD6E73Ne> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/9Zgnj98t> .\r\n<https://id.parliament.uk/VHI2llf1>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/VHI2llf1> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-30+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/VHI2llf1>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/BRTNQywN>
+        .\r\n<https://id.parliament.uk/9Zgnj98t> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/9Zgnj98t>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/TuBqZl6z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/TuBqZl6z>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/TuBqZl6z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/TuBqZl6z>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 51\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/TuBqZl6z>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 51\" .\r\n<https://id.parliament.uk/TuBqZl6z> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"798\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/TuBqZl6z>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 51\" .\r\n<https://id.parliament.uk/TuBqZl6z> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/40fYpO9c> .\r\n<https://id.parliament.uk/TuBqZl6z>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/k5jw9Nhv>
+        .\r\n<https://id.parliament.uk/40fYpO9c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/40fYpO9c>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-24+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/40fYpO9c> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/yiuTaSI4> .\r\n<https://id.parliament.uk/k5jw9Nhv>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/k5jw9Nhv> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/5U4yBcY4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/5U4yBcY4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/5U4yBcY4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/5U4yBcY4> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 52\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/5U4yBcY4> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 52\" .\r\n<https://id.parliament.uk/5U4yBcY4>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"121\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/5U4yBcY4> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 52\" .\r\n<https://id.parliament.uk/5U4yBcY4>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/sPjZPCb0>
+        .\r\n<https://id.parliament.uk/5U4yBcY4> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/0ifq7ERi> .\r\n<https://id.parliament.uk/sPjZPCb0>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/sPjZPCb0> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-17+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/sPjZPCb0>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/XbTBTDMo>
+        .\r\n<https://id.parliament.uk/0ifq7ERi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/0ifq7ERi>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/dNxWbKuU> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/dNxWbKuU>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/dNxWbKuU> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/dNxWbKuU>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 53\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/dNxWbKuU>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 53\" .\r\n<https://id.parliament.uk/dNxWbKuU> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"607\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/dNxWbKuU>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 53\" .\r\n<https://id.parliament.uk/dNxWbKuU> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/E5mpMWcg> .\r\n<https://id.parliament.uk/dNxWbKuU>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/yuPpm1jw>
+        .\r\n<https://id.parliament.uk/E5mpMWcg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/E5mpMWcg>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/E5mpMWcg> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/7dSvuueH> .\r\n<https://id.parliament.uk/yuPpm1jw>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/yuPpm1jw> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/rjzMGG28>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/rjzMGG28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/rjzMGG28>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/rjzMGG28> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 54\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/rjzMGG28> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 54\" .\r\n<https://id.parliament.uk/rjzMGG28>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"829\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/rjzMGG28> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 54\" .\r\n<https://id.parliament.uk/rjzMGG28>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/rWaK4CZm>
+        .\r\n<https://id.parliament.uk/rjzMGG28> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/wMkdwlCh> .\r\n<https://id.parliament.uk/rWaK4CZm>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/rWaK4CZm> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-21+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/rWaK4CZm>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/NDZSYjeE>
+        .\r\n<https://id.parliament.uk/wMkdwlCh> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/wMkdwlCh>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/9PfnbabC> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/9PfnbabC>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/9PfnbabC> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/9PfnbabC>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 55\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/9PfnbabC>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 55\" .\r\n<https://id.parliament.uk/9PfnbabC> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"592\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/9PfnbabC>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 55\" .\r\n<https://id.parliament.uk/9PfnbabC> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/4ckl6Ecn> .\r\n<https://id.parliament.uk/9PfnbabC>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/Ix8dPawU>
+        .\r\n<https://id.parliament.uk/4ckl6Ecn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/4ckl6Ecn>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-16+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/4ckl6Ecn> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XouN12Ow> .\r\n<https://id.parliament.uk/Ix8dPawU>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/Ix8dPawU> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/uNiGNHey>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/uNiGNHey> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/uNiGNHey>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/uNiGNHey> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 56\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/uNiGNHey> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 56\" .\r\n<https://id.parliament.uk/uNiGNHey>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"618\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/uNiGNHey> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 56\" .\r\n<https://id.parliament.uk/uNiGNHey>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/8nTtARxa>
+        .\r\n<https://id.parliament.uk/uNiGNHey> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/A3hB6Aj4> .\r\n<https://id.parliament.uk/8nTtARxa>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/8nTtARxa> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-24+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/8nTtARxa>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/NDZSYjeE>
+        .\r\n<https://id.parliament.uk/A3hB6Aj4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/A3hB6Aj4>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/LFLdzMuO> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/LFLdzMuO>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/LFLdzMuO> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/LFLdzMuO>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 57\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/LFLdzMuO>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 57\" .\r\n<https://id.parliament.uk/LFLdzMuO> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"593\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/LFLdzMuO>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 57\" .\r\n<https://id.parliament.uk/LFLdzMuO> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/2i869NR9> .\r\n<https://id.parliament.uk/LFLdzMuO>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/lq49zoKs>
+        .\r\n<https://id.parliament.uk/2i869NR9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/2i869NR9>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-14+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/2i869NR9> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/yiuTaSI4> .\r\n<https://id.parliament.uk/lq49zoKs>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/lq49zoKs> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/lh2dYuHD>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/lh2dYuHD> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/lh2dYuHD>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/lh2dYuHD> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 58\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/lh2dYuHD> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 58\" .\r\n<https://id.parliament.uk/lh2dYuHD>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"599\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/lh2dYuHD> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 58\" .\r\n<https://id.parliament.uk/lh2dYuHD>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/F6QnrHlj>
+        .\r\n<https://id.parliament.uk/lh2dYuHD> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/jvQpwIVt> .\r\n<https://id.parliament.uk/F6QnrHlj>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/F6QnrHlj> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-21+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/F6QnrHlj>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/7dSvuueH>
+        .\r\n<https://id.parliament.uk/jvQpwIVt> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/jvQpwIVt>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/8HUWJm9e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/8HUWJm9e>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/8HUWJm9e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/8HUWJm9e>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 59\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/8HUWJm9e>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 59\" .\r\n<https://id.parliament.uk/8HUWJm9e> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"598\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/8HUWJm9e>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 59\" .\r\n<https://id.parliament.uk/8HUWJm9e> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/S0ebryc4> .\r\n<https://id.parliament.uk/8HUWJm9e>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/0A9lArUa>
+        .\r\n<https://id.parliament.uk/S0ebryc4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/S0ebryc4>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-18+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/S0ebryc4> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/NDZSYjeE> .\r\n<https://id.parliament.uk/0A9lArUa>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/0A9lArUa> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/BdanAxAh>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/BdanAxAh> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/BdanAxAh>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/BdanAxAh> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 60\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/BdanAxAh> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 60\" .\r\n<https://id.parliament.uk/BdanAxAh>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"635\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/BdanAxAh> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 60\" .\r\n<https://id.parliament.uk/BdanAxAh>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/5fbXtiCF>
+        .\r\n<https://id.parliament.uk/BdanAxAh> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/TvrrHZTL> .\r\n<https://id.parliament.uk/5fbXtiCF>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/5fbXtiCF> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-29+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/5fbXtiCF>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/yiuTaSI4>
+        .\r\n<https://id.parliament.uk/TvrrHZTL> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/TvrrHZTL>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/bUEOr4ad> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/bUEOr4ad>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/bUEOr4ad> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/bUEOr4ad>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 61\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/bUEOr4ad>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 61\" .\r\n<https://id.parliament.uk/bUEOr4ad> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"597\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/bUEOr4ad>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 61\" .\r\n<https://id.parliament.uk/bUEOr4ad> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/WX7uzApY> .\r\n<https://id.parliament.uk/bUEOr4ad>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/Xd5yfp3V>
+        .\r\n<https://id.parliament.uk/WX7uzApY> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/WX7uzApY>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-18+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/WX7uzApY> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/yiuTaSI4> .\r\n<https://id.parliament.uk/Xd5yfp3V>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/Xd5yfp3V> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/Q2dC6z5O>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/Q2dC6z5O> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/Q2dC6z5O>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/Q2dC6z5O> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 62\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/Q2dC6z5O> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 62\" .\r\n<https://id.parliament.uk/Q2dC6z5O>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"591\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/Q2dC6z5O> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 62\" .\r\n<https://id.parliament.uk/Q2dC6z5O>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/5QMvNHCV>
+        .\r\n<https://id.parliament.uk/Q2dC6z5O> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/26Y9ftes> .\r\n<https://id.parliament.uk/5QMvNHCV>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/5QMvNHCV> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-14+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/5QMvNHCV>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/5LQ5Ar74>
+        .\r\n<https://id.parliament.uk/26Y9ftes> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/26Y9ftes>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/RcGToJSJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/RcGToJSJ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/RcGToJSJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/RcGToJSJ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 63\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/RcGToJSJ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 63\" .\r\n<https://id.parliament.uk/RcGToJSJ> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"629\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/RcGToJSJ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 63\" .\r\n<https://id.parliament.uk/RcGToJSJ> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/4DXV4KGc> .\r\n<https://id.parliament.uk/RcGToJSJ>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/cWSEaAzA>
+        .\r\n<https://id.parliament.uk/4DXV4KGc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/4DXV4KGc>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-24+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/4DXV4KGc> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/ZU3IXBtP> .\r\n<https://id.parliament.uk/cWSEaAzA>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/cWSEaAzA> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/YOVMhcqy>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/YOVMhcqy> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/YOVMhcqy>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/YOVMhcqy> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 64\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/YOVMhcqy> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 64\" .\r\n<https://id.parliament.uk/YOVMhcqy>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"647\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/YOVMhcqy> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 64\" .\r\n<https://id.parliament.uk/YOVMhcqy>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/uJMNrUDs>
+        .\r\n<https://id.parliament.uk/YOVMhcqy> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/K83vusrm> .\r\n<https://id.parliament.uk/uJMNrUDs>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/uJMNrUDs> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-30+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/uJMNrUDs>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/kv2Qqfn9>
+        .\r\n<https://id.parliament.uk/kv2Qqfn9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Group> .\r\n<https://id.parliament.uk/kv2Qqfn9>
+        <https://id.parliament.uk/schema/groupName> \"groupName - 14\" .\r\n<https://id.parliament.uk/K83vusrm>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/K83vusrm> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/5pJMwiMT>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/5pJMwiMT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/5pJMwiMT>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/5pJMwiMT> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 65\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/5pJMwiMT> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 65\" .\r\n<https://id.parliament.uk/5pJMwiMT>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"643\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/5pJMwiMT> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 65\" .\r\n<https://id.parliament.uk/5pJMwiMT>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/zTdUgdFx>
+        .\r\n<https://id.parliament.uk/5pJMwiMT> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/t070fIUe> .\r\n<https://id.parliament.uk/zTdUgdFx>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/zTdUgdFx> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-25+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/zTdUgdFx>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/5LQ5Ar74>
+        .\r\n<https://id.parliament.uk/t070fIUe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/t070fIUe>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/ZIUjUqOY> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/ZIUjUqOY>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/ZIUjUqOY> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/ZIUjUqOY>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 66\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/ZIUjUqOY>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 66\" .\r\n<https://id.parliament.uk/ZIUjUqOY> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"912\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/ZIUjUqOY>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 66\" .\r\n<https://id.parliament.uk/ZIUjUqOY> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/vgTfN5KX> .\r\n<https://id.parliament.uk/ZIUjUqOY>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/imgmtCq9>
+        .\r\n<https://id.parliament.uk/vgTfN5KX> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/vgTfN5KX>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-17+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/vgTfN5KX> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/7gnSwbLO> .\r\n<https://id.parliament.uk/imgmtCq9>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/imgmtCq9> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/ijAPvpBd>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/ijAPvpBd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/ijAPvpBd>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/ijAPvpBd> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 67\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/ijAPvpBd> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 67\" .\r\n<https://id.parliament.uk/ijAPvpBd>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"888\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/ijAPvpBd> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 67\" .\r\n<https://id.parliament.uk/ijAPvpBd>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/26Qu3wQF>
+        .\r\n<https://id.parliament.uk/ijAPvpBd> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/2hbUBGLm> .\r\n<https://id.parliament.uk/26Qu3wQF>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/26Qu3wQF> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-21+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/26Qu3wQF>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/7gnSwbLO>
+        .\r\n<https://id.parliament.uk/2hbUBGLm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/2hbUBGLm>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/4EdTvost> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/4EdTvost>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/4EdTvost> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/4EdTvost>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 68\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/4EdTvost>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 68\" .\r\n<https://id.parliament.uk/4EdTvost> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"664\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/4EdTvost>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 68\" .\r\n<https://id.parliament.uk/4EdTvost> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/lmZu2cSE> .\r\n<https://id.parliament.uk/4EdTvost>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/Th3KBYE1>
+        .\r\n<https://id.parliament.uk/lmZu2cSE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/lmZu2cSE>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-01+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/lmZu2cSE> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/5LQ5Ar74> .\r\n<https://id.parliament.uk/Th3KBYE1>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/Th3KBYE1> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/v2fDLDBe>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/v2fDLDBe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/v2fDLDBe>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/v2fDLDBe> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 69\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/v2fDLDBe> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 69\" .\r\n<https://id.parliament.uk/v2fDLDBe>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"879\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/v2fDLDBe> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 69\" .\r\n<https://id.parliament.uk/v2fDLDBe>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/dFKcNjk8>
+        .\r\n<https://id.parliament.uk/v2fDLDBe> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/F1z92xaj> .\r\n<https://id.parliament.uk/dFKcNjk8>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/dFKcNjk8> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/dFKcNjk8>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/fKqMNz79>
+        .\r\n<https://id.parliament.uk/F1z92xaj> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/F1z92xaj>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/yvJQZWRS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/yvJQZWRS>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/yvJQZWRS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/yvJQZWRS>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 70\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/yvJQZWRS>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 70\" .\r\n<https://id.parliament.uk/yvJQZWRS> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"658\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/yvJQZWRS>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 70\" .\r\n<https://id.parliament.uk/yvJQZWRS> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/g48hkvPn> .\r\n<https://id.parliament.uk/yvJQZWRS>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/Y6Fg96Qc>
+        .\r\n<https://id.parliament.uk/g48hkvPn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/g48hkvPn>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-01+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/g48hkvPn> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/nFL8Pq3e> .\r\n<https://id.parliament.uk/nFL8Pq3e>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Group>
+        .\r\n<https://id.parliament.uk/nFL8Pq3e> <https://id.parliament.uk/schema/groupName>
+        \"groupName - 15\" .\r\n<https://id.parliament.uk/Y6Fg96Qc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/Y6Fg96Qc>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/NRSdVnQe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/NRSdVnQe>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/NRSdVnQe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/NRSdVnQe>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 71\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/NRSdVnQe>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 71\" .\r\n<https://id.parliament.uk/NRSdVnQe> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"655\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/NRSdVnQe>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 71\" .\r\n<https://id.parliament.uk/NRSdVnQe> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/HEwFBLoc> .\r\n<https://id.parliament.uk/NRSdVnQe>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/rB4zy7ZP>
+        .\r\n<https://id.parliament.uk/HEwFBLoc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/HEwFBLoc>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/HEwFBLoc> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/7dSvuueH> .\r\n<https://id.parliament.uk/rB4zy7ZP>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/rB4zy7ZP> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/eqmSAYR6>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/eqmSAYR6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/eqmSAYR6>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/eqmSAYR6> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 72\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/eqmSAYR6> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 72\" .\r\n<https://id.parliament.uk/eqmSAYR6>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"665\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/eqmSAYR6> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 72\" .\r\n<https://id.parliament.uk/eqmSAYR6>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/waT2amjz>
+        .\r\n<https://id.parliament.uk/eqmSAYR6> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/HNyM3I1B> .\r\n<https://id.parliament.uk/waT2amjz>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/waT2amjz> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-01+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/waT2amjz>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/BRTNQywN>
+        .\r\n<https://id.parliament.uk/HNyM3I1B> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/HNyM3I1B>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/58xXcnw9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/58xXcnw9>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/58xXcnw9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/58xXcnw9>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 73\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/58xXcnw9>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 73\" .\r\n<https://id.parliament.uk/58xXcnw9> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"654\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/58xXcnw9>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 73\" .\r\n<https://id.parliament.uk/58xXcnw9> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/6rdQLNSS> .\r\n<https://id.parliament.uk/58xXcnw9>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/4NTQX1GP>
+        .\r\n<https://id.parliament.uk/6rdQLNSS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/6rdQLNSS>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-01+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/6rdQLNSS> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/7dSvuueH> .\r\n<https://id.parliament.uk/4NTQX1GP>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/4NTQX1GP> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/ez3sdNNT>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/ez3sdNNT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/ez3sdNNT>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/ez3sdNNT> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 74\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/ez3sdNNT> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 74\" .\r\n<https://id.parliament.uk/ez3sdNNT>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"657\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/ez3sdNNT> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 74\" .\r\n<https://id.parliament.uk/ez3sdNNT>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/Je3lAVxM>
+        .\r\n<https://id.parliament.uk/ez3sdNNT> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/ufLIT2Or> .\r\n<https://id.parliament.uk/Je3lAVxM>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/Je3lAVxM> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/Je3lAVxM>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/NDZSYjeE>
+        .\r\n<https://id.parliament.uk/ufLIT2Or> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/ufLIT2Or>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/181ZoViL> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/181ZoViL>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/181ZoViL> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/181ZoViL>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 75\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/181ZoViL>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 75\" .\r\n<https://id.parliament.uk/181ZoViL> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"878\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/181ZoViL>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 75\" .\r\n<https://id.parliament.uk/181ZoViL> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/LKbEOamb> .\r\n<https://id.parliament.uk/181ZoViL>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/EMd5zhNn>
+        .\r\n<https://id.parliament.uk/LKbEOamb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/LKbEOamb>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/LKbEOamb> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fKqMNz79> .\r\n<https://id.parliament.uk/EMd5zhNn>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/EMd5zhNn> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/z0qrw2Ka>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/z0qrw2Ka> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/z0qrw2Ka>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/z0qrw2Ka> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 76\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/z0qrw2Ka> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 76\" .\r\n<https://id.parliament.uk/z0qrw2Ka>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"877\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/z0qrw2Ka> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 76\" .\r\n<https://id.parliament.uk/z0qrw2Ka>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/PvgJFfzu>
+        .\r\n<https://id.parliament.uk/z0qrw2Ka> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/bAycZdhj> .\r\n<https://id.parliament.uk/PvgJFfzu>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/PvgJFfzu> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/PvgJFfzu>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/fKqMNz79>
+        .\r\n<https://id.parliament.uk/bAycZdhj> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/bAycZdhj>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/KUKpCZa3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/KUKpCZa3>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/KUKpCZa3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/KUKpCZa3>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 77\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/KUKpCZa3>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 77\" .\r\n<https://id.parliament.uk/KUKpCZa3> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"893\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/KUKpCZa3>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 77\" .\r\n<https://id.parliament.uk/KUKpCZa3> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/DaC29Iwv> .\r\n<https://id.parliament.uk/KUKpCZa3>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/zTTK3xwl>
+        .\r\n<https://id.parliament.uk/DaC29Iwv> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/DaC29Iwv>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/DaC29Iwv> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/7dSvuueH> .\r\n<https://id.parliament.uk/zTTK3xwl>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/zTTK3xwl> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/oPe8W6LR>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/oPe8W6LR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/oPe8W6LR>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/oPe8W6LR> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 78\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/oPe8W6LR> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 78\" .\r\n<https://id.parliament.uk/oPe8W6LR>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"896\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/oPe8W6LR> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 78\" .\r\n<https://id.parliament.uk/oPe8W6LR>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/bcwSXGsX>
+        .\r\n<https://id.parliament.uk/oPe8W6LR> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/LZZDP3oe> .\r\n<https://id.parliament.uk/bcwSXGsX>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/bcwSXGsX> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/bcwSXGsX>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/yiuTaSI4>
+        .\r\n<https://id.parliament.uk/LZZDP3oe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/LZZDP3oe>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/pw7G14pf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/pw7G14pf>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/pw7G14pf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/pw7G14pf>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 79\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/pw7G14pf>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 79\" .\r\n<https://id.parliament.uk/pw7G14pf> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"917\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/pw7G14pf>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 79\" .\r\n<https://id.parliament.uk/pw7G14pf> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/MPd5Ld9M> .\r\n<https://id.parliament.uk/pw7G14pf>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/sCsUv9LP>
+        .\r\n<https://id.parliament.uk/MPd5Ld9M> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/MPd5Ld9M>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/MPd5Ld9M> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/DkHdH4kZ> .\r\n<https://id.parliament.uk/DkHdH4kZ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Group>
+        .\r\n<https://id.parliament.uk/DkHdH4kZ> <https://id.parliament.uk/schema/groupName>
+        \"groupName - 16\" .\r\n<https://id.parliament.uk/sCsUv9LP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/sCsUv9LP>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/9WjR8ian> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/9WjR8ian>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/9WjR8ian> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/9WjR8ian>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 80\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/9WjR8ian>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 80\" .\r\n<https://id.parliament.uk/9WjR8ian> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"891\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/9WjR8ian>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 80\" .\r\n<https://id.parliament.uk/9WjR8ian> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/GmuvWRZO> .\r\n<https://id.parliament.uk/9WjR8ian>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/LtEJxMbn>
+        .\r\n<https://id.parliament.uk/GmuvWRZO> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/GmuvWRZO>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/GmuvWRZO> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fKqMNz79> .\r\n<https://id.parliament.uk/LtEJxMbn>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/LtEJxMbn> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/ZZqT1pd0>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/ZZqT1pd0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/ZZqT1pd0>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/ZZqT1pd0> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 81\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/ZZqT1pd0> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 81\" .\r\n<https://id.parliament.uk/ZZqT1pd0>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"663\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/ZZqT1pd0> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 81\" .\r\n<https://id.parliament.uk/ZZqT1pd0>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/XInX9awv>
+        .\r\n<https://id.parliament.uk/ZZqT1pd0> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/YO89Z75K> .\r\n<https://id.parliament.uk/XInX9awv>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/XInX9awv> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-01+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/XInX9awv>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/5LQ5Ar74>
+        .\r\n<https://id.parliament.uk/YO89Z75K> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/YO89Z75K>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/cmbxjWzh> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/cmbxjWzh>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/cmbxjWzh> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/cmbxjWzh>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 82\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/cmbxjWzh>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 82\" .\r\n<https://id.parliament.uk/cmbxjWzh> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"666\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/cmbxjWzh>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 82\" .\r\n<https://id.parliament.uk/cmbxjWzh> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/25iK4k3e> .\r\n<https://id.parliament.uk/cmbxjWzh>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/sVns1L8Y>
+        .\r\n<https://id.parliament.uk/25iK4k3e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/25iK4k3e>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-01+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/25iK4k3e> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/5LQ5Ar74> .\r\n<https://id.parliament.uk/sVns1L8Y>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/sVns1L8Y> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/hs0US9Hw>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/hs0US9Hw> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/hs0US9Hw>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/hs0US9Hw> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 83\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/hs0US9Hw> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 83\" .\r\n<https://id.parliament.uk/hs0US9Hw>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"895\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/hs0US9Hw> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 83\" .\r\n<https://id.parliament.uk/hs0US9Hw>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/t07Oxwwk>
+        .\r\n<https://id.parliament.uk/hs0US9Hw> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/VKMmNyZw> .\r\n<https://id.parliament.uk/t07Oxwwk>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/t07Oxwwk> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-06+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/t07Oxwwk>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/yiuTaSI4>
+        .\r\n<https://id.parliament.uk/VKMmNyZw> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/VKMmNyZw>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/b9hRtbhC> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/b9hRtbhC>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/b9hRtbhC> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/b9hRtbhC>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 84\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/b9hRtbhC>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 84\" .\r\n<https://id.parliament.uk/b9hRtbhC> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"857\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/b9hRtbhC>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 84\" .\r\n<https://id.parliament.uk/b9hRtbhC> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/K6kip00x> .\r\n<https://id.parliament.uk/b9hRtbhC>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/qOj7JAd8>
+        .\r\n<https://id.parliament.uk/K6kip00x> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/K6kip00x>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-05+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/K6kip00x> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/eup4DwE5> .\r\n<https://id.parliament.uk/qOj7JAd8>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/qOj7JAd8> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/gTgidljI> .\r\n<https://id.parliament.uk/YZnLn72f>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/YZnLn72f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/YZnLn72f>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/YZnLn72f> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 85\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/YZnLn72f> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 85\" .\r\n<https://id.parliament.uk/YZnLn72f>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"855\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/YZnLn72f> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 85\" .\r\n<https://id.parliament.uk/YZnLn72f>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/brnEXxQN>
+        .\r\n<https://id.parliament.uk/YZnLn72f> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/lV20Bjux> .\r\n<https://id.parliament.uk/brnEXxQN>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/brnEXxQN> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-05+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/brnEXxQN>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/eup4DwE5>
+        .\r\n<https://id.parliament.uk/lV20Bjux> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/lV20Bjux>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/gTgidljI>
+        .\r\n<https://id.parliament.uk/olhuTQTg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/olhuTQTg>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/olhuTQTg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/olhuTQTg>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 86\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/olhuTQTg>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 86\" .\r\n<https://id.parliament.uk/olhuTQTg> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"853\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/olhuTQTg>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 86\" .\r\n<https://id.parliament.uk/olhuTQTg> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/s8eduPJU> .\r\n<https://id.parliament.uk/olhuTQTg>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/1UXwbopq>
+        .\r\n<https://id.parliament.uk/s8eduPJU> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/s8eduPJU>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-05+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/s8eduPJU> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/eup4DwE5> .\r\n<https://id.parliament.uk/1UXwbopq>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/1UXwbopq> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/gTgidljI> .\r\n<https://id.parliament.uk/w3m931qg>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/w3m931qg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/w3m931qg>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/w3m931qg> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 87\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/w3m931qg> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 87\" .\r\n<https://id.parliament.uk/w3m931qg>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"682\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/w3m931qg> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 87\" .\r\n<https://id.parliament.uk/w3m931qg>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/TZR852WV>
+        .\r\n<https://id.parliament.uk/w3m931qg> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/WKnAjjLi> .\r\n<https://id.parliament.uk/TZR852WV>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/TZR852WV> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-06+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/TZR852WV>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/NDZSYjeE>
+        .\r\n<https://id.parliament.uk/WKnAjjLi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/WKnAjjLi>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/CHZfxISd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/CHZfxISd>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/CHZfxISd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/CHZfxISd>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 88\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/CHZfxISd>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 88\" .\r\n<https://id.parliament.uk/CHZfxISd> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"854\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/CHZfxISd>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 88\" .\r\n<https://id.parliament.uk/CHZfxISd> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/KzKXutmB> .\r\n<https://id.parliament.uk/CHZfxISd>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/V8H9QZ1p>
+        .\r\n<https://id.parliament.uk/KzKXutmB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/KzKXutmB>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-05+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/KzKXutmB> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/eup4DwE5> .\r\n<https://id.parliament.uk/V8H9QZ1p>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/V8H9QZ1p> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/gTgidljI> .\r\n<https://id.parliament.uk/T7oi7f0E>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/T7oi7f0E> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/T7oi7f0E>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/T7oi7f0E> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 89\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/T7oi7f0E> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 89\" .\r\n<https://id.parliament.uk/T7oi7f0E>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"856\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/T7oi7f0E> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 89\" .\r\n<https://id.parliament.uk/T7oi7f0E>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/elHq7PWF>
+        .\r\n<https://id.parliament.uk/T7oi7f0E> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/WdlP3RL1> .\r\n<https://id.parliament.uk/elHq7PWF>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/elHq7PWF> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-05+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/elHq7PWF>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/eup4DwE5>
+        .\r\n<https://id.parliament.uk/WdlP3RL1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/WdlP3RL1>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/gTgidljI>
+        .\r\n<https://id.parliament.uk/IYqCRJN5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/IYqCRJN5>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/IYqCRJN5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/IYqCRJN5>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 90\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/IYqCRJN5>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 90\" .\r\n<https://id.parliament.uk/IYqCRJN5> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"676\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/IYqCRJN5>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 90\" .\r\n<https://id.parliament.uk/IYqCRJN5> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/QlXTuSAp> .\r\n<https://id.parliament.uk/IYqCRJN5>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/MVnuNAsM>
+        .\r\n<https://id.parliament.uk/QlXTuSAp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/QlXTuSAp>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-06+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/QlXTuSAp> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XbTBTDMo> .\r\n<https://id.parliament.uk/MVnuNAsM>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/MVnuNAsM> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/wzOpc7Aj>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/wzOpc7Aj> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/wzOpc7Aj>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/wzOpc7Aj> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 91\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/wzOpc7Aj> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 91\" .\r\n<https://id.parliament.uk/wzOpc7Aj>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"691\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/wzOpc7Aj> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 91\" .\r\n<https://id.parliament.uk/wzOpc7Aj>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/c2j7TK3q>
+        .\r\n<https://id.parliament.uk/wzOpc7Aj> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/rGmwrYWm> .\r\n<https://id.parliament.uk/c2j7TK3q>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/c2j7TK3q> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-07+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/c2j7TK3q>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/ZU3IXBtP>
+        .\r\n<https://id.parliament.uk/rGmwrYWm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/rGmwrYWm>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/8xNcqHgV> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/8xNcqHgV>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/8xNcqHgV> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/8xNcqHgV>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 92\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/8xNcqHgV>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 92\" .\r\n<https://id.parliament.uk/8xNcqHgV> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"667\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/8xNcqHgV>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 92\" .\r\n<https://id.parliament.uk/8xNcqHgV> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/jzdEemyP> .\r\n<https://id.parliament.uk/8xNcqHgV>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/uIv7V5Fh>
+        .\r\n<https://id.parliament.uk/jzdEemyP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/jzdEemyP>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-07+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/jzdEemyP> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XouN12Ow> .\r\n<https://id.parliament.uk/uIv7V5Fh>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/uIv7V5Fh> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/tiA7a71r>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/tiA7a71r> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/tiA7a71r>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/tiA7a71r> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 93\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/tiA7a71r> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 93\" .\r\n<https://id.parliament.uk/tiA7a71r>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"688\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/tiA7a71r> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 93\" .\r\n<https://id.parliament.uk/tiA7a71r>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/Qm5qIh0P>
+        .\r\n<https://id.parliament.uk/tiA7a71r> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/R6OYbZOe> .\r\n<https://id.parliament.uk/Qm5qIh0P>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/Qm5qIh0P> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-07+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/Qm5qIh0P>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/7dSvuueH>
+        .\r\n<https://id.parliament.uk/R6OYbZOe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/R6OYbZOe>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/Keztycwl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/Keztycwl>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/Keztycwl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/Keztycwl>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 94\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/Keztycwl>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 94\" .\r\n<https://id.parliament.uk/Keztycwl> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"880\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/Keztycwl>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 94\" .\r\n<https://id.parliament.uk/Keztycwl> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/crlcWHt2> .\r\n<https://id.parliament.uk/Keztycwl>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/NPsTtMcv>
+        .\r\n<https://id.parliament.uk/crlcWHt2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/crlcWHt2>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-07+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/crlcWHt2> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fKqMNz79> .\r\n<https://id.parliament.uk/NPsTtMcv>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/NPsTtMcv> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/PhwmELqG>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/PhwmELqG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/PhwmELqG>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/PhwmELqG> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 95\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/PhwmELqG> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 95\" .\r\n<https://id.parliament.uk/PhwmELqG>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"696\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/PhwmELqG> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 95\" .\r\n<https://id.parliament.uk/PhwmELqG>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/630Ft4k4>
+        .\r\n<https://id.parliament.uk/PhwmELqG> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/kgC76Ime> .\r\n<https://id.parliament.uk/630Ft4k4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/630Ft4k4> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-08+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/630Ft4k4>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/NDZSYjeE>
+        .\r\n<https://id.parliament.uk/kgC76Ime> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/kgC76Ime>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/1IUldWII> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/1IUldWII>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/1IUldWII> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/1IUldWII>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 96\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/1IUldWII>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 96\" .\r\n<https://id.parliament.uk/1IUldWII> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"695\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/1IUldWII>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 96\" .\r\n<https://id.parliament.uk/1IUldWII> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/wTM8MSS7> .\r\n<https://id.parliament.uk/1IUldWII>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/ThkRNxvE>
+        .\r\n<https://id.parliament.uk/wTM8MSS7> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/wTM8MSS7>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-08+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/wTM8MSS7> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fKqMNz79> .\r\n<https://id.parliament.uk/ThkRNxvE>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/ThkRNxvE> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/Z1VEYuzd>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/Z1VEYuzd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/Z1VEYuzd>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/Z1VEYuzd> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 97\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/Z1VEYuzd> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 97\" .\r\n<https://id.parliament.uk/Z1VEYuzd>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"703\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/Z1VEYuzd> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 97\" .\r\n<https://id.parliament.uk/Z1VEYuzd>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/iC7vA0Z9>
+        .\r\n<https://id.parliament.uk/Z1VEYuzd> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/4hcgudSd> .\r\n<https://id.parliament.uk/iC7vA0Z9>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/iC7vA0Z9> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-11+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/iC7vA0Z9>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/5LQ5Ar74>
+        .\r\n<https://id.parliament.uk/4hcgudSd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/4hcgudSd>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/WOETQ8oL> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/WOETQ8oL>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/WOETQ8oL> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/WOETQ8oL>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 98\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/WOETQ8oL>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 98\" .\r\n<https://id.parliament.uk/WOETQ8oL> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"860\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/WOETQ8oL>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 98\" .\r\n<https://id.parliament.uk/WOETQ8oL> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/tPANiKqA> .\r\n<https://id.parliament.uk/WOETQ8oL>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/mEw7S9ov>
+        .\r\n<https://id.parliament.uk/tPANiKqA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/tPANiKqA>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-11+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/tPANiKqA> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/yiuTaSI4> .\r\n<https://id.parliament.uk/mEw7S9ov>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/mEw7S9ov> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/jKgfbLZG>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/jKgfbLZG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/jKgfbLZG>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/jKgfbLZG> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 99\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/jKgfbLZG> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 99\" .\r\n<https://id.parliament.uk/jKgfbLZG>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"698\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/jKgfbLZG> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 99\" .\r\n<https://id.parliament.uk/jKgfbLZG>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/5GvYaS8l>
+        .\r\n<https://id.parliament.uk/jKgfbLZG> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/4OyKxSz9> .\r\n<https://id.parliament.uk/5GvYaS8l>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/5GvYaS8l> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-11+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/5GvYaS8l>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/HYfypSOE>
+        .\r\n<https://id.parliament.uk/4OyKxSz9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/4OyKxSz9>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/BN7ucM8o> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/BN7ucM8o>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/BN7ucM8o> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/BN7ucM8o>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 100\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/BN7ucM8o>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 100\" .\r\n<https://id.parliament.uk/BN7ucM8o> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"687\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/BN7ucM8o>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 100\" .\r\n<https://id.parliament.uk/BN7ucM8o> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/ngVa6Qf3> .\r\n<https://id.parliament.uk/BN7ucM8o>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/j4YnKrGQ>
+        .\r\n<https://id.parliament.uk/ngVa6Qf3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/ngVa6Qf3>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-08+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/ngVa6Qf3> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fpWTqVKh> .\r\n<https://id.parliament.uk/fpWTqVKh>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Group>
+        .\r\n<https://id.parliament.uk/fpWTqVKh> <https://id.parliament.uk/schema/groupName>
+        \"groupName - 17\" .\r\n<https://id.parliament.uk/j4YnKrGQ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/j4YnKrGQ>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/PyLlquNq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/PyLlquNq>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/PyLlquNq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/PyLlquNq>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 101\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/PyLlquNq>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 101\" .\r\n<https://id.parliament.uk/PyLlquNq> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"677\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/PyLlquNq>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 101\" .\r\n<https://id.parliament.uk/PyLlquNq> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/koKeyDBh> .\r\n<https://id.parliament.uk/PyLlquNq>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/Q5DIXbsV>
+        .\r\n<https://id.parliament.uk/koKeyDBh> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/koKeyDBh>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-08+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/koKeyDBh> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fpWTqVKh> .\r\n<https://id.parliament.uk/Q5DIXbsV>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/Q5DIXbsV> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/LldrrMNS>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/LldrrMNS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/LldrrMNS>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/LldrrMNS> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 102\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/LldrrMNS> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 102\" .\r\n<https://id.parliament.uk/LldrrMNS>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"673\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/LldrrMNS> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 102\" .\r\n<https://id.parliament.uk/LldrrMNS>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/21jNcoz8>
+        .\r\n<https://id.parliament.uk/LldrrMNS> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/ZkjV9gWZ> .\r\n<https://id.parliament.uk/21jNcoz8>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/21jNcoz8> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-08+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/21jNcoz8>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/XouN12Ow>
+        .\r\n<https://id.parliament.uk/ZkjV9gWZ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/ZkjV9gWZ>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/nohxpB6K> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/nohxpB6K>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/nohxpB6K> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/nohxpB6K>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 103\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/nohxpB6K>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 103\" .\r\n<https://id.parliament.uk/nohxpB6K> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"670\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/nohxpB6K>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 103\" .\r\n<https://id.parliament.uk/nohxpB6K> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/buWmokrg> .\r\n<https://id.parliament.uk/nohxpB6K>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/DKrpinkq>
+        .\r\n<https://id.parliament.uk/buWmokrg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/buWmokrg>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-08+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/buWmokrg> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XouN12Ow> .\r\n<https://id.parliament.uk/DKrpinkq>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/DKrpinkq> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/aQaZuLyK>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/aQaZuLyK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/aQaZuLyK>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/aQaZuLyK> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 104\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/aQaZuLyK> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 104\" .\r\n<https://id.parliament.uk/aQaZuLyK>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"905\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/aQaZuLyK> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 104\" .\r\n<https://id.parliament.uk/aQaZuLyK>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/SKzgadiu>
+        .\r\n<https://id.parliament.uk/aQaZuLyK> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/d3zxRvk4> .\r\n<https://id.parliament.uk/SKzgadiu>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/SKzgadiu> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-13+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/SKzgadiu>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/NDZSYjeE>
+        .\r\n<https://id.parliament.uk/d3zxRvk4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/d3zxRvk4>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/nky6NCi1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/nky6NCi1>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/nky6NCi1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/nky6NCi1>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 105\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/nky6NCi1>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 105\" .\r\n<https://id.parliament.uk/nky6NCi1> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"653\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/nky6NCi1>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 105\" .\r\n<https://id.parliament.uk/nky6NCi1> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/Wwwxqo4J> .\r\n<https://id.parliament.uk/nky6NCi1>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/kiJwF0d5>
+        .\r\n<https://id.parliament.uk/Wwwxqo4J> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/Wwwxqo4J>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-31+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/Wwwxqo4J> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fKqMNz79> .\r\n<https://id.parliament.uk/kiJwF0d5>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/kiJwF0d5> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/66skcwzN>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/66skcwzN> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/66skcwzN>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/66skcwzN> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 106\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/66skcwzN> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 106\" .\r\n<https://id.parliament.uk/66skcwzN>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"898\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/66skcwzN> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 106\" .\r\n<https://id.parliament.uk/66skcwzN>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/AHFOvb9h>
+        .\r\n<https://id.parliament.uk/66skcwzN> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/okoEwpBW> .\r\n<https://id.parliament.uk/AHFOvb9h>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/AHFOvb9h> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-13+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/AHFOvb9h>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/yiuTaSI4>
+        .\r\n<https://id.parliament.uk/okoEwpBW> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/okoEwpBW>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/I9rWxORS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/I9rWxORS>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/I9rWxORS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/I9rWxORS>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 107\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/I9rWxORS>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 107\" .\r\n<https://id.parliament.uk/I9rWxORS> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"715\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/I9rWxORS>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 107\" .\r\n<https://id.parliament.uk/I9rWxORS> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/nBIracyf> .\r\n<https://id.parliament.uk/I9rWxORS>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/Fwns2363>
+        .\r\n<https://id.parliament.uk/nBIracyf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/nBIracyf>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-13+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/nBIracyf> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/NDZSYjeE> .\r\n<https://id.parliament.uk/Fwns2363>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/Fwns2363> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/leJaKS5E>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/leJaKS5E> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/leJaKS5E>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/leJaKS5E> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 108\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/leJaKS5E> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 108\" .\r\n<https://id.parliament.uk/leJaKS5E>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"909\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/leJaKS5E> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 108\" .\r\n<https://id.parliament.uk/leJaKS5E>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/4yz9ib7D>
+        .\r\n<https://id.parliament.uk/leJaKS5E> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/PuKCWhOF> .\r\n<https://id.parliament.uk/4yz9ib7D>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/4yz9ib7D> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-14+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/4yz9ib7D>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/yiuTaSI4>
+        .\r\n<https://id.parliament.uk/PuKCWhOF> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/PuKCWhOF>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/N3pbTe7F> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/N3pbTe7F>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/N3pbTe7F> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/N3pbTe7F>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 109\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/N3pbTe7F>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 109\" .\r\n<https://id.parliament.uk/N3pbTe7F> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"719\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/N3pbTe7F>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 109\" .\r\n<https://id.parliament.uk/N3pbTe7F> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/qWQujVpH> .\r\n<https://id.parliament.uk/N3pbTe7F>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/SE7Aj9Hz>
+        .\r\n<https://id.parliament.uk/qWQujVpH> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/qWQujVpH>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-14+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/qWQujVpH> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fKqMNz79> .\r\n<https://id.parliament.uk/SE7Aj9Hz>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/SE7Aj9Hz> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/itrbNOwE>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/itrbNOwE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/itrbNOwE>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/itrbNOwE> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 110\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/itrbNOwE> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 110\" .\r\n<https://id.parliament.uk/itrbNOwE>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"1067\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/itrbNOwE> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 110\" .\r\n<https://id.parliament.uk/itrbNOwE>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/aFyadxgl>
+        .\r\n<https://id.parliament.uk/itrbNOwE> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/rSOd6At4> .\r\n<https://id.parliament.uk/aFyadxgl>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/aFyadxgl> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/aFyadxgl>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/UIV7W27r>
+        .\r\n<https://id.parliament.uk/UIV7W27r> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Group> .\r\n<https://id.parliament.uk/UIV7W27r>
+        <https://id.parliament.uk/schema/groupName> \"groupName - 18\" .\r\n<https://id.parliament.uk/rSOd6At4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/rSOd6At4> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/Y5ihrxeg>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/Y5ihrxeg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/Y5ihrxeg>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/Y5ihrxeg> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 111\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/Y5ihrxeg> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 111\" .\r\n<https://id.parliament.uk/Y5ihrxeg>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"1065\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/Y5ihrxeg> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 111\" .\r\n<https://id.parliament.uk/Y5ihrxeg>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/2lKySoAc>
+        .\r\n<https://id.parliament.uk/Y5ihrxeg> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/GjPYe6E4> .\r\n<https://id.parliament.uk/2lKySoAc>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/2lKySoAc> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/2lKySoAc>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/UIV7W27r>
+        .\r\n<https://id.parliament.uk/GjPYe6E4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/GjPYe6E4>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/rMrXIRPv> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/rMrXIRPv>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/rMrXIRPv> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/rMrXIRPv>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 112\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/rMrXIRPv>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 112\" .\r\n<https://id.parliament.uk/rMrXIRPv> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"1063\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/rMrXIRPv>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 112\" .\r\n<https://id.parliament.uk/rMrXIRPv> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/FpWprriy> .\r\n<https://id.parliament.uk/rMrXIRPv>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/CNezzmKU>
+        .\r\n<https://id.parliament.uk/FpWprriy> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/FpWprriy>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/FpWprriy> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/UIV7W27r> .\r\n<https://id.parliament.uk/CNezzmKU>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/CNezzmKU> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/hMaj7XDd>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/hMaj7XDd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/hMaj7XDd>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/hMaj7XDd> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 113\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/hMaj7XDd> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 113\" .\r\n<https://id.parliament.uk/hMaj7XDd>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"1066\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/hMaj7XDd> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 113\" .\r\n<https://id.parliament.uk/hMaj7XDd>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/WpWJdjxe>
+        .\r\n<https://id.parliament.uk/hMaj7XDd> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/KRoYyf39> .\r\n<https://id.parliament.uk/WpWJdjxe>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/WpWJdjxe> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/WpWJdjxe>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/UIV7W27r>
+        .\r\n<https://id.parliament.uk/KRoYyf39> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/KRoYyf39>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/uhL6bPvV> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/uhL6bPvV>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/uhL6bPvV> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/uhL6bPvV>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 114\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/uhL6bPvV>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 114\" .\r\n<https://id.parliament.uk/uhL6bPvV> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"1068\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/uhL6bPvV>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 114\" .\r\n<https://id.parliament.uk/uhL6bPvV> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/LwV1dWdD> .\r\n<https://id.parliament.uk/uhL6bPvV>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/eCC4xqSd>
+        .\r\n<https://id.parliament.uk/LwV1dWdD> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/LwV1dWdD>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/LwV1dWdD> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/UIV7W27r> .\r\n<https://id.parliament.uk/eCC4xqSd>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/eCC4xqSd> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/MJRZgm6X>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/MJRZgm6X> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/MJRZgm6X>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/MJRZgm6X> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 115\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/MJRZgm6X> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 115\" .\r\n<https://id.parliament.uk/MJRZgm6X>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"1070\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/MJRZgm6X> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 115\" .\r\n<https://id.parliament.uk/MJRZgm6X>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/plKvEflr>
+        .\r\n<https://id.parliament.uk/MJRZgm6X> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/8MyEStfv> .\r\n<https://id.parliament.uk/plKvEflr>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/plKvEflr> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/plKvEflr>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/UIV7W27r>
+        .\r\n<https://id.parliament.uk/8MyEStfv> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/8MyEStfv>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/9Nv0gELe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/9Nv0gELe>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/9Nv0gELe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/9Nv0gELe>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 116\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/9Nv0gELe>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 116\" .\r\n<https://id.parliament.uk/9Nv0gELe> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"709\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/9Nv0gELe>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 116\" .\r\n<https://id.parliament.uk/9Nv0gELe> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/ktlPPWYD> .\r\n<https://id.parliament.uk/9Nv0gELe>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/VwdFcdKq>
+        .\r\n<https://id.parliament.uk/ktlPPWYD> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/ktlPPWYD>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-15+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/ktlPPWYD> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/NDZSYjeE> .\r\n<https://id.parliament.uk/VwdFcdKq>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/VwdFcdKq> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/rdYNYrB9>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/rdYNYrB9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/rdYNYrB9>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/rdYNYrB9> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 117\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/rdYNYrB9> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 117\" .\r\n<https://id.parliament.uk/rdYNYrB9>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"717\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/rdYNYrB9> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 117\" .\r\n<https://id.parliament.uk/rdYNYrB9>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/mAHMh7zR>
+        .\r\n<https://id.parliament.uk/rdYNYrB9> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/QA1PcSCp> .\r\n<https://id.parliament.uk/mAHMh7zR>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/mAHMh7zR> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-15+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/mAHMh7zR>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/XouN12Ow>
+        .\r\n<https://id.parliament.uk/QA1PcSCp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/QA1PcSCp>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/D9vkxjm0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/D9vkxjm0>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/D9vkxjm0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/D9vkxjm0>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 118\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/D9vkxjm0>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 118\" .\r\n<https://id.parliament.uk/D9vkxjm0> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 118\" .\r\n<https://id.parliament.uk/D9vkxjm0>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/gYHg7QFf>
+        .\r\n<https://id.parliament.uk/D9vkxjm0> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/jTuty5ho> .\r\n<https://id.parliament.uk/gYHg7QFf>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/gYHg7QFf> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-15+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/gYHg7QFf>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/7dSvuueH>
+        .\r\n<https://id.parliament.uk/jTuty5ho> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/jTuty5ho>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/vPuOxy1B> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/vPuOxy1B>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/vPuOxy1B> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/vPuOxy1B>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 119\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/vPuOxy1B>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 119\" .\r\n<https://id.parliament.uk/vPuOxy1B> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"779\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/vPuOxy1B>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 119\" .\r\n<https://id.parliament.uk/vPuOxy1B> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/9ZAdr8BY> .\r\n<https://id.parliament.uk/vPuOxy1B>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/QVLaGR9L>
+        .\r\n<https://id.parliament.uk/9ZAdr8BY> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/9ZAdr8BY>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/9ZAdr8BY> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/79sn5e3n> .\r\n<https://id.parliament.uk/QVLaGR9L>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/QVLaGR9L> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/tZhWfLGW>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/tZhWfLGW> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/tZhWfLGW>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/tZhWfLGW> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 120\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/tZhWfLGW> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 120\" .\r\n<https://id.parliament.uk/tZhWfLGW>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"778\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/tZhWfLGW> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 120\" .\r\n<https://id.parliament.uk/tZhWfLGW>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/vgqGQbkm>
+        .\r\n<https://id.parliament.uk/tZhWfLGW> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/KWpudKrZ> .\r\n<https://id.parliament.uk/vgqGQbkm>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/vgqGQbkm> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/vgqGQbkm>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/79sn5e3n>
+        .\r\n<https://id.parliament.uk/KWpudKrZ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/KWpudKrZ>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/avoNURrR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/avoNURrR>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/avoNURrR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/avoNURrR>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 121\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/avoNURrR>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 121\" .\r\n<https://id.parliament.uk/avoNURrR> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"628\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/avoNURrR>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 121\" .\r\n<https://id.parliament.uk/avoNURrR> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/WkSMeKah> .\r\n<https://id.parliament.uk/avoNURrR>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/BYngh8z1>
+        .\r\n<https://id.parliament.uk/WkSMeKah> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/WkSMeKah>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-16+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/WkSMeKah> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/79sn5e3n> .\r\n<https://id.parliament.uk/BYngh8z1>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/BYngh8z1> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/s75qT4mw>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/s75qT4mw> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/s75qT4mw>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/s75qT4mw> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 122\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/s75qT4mw> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 122\" .\r\n<https://id.parliament.uk/s75qT4mw>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"840\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/s75qT4mw> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 122\" .\r\n<https://id.parliament.uk/s75qT4mw>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/DOGB8Le4>
+        .\r\n<https://id.parliament.uk/s75qT4mw> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/3HrW7G3b> .\r\n<https://id.parliament.uk/DOGB8Le4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/DOGB8Le4> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/DOGB8Le4>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/79sn5e3n>
+        .\r\n<https://id.parliament.uk/3HrW7G3b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/3HrW7G3b>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/YdZGzcJA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/YdZGzcJA>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/YdZGzcJA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/YdZGzcJA>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 123\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/YdZGzcJA>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 123\" .\r\n<https://id.parliament.uk/YdZGzcJA> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"730\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/YdZGzcJA>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 123\" .\r\n<https://id.parliament.uk/YdZGzcJA> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/97Woii31> .\r\n<https://id.parliament.uk/YdZGzcJA>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/dnBED32B>
+        .\r\n<https://id.parliament.uk/97Woii31> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/97Woii31>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-18+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/97Woii31> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fKqMNz79> .\r\n<https://id.parliament.uk/dnBED32B>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/dnBED32B> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/N1TcXxev>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/N1TcXxev> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/N1TcXxev>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/N1TcXxev> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 124\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/N1TcXxev> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 124\" .\r\n<https://id.parliament.uk/N1TcXxev>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"706\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/N1TcXxev> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 124\" .\r\n<https://id.parliament.uk/N1TcXxev>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/3H2a62MQ>
+        .\r\n<https://id.parliament.uk/N1TcXxev> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/665mjGeq> .\r\n<https://id.parliament.uk/3H2a62MQ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/3H2a62MQ> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-18+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/3H2a62MQ>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/5LQ5Ar74>
+        .\r\n<https://id.parliament.uk/665mjGeq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/665mjGeq>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/u2nfODML> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/u2nfODML>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/u2nfODML> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/u2nfODML>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 125\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/u2nfODML>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 125\" .\r\n<https://id.parliament.uk/u2nfODML> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"707\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/u2nfODML>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 125\" .\r\n<https://id.parliament.uk/u2nfODML> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/XEgy9gKK> .\r\n<https://id.parliament.uk/u2nfODML>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/tWfu2Nyq>
+        .\r\n<https://id.parliament.uk/XEgy9gKK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/XEgy9gKK>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-18+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/XEgy9gKK> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/5LQ5Ar74> .\r\n<https://id.parliament.uk/tWfu2Nyq>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/tWfu2Nyq> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/GHIocidH>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/GHIocidH> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/GHIocidH>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/GHIocidH> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 126\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/GHIocidH> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 126\" .\r\n<https://id.parliament.uk/GHIocidH>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"839\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/GHIocidH> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 126\" .\r\n<https://id.parliament.uk/GHIocidH>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/YhyvgA49>
+        .\r\n<https://id.parliament.uk/GHIocidH> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/WmTUL82V> .\r\n<https://id.parliament.uk/YhyvgA49>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/YhyvgA49> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-30+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/YhyvgA49>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/79sn5e3n>
+        .\r\n<https://id.parliament.uk/WmTUL82V> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/WmTUL82V>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/YhMNMpYo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/YhMNMpYo>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/YhMNMpYo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/YhMNMpYo>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 127\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/YhMNMpYo>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 127\" .\r\n<https://id.parliament.uk/YhMNMpYo> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"729\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/YhMNMpYo>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 127\" .\r\n<https://id.parliament.uk/YhMNMpYo> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/yzmWisVv> .\r\n<https://id.parliament.uk/YhMNMpYo>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/iwUtxq6V>
+        .\r\n<https://id.parliament.uk/yzmWisVv> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/yzmWisVv>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-18+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/yzmWisVv> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/NDZSYjeE> .\r\n<https://id.parliament.uk/iwUtxq6V>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/iwUtxq6V> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/kqzXWiAO>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/kqzXWiAO> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/kqzXWiAO>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/kqzXWiAO> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 128\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/kqzXWiAO> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 128\" .\r\n<https://id.parliament.uk/kqzXWiAO>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"526\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/kqzXWiAO> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 128\" .\r\n<https://id.parliament.uk/kqzXWiAO>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/1lAV8kaU>
+        .\r\n<https://id.parliament.uk/kqzXWiAO> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/V2jm1mhC> .\r\n<https://id.parliament.uk/1lAV8kaU>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/1lAV8kaU> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-26+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/1lAV8kaU>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/fpWTqVKh>
+        .\r\n<https://id.parliament.uk/V2jm1mhC> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/V2jm1mhC>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/xa91QFSm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/xa91QFSm>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/xa91QFSm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/xa91QFSm>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 129\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/xa91QFSm>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 129\" .\r\n<https://id.parliament.uk/xa91QFSm> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"838\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/xa91QFSm>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 129\" .\r\n<https://id.parliament.uk/xa91QFSm> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/Wgm9YGFV> .\r\n<https://id.parliament.uk/xa91QFSm>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/7ayWbhIK>
+        .\r\n<https://id.parliament.uk/Wgm9YGFV> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/Wgm9YGFV>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-17+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/Wgm9YGFV> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fpWTqVKh> .\r\n<https://id.parliament.uk/7ayWbhIK>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/7ayWbhIK> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/ITytkRlT>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/ITytkRlT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/ITytkRlT>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/ITytkRlT> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 130\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/ITytkRlT> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 130\" .\r\n<https://id.parliament.uk/ITytkRlT>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"522\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/ITytkRlT> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 130\" .\r\n<https://id.parliament.uk/ITytkRlT>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/pA6X11np>
+        .\r\n<https://id.parliament.uk/ITytkRlT> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/DX1ZptHJ> .\r\n<https://id.parliament.uk/pA6X11np>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/pA6X11np> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-01+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/pA6X11np>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/JVJB3tuB>
+        .\r\n<https://id.parliament.uk/JVJB3tuB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Group> .\r\n<https://id.parliament.uk/JVJB3tuB>
+        <https://id.parliament.uk/schema/groupName> \"groupName - 19\" .\r\n<https://id.parliament.uk/DX1ZptHJ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/DX1ZptHJ> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/7uCF2qgm>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/7uCF2qgm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/7uCF2qgm>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/7uCF2qgm> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 131\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/7uCF2qgm> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 131\" .\r\n<https://id.parliament.uk/7uCF2qgm>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"521\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/7uCF2qgm> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 131\" .\r\n<https://id.parliament.uk/7uCF2qgm>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/B7FoleTf>
+        .\r\n<https://id.parliament.uk/7uCF2qgm> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/sSDUxi1Q> .\r\n<https://id.parliament.uk/B7FoleTf>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/B7FoleTf> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-01+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/B7FoleTf>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/JVJB3tuB>
+        .\r\n<https://id.parliament.uk/sSDUxi1Q> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/sSDUxi1Q>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/vBqvzucr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/vBqvzucr>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/vBqvzucr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/vBqvzucr>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 132\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/vBqvzucr>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 132\" .\r\n<https://id.parliament.uk/vBqvzucr> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"513\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/vBqvzucr>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 132\" .\r\n<https://id.parliament.uk/vBqvzucr> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/AhLtGgwE> .\r\n<https://id.parliament.uk/vBqvzucr>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/oaeGqOmW>
+        .\r\n<https://id.parliament.uk/AhLtGgwE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/AhLtGgwE>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-26+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/AhLtGgwE> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fpWTqVKh> .\r\n<https://id.parliament.uk/oaeGqOmW>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/oaeGqOmW> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/4e7ROEBU>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/4e7ROEBU> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/4e7ROEBU>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/4e7ROEBU> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 133\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/4e7ROEBU> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 133\" .\r\n<https://id.parliament.uk/4e7ROEBU>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"626\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/4e7ROEBU> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 133\" .\r\n<https://id.parliament.uk/4e7ROEBU>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/uXgMiiXW>
+        .\r\n<https://id.parliament.uk/4e7ROEBU> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/NY96FUuV> .\r\n<https://id.parliament.uk/uXgMiiXW>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/uXgMiiXW> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-30+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/uXgMiiXW>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/JVJB3tuB>
+        .\r\n<https://id.parliament.uk/NY96FUuV> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/NY96FUuV>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/9S89Uofh> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/9S89Uofh>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/9S89Uofh> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/9S89Uofh>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 134\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/9S89Uofh>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 134\" .\r\n<https://id.parliament.uk/9S89Uofh> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"623\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/9S89Uofh>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 134\" .\r\n<https://id.parliament.uk/9S89Uofh> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/6Rz43qvX> .\r\n<https://id.parliament.uk/9S89Uofh>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/nR6OHhoL>
+        .\r\n<https://id.parliament.uk/6Rz43qvX> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/6Rz43qvX>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-30+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/6Rz43qvX> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/JVJB3tuB> .\r\n<https://id.parliament.uk/nR6OHhoL>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/nR6OHhoL> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/4bwmdrUh>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/4bwmdrUh> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/4bwmdrUh>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/4bwmdrUh> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 135\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/4bwmdrUh> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 135\" .\r\n<https://id.parliament.uk/4bwmdrUh>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"620\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/4bwmdrUh> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 135\" .\r\n<https://id.parliament.uk/4bwmdrUh>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/9NDpK6YH>
+        .\r\n<https://id.parliament.uk/4bwmdrUh> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/PXfg6pxB> .\r\n<https://id.parliament.uk/9NDpK6YH>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/9NDpK6YH> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-30+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/9NDpK6YH>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/JVJB3tuB>
+        .\r\n<https://id.parliament.uk/PXfg6pxB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/PXfg6pxB>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/YI5L3LfM> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/YI5L3LfM>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/YI5L3LfM> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/YI5L3LfM>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 136\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/YI5L3LfM>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 136\" .\r\n<https://id.parliament.uk/YI5L3LfM> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"622\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/YI5L3LfM>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 136\" .\r\n<https://id.parliament.uk/YI5L3LfM> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/4i2IW9JJ> .\r\n<https://id.parliament.uk/YI5L3LfM>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/uMC04oEu>
+        .\r\n<https://id.parliament.uk/4i2IW9JJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/4i2IW9JJ>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-30+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/4i2IW9JJ> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/JVJB3tuB> .\r\n<https://id.parliament.uk/uMC04oEu>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/uMC04oEu> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/X9tJrtug>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/X9tJrtug> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/X9tJrtug>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/X9tJrtug> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 137\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/X9tJrtug> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 137\" .\r\n<https://id.parliament.uk/X9tJrtug>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"837\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/X9tJrtug> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 137\" .\r\n<https://id.parliament.uk/X9tJrtug>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/BoG0LUiU>
+        .\r\n<https://id.parliament.uk/X9tJrtug> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/hTZ6jXdk> .\r\n<https://id.parliament.uk/BoG0LUiU>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/BoG0LUiU> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-21+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/BoG0LUiU>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/ni8aOEk3>
+        .\r\n<https://id.parliament.uk/ni8aOEk3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Group> .\r\n<https://id.parliament.uk/ni8aOEk3>
+        <https://id.parliament.uk/schema/groupName> \"groupName - 20\" .\r\n<https://id.parliament.uk/hTZ6jXdk>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/hTZ6jXdk> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/MJ4ILVps>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/MJ4ILVps> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/MJ4ILVps>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/MJ4ILVps> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 138\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/MJ4ILVps> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 138\" .\r\n<https://id.parliament.uk/MJ4ILVps>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"734\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/MJ4ILVps> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 138\" .\r\n<https://id.parliament.uk/MJ4ILVps>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/b3UIQwJ8>
+        .\r\n<https://id.parliament.uk/MJ4ILVps> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/O2X0qWrg> .\r\n<https://id.parliament.uk/b3UIQwJ8>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/b3UIQwJ8> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-19+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/b3UIQwJ8>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/HYfypSOE>
+        .\r\n<https://id.parliament.uk/O2X0qWrg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/O2X0qWrg>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/6XQ6ig48> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/6XQ6ig48>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/6XQ6ig48> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/6XQ6ig48>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 139\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/6XQ6ig48>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 139\" .\r\n<https://id.parliament.uk/6XQ6ig48> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"731\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/6XQ6ig48>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 139\" .\r\n<https://id.parliament.uk/6XQ6ig48> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/OKq4nd7o> .\r\n<https://id.parliament.uk/6XQ6ig48>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/hj1bbx7c>
+        .\r\n<https://id.parliament.uk/OKq4nd7o> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/OKq4nd7o>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-18+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/OKq4nd7o> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/5LQ5Ar74> .\r\n<https://id.parliament.uk/hj1bbx7c>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/hj1bbx7c> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/GVXkRR2M>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/GVXkRR2M> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/GVXkRR2M>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/GVXkRR2M> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 140\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/GVXkRR2M> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 140\" .\r\n<https://id.parliament.uk/GVXkRR2M>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"1030\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/GVXkRR2M> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 140\" .\r\n<https://id.parliament.uk/GVXkRR2M>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/wgdGvoby>
+        .\r\n<https://id.parliament.uk/GVXkRR2M> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/k6e1O3T7> .\r\n<https://id.parliament.uk/wgdGvoby>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/wgdGvoby> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-18+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/wgdGvoby>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/XbTBTDMo>
+        .\r\n<https://id.parliament.uk/k6e1O3T7> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/k6e1O3T7>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/HNjL6uzv> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/HNjL6uzv>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/HNjL6uzv> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/HNjL6uzv>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 141\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/HNjL6uzv>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 141\" .\r\n<https://id.parliament.uk/HNjL6uzv> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"737\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/HNjL6uzv>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 141\" .\r\n<https://id.parliament.uk/HNjL6uzv> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/i3eQ1NDK> .\r\n<https://id.parliament.uk/HNjL6uzv>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/yPbxlCFH>
+        .\r\n<https://id.parliament.uk/i3eQ1NDK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/i3eQ1NDK>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-20+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/i3eQ1NDK> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/HYfypSOE> .\r\n<https://id.parliament.uk/yPbxlCFH>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/yPbxlCFH> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/OohXDEMJ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/OohXDEMJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/OohXDEMJ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/OohXDEMJ> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 142\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/OohXDEMJ> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 142\" .\r\n<https://id.parliament.uk/OohXDEMJ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"904\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/OohXDEMJ> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 142\" .\r\n<https://id.parliament.uk/OohXDEMJ>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/07mwhqiT>
+        .\r\n<https://id.parliament.uk/OohXDEMJ> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/QbzwUe17> .\r\n<https://id.parliament.uk/07mwhqiT>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/07mwhqiT> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-20+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/07mwhqiT>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/g8hByIik>
+        .\r\n<https://id.parliament.uk/g8hByIik> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Group> .\r\n<https://id.parliament.uk/g8hByIik>
+        <https://id.parliament.uk/schema/groupName> \"groupName - 21\" .\r\n<https://id.parliament.uk/QbzwUe17>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/QbzwUe17> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/4kSUJ4K2>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/4kSUJ4K2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/4kSUJ4K2>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/4kSUJ4K2> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 143\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/4kSUJ4K2> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 143\" .\r\n<https://id.parliament.uk/4kSUJ4K2>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"739\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/4kSUJ4K2> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 143\" .\r\n<https://id.parliament.uk/4kSUJ4K2>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/Jz5ayidS>
+        .\r\n<https://id.parliament.uk/4kSUJ4K2> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/vdp9GgsX> .\r\n<https://id.parliament.uk/Jz5ayidS>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/Jz5ayidS> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-20+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/Jz5ayidS>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/5LQ5Ar74>
+        .\r\n<https://id.parliament.uk/vdp9GgsX> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/vdp9GgsX>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/VdxVTQ0L> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/VdxVTQ0L>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/VdxVTQ0L> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/VdxVTQ0L>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 144\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/VdxVTQ0L>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 144\" .\r\n<https://id.parliament.uk/VdxVTQ0L> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"738\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/VdxVTQ0L>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 144\" .\r\n<https://id.parliament.uk/VdxVTQ0L> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/j9IPPPC9> .\r\n<https://id.parliament.uk/VdxVTQ0L>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/1B8DSj6y>
+        .\r\n<https://id.parliament.uk/j9IPPPC9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/j9IPPPC9>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-25+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/j9IPPPC9> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/7dSvuueH> .\r\n<https://id.parliament.uk/1B8DSj6y>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/1B8DSj6y> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/CMCJ3a82>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/CMCJ3a82> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/CMCJ3a82>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/CMCJ3a82> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 145\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/CMCJ3a82> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 145\" .\r\n<https://id.parliament.uk/CMCJ3a82>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"897\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/CMCJ3a82> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 145\" .\r\n<https://id.parliament.uk/CMCJ3a82>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/Llq9prcO>
+        .\r\n<https://id.parliament.uk/CMCJ3a82> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/NNZyLkm8> .\r\n<https://id.parliament.uk/Llq9prcO>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/Llq9prcO> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-25+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/Llq9prcO>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/HYfypSOE>
+        .\r\n<https://id.parliament.uk/NNZyLkm8> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/NNZyLkm8>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/mRgc1Qvc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/mRgc1Qvc>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/mRgc1Qvc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/mRgc1Qvc>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 146\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/mRgc1Qvc>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 146\" .\r\n<https://id.parliament.uk/mRgc1Qvc> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"761\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/mRgc1Qvc>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 146\" .\r\n<https://id.parliament.uk/mRgc1Qvc> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/wFTQha8D> .\r\n<https://id.parliament.uk/mRgc1Qvc>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/snpPLUSB>
+        .\r\n<https://id.parliament.uk/wFTQha8D> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/wFTQha8D>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-25+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/wFTQha8D> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/5LQ5Ar74> .\r\n<https://id.parliament.uk/snpPLUSB>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/snpPLUSB> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/h8w2BHwS>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/h8w2BHwS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/h8w2BHwS>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/h8w2BHwS> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 147\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/h8w2BHwS> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 147\" .\r\n<https://id.parliament.uk/h8w2BHwS>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"754\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/h8w2BHwS> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 147\" .\r\n<https://id.parliament.uk/h8w2BHwS>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/PVt9t1Mf>
+        .\r\n<https://id.parliament.uk/h8w2BHwS> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/GQOruZBT> .\r\n<https://id.parliament.uk/PVt9t1Mf>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/PVt9t1Mf> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-25+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/PVt9t1Mf>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/5LQ5Ar74>
+        .\r\n<https://id.parliament.uk/GQOruZBT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/GQOruZBT>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/UD4HjKbu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/UD4HjKbu>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/UD4HjKbu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/UD4HjKbu>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 148\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/UD4HjKbu>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 148\" .\r\n<https://id.parliament.uk/UD4HjKbu> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"748\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/UD4HjKbu>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 148\" .\r\n<https://id.parliament.uk/UD4HjKbu> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/9UPBD2Md> .\r\n<https://id.parliament.uk/UD4HjKbu>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/3dE9HsCE>
+        .\r\n<https://id.parliament.uk/9UPBD2Md> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/9UPBD2Md>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-25+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/9UPBD2Md> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/NDZSYjeE> .\r\n<https://id.parliament.uk/3dE9HsCE>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/3dE9HsCE> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/HZod54jz>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/HZod54jz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/HZod54jz>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/HZod54jz> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 149\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/HZod54jz> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 149\" .\r\n<https://id.parliament.uk/HZod54jz>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"771\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/HZod54jz> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 149\" .\r\n<https://id.parliament.uk/HZod54jz>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/tDtOGEse>
+        .\r\n<https://id.parliament.uk/HZod54jz> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/3WxJmYZD> .\r\n<https://id.parliament.uk/tDtOGEse>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/tDtOGEse> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-28+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/tDtOGEse>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/5LQ5Ar74>
+        .\r\n<https://id.parliament.uk/3WxJmYZD> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/3WxJmYZD>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/zfcsMSD3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/zfcsMSD3>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/zfcsMSD3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/zfcsMSD3>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 150\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/zfcsMSD3>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 150\" .\r\n<https://id.parliament.uk/zfcsMSD3> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"769\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/zfcsMSD3>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 150\" .\r\n<https://id.parliament.uk/zfcsMSD3> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/Qol6iEYA> .\r\n<https://id.parliament.uk/zfcsMSD3>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/1po2BJxp>
+        .\r\n<https://id.parliament.uk/Qol6iEYA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/Qol6iEYA>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-28+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/Qol6iEYA> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XbTBTDMo> .\r\n<https://id.parliament.uk/1po2BJxp>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/1po2BJxp> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/NTd30zpo>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/NTd30zpo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/NTd30zpo>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/NTd30zpo> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 151\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/NTd30zpo> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 151\" .\r\n<https://id.parliament.uk/NTd30zpo>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"764\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/NTd30zpo> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 151\" .\r\n<https://id.parliament.uk/NTd30zpo>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/IsIZtZBp>
+        .\r\n<https://id.parliament.uk/NTd30zpo> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/XNmQJL6V> .\r\n<https://id.parliament.uk/IsIZtZBp>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/IsIZtZBp> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-28+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/IsIZtZBp>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/XouN12Ow>
+        .\r\n<https://id.parliament.uk/XNmQJL6V> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/XNmQJL6V>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/5dLGzkeI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/5dLGzkeI>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/5dLGzkeI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/5dLGzkeI>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 152\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/5dLGzkeI>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 152\" .\r\n<https://id.parliament.uk/5dLGzkeI> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 152\" .\r\n<https://id.parliament.uk/5dLGzkeI>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/whjpgchX>
+        .\r\n<https://id.parliament.uk/5dLGzkeI> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/3bZHylgr> .\r\n<https://id.parliament.uk/whjpgchX>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/whjpgchX> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-28+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/whjpgchX>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/BRTNQywN>
+        .\r\n<https://id.parliament.uk/3bZHylgr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/3bZHylgr>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/98auwKwP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/98auwKwP>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/98auwKwP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/98auwKwP>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 153\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/98auwKwP>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 153\" .\r\n<https://id.parliament.uk/98auwKwP> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"770\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/98auwKwP>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 153\" .\r\n<https://id.parliament.uk/98auwKwP> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/wgDLFyxo> .\r\n<https://id.parliament.uk/98auwKwP>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/F7LRwguI>
+        .\r\n<https://id.parliament.uk/wgDLFyxo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/wgDLFyxo>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-28+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/wgDLFyxo> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/BRTNQywN> .\r\n<https://id.parliament.uk/F7LRwguI>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/F7LRwguI> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/P5Zu6fkP>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/P5Zu6fkP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/P5Zu6fkP>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/P5Zu6fkP> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 154\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/P5Zu6fkP> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 154\" .\r\n<https://id.parliament.uk/P5Zu6fkP>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 154\" .\r\n<https://id.parliament.uk/P5Zu6fkP> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/FafO3XiI> .\r\n<https://id.parliament.uk/P5Zu6fkP>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/fa5HaWHq>
+        .\r\n<https://id.parliament.uk/FafO3XiI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/FafO3XiI>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-28+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/FafO3XiI> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/NDZSYjeE> .\r\n<https://id.parliament.uk/fa5HaWHq>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/fa5HaWHq> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/4GqD7K0p>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/4GqD7K0p> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/4GqD7K0p>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/4GqD7K0p> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 155\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/4GqD7K0p> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 155\" .\r\n<https://id.parliament.uk/4GqD7K0p>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"755\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/4GqD7K0p> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 155\" .\r\n<https://id.parliament.uk/4GqD7K0p>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/xGF76JwA>
+        .\r\n<https://id.parliament.uk/4GqD7K0p> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/PHiVZHeP> .\r\n<https://id.parliament.uk/xGF76JwA>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/xGF76JwA> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-29+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/xGF76JwA>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/fpWTqVKh>
+        .\r\n<https://id.parliament.uk/PHiVZHeP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/PHiVZHeP>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/Foe6fVxK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/Foe6fVxK>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/Foe6fVxK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/Foe6fVxK>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 156\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/Foe6fVxK>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 156\" .\r\n<https://id.parliament.uk/Foe6fVxK> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"756\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/Foe6fVxK>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 156\" .\r\n<https://id.parliament.uk/Foe6fVxK> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/J1PeCqRi> .\r\n<https://id.parliament.uk/Foe6fVxK>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/iOR7pNdJ>
+        .\r\n<https://id.parliament.uk/J1PeCqRi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/J1PeCqRi>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-29+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/J1PeCqRi> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fpWTqVKh> .\r\n<https://id.parliament.uk/iOR7pNdJ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/iOR7pNdJ> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/RS3W2NQw>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/RS3W2NQw> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/RS3W2NQw>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/RS3W2NQw> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 157\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/RS3W2NQw> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 157\" .\r\n<https://id.parliament.uk/RS3W2NQw>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"757\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/RS3W2NQw> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 157\" .\r\n<https://id.parliament.uk/RS3W2NQw>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/YoZD3Wma>
+        .\r\n<https://id.parliament.uk/RS3W2NQw> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/jQuzcqf5> .\r\n<https://id.parliament.uk/YoZD3Wma>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/YoZD3Wma> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-29+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/YoZD3Wma>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/fpWTqVKh>
+        .\r\n<https://id.parliament.uk/jQuzcqf5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/jQuzcqf5>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/m1AZ18wg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/m1AZ18wg>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/m1AZ18wg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/m1AZ18wg>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 158\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/m1AZ18wg>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 158\" .\r\n<https://id.parliament.uk/m1AZ18wg> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"788\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/m1AZ18wg>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 158\" .\r\n<https://id.parliament.uk/m1AZ18wg> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/7cMqzvFg> .\r\n<https://id.parliament.uk/m1AZ18wg>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/ms7N7n0G>
+        .\r\n<https://id.parliament.uk/7cMqzvFg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/7cMqzvFg>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-29+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/7cMqzvFg> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fpWTqVKh> .\r\n<https://id.parliament.uk/ms7N7n0G>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/ms7N7n0G> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/JPx0duf2>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/JPx0duf2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/JPx0duf2>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/JPx0duf2> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 159\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/JPx0duf2> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 159\" .\r\n<https://id.parliament.uk/JPx0duf2>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"794\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/JPx0duf2> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 159\" .\r\n<https://id.parliament.uk/JPx0duf2>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/XyqblZIf>
+        .\r\n<https://id.parliament.uk/JPx0duf2> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/Kesi1bdT> .\r\n<https://id.parliament.uk/XyqblZIf>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/XyqblZIf> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-02+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/XyqblZIf>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/7dSvuueH>
+        .\r\n<https://id.parliament.uk/Kesi1bdT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/Kesi1bdT>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/C8kKvTBL> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/C8kKvTBL>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/C8kKvTBL> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/C8kKvTBL>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 160\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/C8kKvTBL>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 160\" .\r\n<https://id.parliament.uk/C8kKvTBL> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"784\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/C8kKvTBL>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 160\" .\r\n<https://id.parliament.uk/C8kKvTBL> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/YX81GShN> .\r\n<https://id.parliament.uk/C8kKvTBL>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/6kgJ0bGh>
+        .\r\n<https://id.parliament.uk/YX81GShN> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/YX81GShN>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-02+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/YX81GShN> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XouN12Ow> .\r\n<https://id.parliament.uk/6kgJ0bGh>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/6kgJ0bGh> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/c0IpQmwt>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/c0IpQmwt> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/c0IpQmwt>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/c0IpQmwt> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 161\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/c0IpQmwt> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 161\" .\r\n<https://id.parliament.uk/c0IpQmwt>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"903\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/c0IpQmwt> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 161\" .\r\n<https://id.parliament.uk/c0IpQmwt>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/ttdjT68P>
+        .\r\n<https://id.parliament.uk/c0IpQmwt> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/G9ni0BQM> .\r\n<https://id.parliament.uk/ttdjT68P>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/ttdjT68P> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-02+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/ttdjT68P>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/7dSvuueH>
+        .\r\n<https://id.parliament.uk/G9ni0BQM> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/G9ni0BQM>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/2KKfR6RI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/2KKfR6RI>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/2KKfR6RI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/2KKfR6RI>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 162\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/2KKfR6RI>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 162\" .\r\n<https://id.parliament.uk/2KKfR6RI> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"786\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/2KKfR6RI>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 162\" .\r\n<https://id.parliament.uk/2KKfR6RI> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/UbCkOSbi> .\r\n<https://id.parliament.uk/2KKfR6RI>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/ZlOeT88V>
+        .\r\n<https://id.parliament.uk/UbCkOSbi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/UbCkOSbi>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-29+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/UbCkOSbi> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/HYfypSOE> .\r\n<https://id.parliament.uk/ZlOeT88V>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/ZlOeT88V> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/BZPGfEza>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/BZPGfEza> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/BZPGfEza>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/BZPGfEza> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 163\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/BZPGfEza> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 163\" .\r\n<https://id.parliament.uk/BZPGfEza>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"785\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/BZPGfEza> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 163\" .\r\n<https://id.parliament.uk/BZPGfEza>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/ftFuVyQ5>
+        .\r\n<https://id.parliament.uk/BZPGfEza> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/J8EN7E6N> .\r\n<https://id.parliament.uk/ftFuVyQ5>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/ftFuVyQ5> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-02+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/ftFuVyQ5>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/XouN12Ow>
+        .\r\n<https://id.parliament.uk/J8EN7E6N> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/J8EN7E6N>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/JXxhQblu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/JXxhQblu>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/JXxhQblu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/JXxhQblu>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 164\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/JXxhQblu>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 164\" .\r\n<https://id.parliament.uk/JXxhQblu> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"801\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/JXxhQblu>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 164\" .\r\n<https://id.parliament.uk/JXxhQblu> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/Wd3zlHhD> .\r\n<https://id.parliament.uk/JXxhQblu>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/H6mzvSsA>
+        .\r\n<https://id.parliament.uk/Wd3zlHhD> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/Wd3zlHhD>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-03+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/Wd3zlHhD> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/NDZSYjeE> .\r\n<https://id.parliament.uk/H6mzvSsA>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/H6mzvSsA> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/9Brknpn7>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/9Brknpn7> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/9Brknpn7>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/9Brknpn7> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 165\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/9Brknpn7> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 165\" .\r\n<https://id.parliament.uk/9Brknpn7>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"795\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/9Brknpn7> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 165\" .\r\n<https://id.parliament.uk/9Brknpn7>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/VPUSkLJO>
+        .\r\n<https://id.parliament.uk/9Brknpn7> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/D63ld0id> .\r\n<https://id.parliament.uk/VPUSkLJO>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/VPUSkLJO> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-03+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/VPUSkLJO>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/yiuTaSI4>
+        .\r\n<https://id.parliament.uk/D63ld0id> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/D63ld0id>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/IjLgnN8z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/IjLgnN8z>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/IjLgnN8z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/IjLgnN8z>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 166\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/IjLgnN8z>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 166\" .\r\n<https://id.parliament.uk/IjLgnN8z> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"928\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/IjLgnN8z>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 166\" .\r\n<https://id.parliament.uk/IjLgnN8z> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/i4m8WLDM> .\r\n<https://id.parliament.uk/IjLgnN8z>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/Y6qiLSBv>
+        .\r\n<https://id.parliament.uk/i4m8WLDM> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/i4m8WLDM>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-02+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/i4m8WLDM> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/NDZSYjeE> .\r\n<https://id.parliament.uk/Y6qiLSBv>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/Y6qiLSBv> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/1aUCYOe7>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/1aUCYOe7> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/1aUCYOe7>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/1aUCYOe7> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 167\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/1aUCYOe7> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 167\" .\r\n<https://id.parliament.uk/1aUCYOe7>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"803\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/1aUCYOe7> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 167\" .\r\n<https://id.parliament.uk/1aUCYOe7>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/K7jOJhiU>
+        .\r\n<https://id.parliament.uk/1aUCYOe7> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/EayTsjgy> .\r\n<https://id.parliament.uk/K7jOJhiU>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/K7jOJhiU> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-02+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/K7jOJhiU>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/BRTNQywN>
+        .\r\n<https://id.parliament.uk/EayTsjgy> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/EayTsjgy>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/zd4ymhhN> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/zd4ymhhN>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/zd4ymhhN> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/zd4ymhhN>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 168\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/zd4ymhhN>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 168\" .\r\n<https://id.parliament.uk/zd4ymhhN> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"781\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/zd4ymhhN>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 168\" .\r\n<https://id.parliament.uk/zd4ymhhN> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/HIYdvdKZ> .\r\n<https://id.parliament.uk/zd4ymhhN>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/vdPBBc3g>
+        .\r\n<https://id.parliament.uk/HIYdvdKZ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/HIYdvdKZ>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/HIYdvdKZ> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/yiuTaSI4> .\r\n<https://id.parliament.uk/vdPBBc3g>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/vdPBBc3g> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/MIqYKT1i>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/MIqYKT1i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/MIqYKT1i>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/MIqYKT1i> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 169\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/MIqYKT1i> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 169\" .\r\n<https://id.parliament.uk/MIqYKT1i>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"812\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/MIqYKT1i> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 169\" .\r\n<https://id.parliament.uk/MIqYKT1i>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/Boe0Cd42>
+        .\r\n<https://id.parliament.uk/MIqYKT1i> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/TUVPHf9x> .\r\n<https://id.parliament.uk/Boe0Cd42>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/Boe0Cd42> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/Boe0Cd42>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/BRTNQywN>
+        .\r\n<https://id.parliament.uk/TUVPHf9x> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/TUVPHf9x>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/YhwigIF6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/YhwigIF6>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/YhwigIF6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/YhwigIF6>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 170\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/YhwigIF6>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 170\" .\r\n<https://id.parliament.uk/YhwigIF6> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"0\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/YhwigIF6>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 170\" .\r\n<https://id.parliament.uk/YhwigIF6> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/g01JvVJo> .\r\n<https://id.parliament.uk/YhwigIF6>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/PnLLjtW0>
+        .\r\n<https://id.parliament.uk/g01JvVJo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/g01JvVJo>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/g01JvVJo> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/yiuTaSI4> .\r\n<https://id.parliament.uk/PnLLjtW0>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/PnLLjtW0> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/SUtuR6qs>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/SUtuR6qs> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/SUtuR6qs>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/SUtuR6qs> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 171\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/SUtuR6qs> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 171\" .\r\n<https://id.parliament.uk/SUtuR6qs>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"780\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/SUtuR6qs> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 171\" .\r\n<https://id.parliament.uk/SUtuR6qs>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/DTIQmiVQ>
+        .\r\n<https://id.parliament.uk/SUtuR6qs> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/UNTY7PNO> .\r\n<https://id.parliament.uk/DTIQmiVQ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/DTIQmiVQ> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/DTIQmiVQ>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/JVJB3tuB>
+        .\r\n<https://id.parliament.uk/UNTY7PNO> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/UNTY7PNO>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/UBL9i00X> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/UBL9i00X>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/UBL9i00X> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/UBL9i00X>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 172\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/UBL9i00X>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 172\" .\r\n<https://id.parliament.uk/UBL9i00X> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"810\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/UBL9i00X>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 172\" .\r\n<https://id.parliament.uk/UBL9i00X> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/lenIZKiU> .\r\n<https://id.parliament.uk/UBL9i00X>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/42YVAgkz>
+        .\r\n<https://id.parliament.uk/lenIZKiU> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/lenIZKiU>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-06+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/lenIZKiU> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/7dSvuueH> .\r\n<https://id.parliament.uk/42YVAgkz>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/42YVAgkz> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/KF90wtY4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/KF90wtY4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/KF90wtY4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/KF90wtY4> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 173\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/KF90wtY4> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 173\" .\r\n<https://id.parliament.uk/KF90wtY4>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"816\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/KF90wtY4> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 173\" .\r\n<https://id.parliament.uk/KF90wtY4>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/AWsJmRFZ>
+        .\r\n<https://id.parliament.uk/KF90wtY4> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/gfOq850z> .\r\n<https://id.parliament.uk/AWsJmRFZ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/AWsJmRFZ> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-09+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/AWsJmRFZ>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/XouN12Ow>
+        .\r\n<https://id.parliament.uk/gfOq850z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/gfOq850z>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/gcbZWM8q> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/gcbZWM8q>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/gcbZWM8q> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/gcbZWM8q>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 174\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/gcbZWM8q>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 174\" .\r\n<https://id.parliament.uk/gcbZWM8q> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"0\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/gcbZWM8q>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 174\" .\r\n<https://id.parliament.uk/gcbZWM8q> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/5wkrOAtY> .\r\n<https://id.parliament.uk/gcbZWM8q>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/PIfP18CQ>
+        .\r\n<https://id.parliament.uk/5wkrOAtY> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/5wkrOAtY>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-10+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/5wkrOAtY> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fpWTqVKh> .\r\n<https://id.parliament.uk/PIfP18CQ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/PIfP18CQ> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/Hw2xKRsZ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/Hw2xKRsZ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/Hw2xKRsZ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/Hw2xKRsZ> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 175\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/Hw2xKRsZ> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 175\" .\r\n<https://id.parliament.uk/Hw2xKRsZ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"825\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/Hw2xKRsZ> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 175\" .\r\n<https://id.parliament.uk/Hw2xKRsZ>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/GB5n2CDh>
+        .\r\n<https://id.parliament.uk/Hw2xKRsZ> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/mnCKpXns> .\r\n<https://id.parliament.uk/GB5n2CDh>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/GB5n2CDh> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-10+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/GB5n2CDh>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/yiuTaSI4>
+        .\r\n<https://id.parliament.uk/mnCKpXns> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/mnCKpXns>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/vUb6Fcnn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/vUb6Fcnn>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/vUb6Fcnn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/vUb6Fcnn>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 176\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/vUb6Fcnn>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 176\" .\r\n<https://id.parliament.uk/vUb6Fcnn> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"833\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/vUb6Fcnn>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 176\" .\r\n<https://id.parliament.uk/vUb6Fcnn> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/Wu1mmRM1> .\r\n<https://id.parliament.uk/vUb6Fcnn>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/H0wSQ5qG>
+        .\r\n<https://id.parliament.uk/Wu1mmRM1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/Wu1mmRM1>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-12+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/Wu1mmRM1> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/HYfypSOE> .\r\n<https://id.parliament.uk/H0wSQ5qG>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/H0wSQ5qG> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/BRZBy463>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/BRZBy463> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/BRZBy463>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/BRZBy463> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 177\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/BRZBy463> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 177\" .\r\n<https://id.parliament.uk/BRZBy463>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"0\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/BRZBy463> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 177\" .\r\n<https://id.parliament.uk/BRZBy463>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/JBIhn7el>
+        .\r\n<https://id.parliament.uk/BRZBy463> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/FKyIv1xY> .\r\n<https://id.parliament.uk/JBIhn7el>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/JBIhn7el> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-12+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/JBIhn7el>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/NDZSYjeE>
+        .\r\n<https://id.parliament.uk/FKyIv1xY> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/FKyIv1xY>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/bYMAmxYQ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/bYMAmxYQ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/bYMAmxYQ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/bYMAmxYQ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 178\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/bYMAmxYQ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 178\" .\r\n<https://id.parliament.uk/bYMAmxYQ> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"827\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/bYMAmxYQ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 178\" .\r\n<https://id.parliament.uk/bYMAmxYQ> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/Wna4PL6v> .\r\n<https://id.parliament.uk/bYMAmxYQ>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/K4kH9tSl>
+        .\r\n<https://id.parliament.uk/Wna4PL6v> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/Wna4PL6v>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-12+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/Wna4PL6v> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fKqMNz79> .\r\n<https://id.parliament.uk/K4kH9tSl>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/K4kH9tSl> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/cXKDMYqV>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/cXKDMYqV> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/cXKDMYqV>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/cXKDMYqV> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 179\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/cXKDMYqV> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 179\" .\r\n<https://id.parliament.uk/cXKDMYqV>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"834\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/cXKDMYqV> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 179\" .\r\n<https://id.parliament.uk/cXKDMYqV>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/N5MVHv16>
+        .\r\n<https://id.parliament.uk/cXKDMYqV> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/nns38yQv> .\r\n<https://id.parliament.uk/N5MVHv16>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/N5MVHv16> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-12+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/N5MVHv16>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/yiuTaSI4>
+        .\r\n<https://id.parliament.uk/nns38yQv> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/nns38yQv>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/cDVVk8C2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/cDVVk8C2>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/cDVVk8C2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/cDVVk8C2>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 180\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/cDVVk8C2>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 180\" .\r\n<https://id.parliament.uk/cDVVk8C2> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"0\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/cDVVk8C2>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 180\" .\r\n<https://id.parliament.uk/cDVVk8C2> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/KLBRomRn> .\r\n<https://id.parliament.uk/cDVVk8C2>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/38oel2on>
+        .\r\n<https://id.parliament.uk/KLBRomRn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/KLBRomRn>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-12+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/KLBRomRn> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XbTBTDMo> .\r\n<https://id.parliament.uk/38oel2on>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/38oel2on> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/JHmYoIfJ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/JHmYoIfJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/JHmYoIfJ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/JHmYoIfJ> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 181\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/JHmYoIfJ> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 181\" .\r\n<https://id.parliament.uk/JHmYoIfJ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"852\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/JHmYoIfJ> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 181\" .\r\n<https://id.parliament.uk/JHmYoIfJ>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/LwHhcLOH>
+        .\r\n<https://id.parliament.uk/JHmYoIfJ> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/6OQ1w3DW> .\r\n<https://id.parliament.uk/LwHhcLOH>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/LwHhcLOH> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-16+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/LwHhcLOH>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/7gnSwbLO>
+        .\r\n<https://id.parliament.uk/6OQ1w3DW> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/6OQ1w3DW>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/55gPdheg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/55gPdheg>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/55gPdheg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/55gPdheg>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 182\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/55gPdheg>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 182\" .\r\n<https://id.parliament.uk/55gPdheg> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"819\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/55gPdheg>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 182\" .\r\n<https://id.parliament.uk/55gPdheg> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/9T8nEUBG> .\r\n<https://id.parliament.uk/55gPdheg>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/2587nSWp>
+        .\r\n<https://id.parliament.uk/9T8nEUBG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/9T8nEUBG>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-13+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/9T8nEUBG> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XouN12Ow> .\r\n<https://id.parliament.uk/2587nSWp>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/2587nSWp> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/qSs9kGvu>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/qSs9kGvu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/qSs9kGvu>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/qSs9kGvu> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 183\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/qSs9kGvu> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 183\" .\r\n<https://id.parliament.uk/qSs9kGvu>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"844\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/qSs9kGvu> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 183\" .\r\n<https://id.parliament.uk/qSs9kGvu>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/wNIEHC5o>
+        .\r\n<https://id.parliament.uk/qSs9kGvu> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/gyec2cjN> .\r\n<https://id.parliament.uk/wNIEHC5o>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/wNIEHC5o> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-16+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/wNIEHC5o>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/fpWTqVKh>
+        .\r\n<https://id.parliament.uk/gyec2cjN> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/gyec2cjN>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/QsAJ99E3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/QsAJ99E3>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/QsAJ99E3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/QsAJ99E3>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 184\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/QsAJ99E3>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 184\" .\r\n<https://id.parliament.uk/QsAJ99E3> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"850\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/QsAJ99E3>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 184\" .\r\n<https://id.parliament.uk/QsAJ99E3> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/BFTcwmEt> .\r\n<https://id.parliament.uk/QsAJ99E3>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/mA0R8oxO>
+        .\r\n<https://id.parliament.uk/BFTcwmEt> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/BFTcwmEt>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-16+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/BFTcwmEt> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/5LQ5Ar74> .\r\n<https://id.parliament.uk/mA0R8oxO>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/mA0R8oxO> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/wIlQG2bb>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/wIlQG2bb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/wIlQG2bb>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/wIlQG2bb> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 185\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/wIlQG2bb> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 185\" .\r\n<https://id.parliament.uk/wIlQG2bb>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"0\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/wIlQG2bb> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 185\" .\r\n<https://id.parliament.uk/wIlQG2bb>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/EqDEAgrl>
+        .\r\n<https://id.parliament.uk/wIlQG2bb> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/RvO51D8Y> .\r\n<https://id.parliament.uk/EqDEAgrl>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/EqDEAgrl> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-16+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/EqDEAgrl>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/HYfypSOE>
+        .\r\n<https://id.parliament.uk/RvO51D8Y> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/RvO51D8Y>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/Qeou2KIY> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/Qeou2KIY>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/Qeou2KIY> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/Qeou2KIY>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 186\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/Qeou2KIY>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 186\" .\r\n<https://id.parliament.uk/Qeou2KIY> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"849\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/Qeou2KIY>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 186\" .\r\n<https://id.parliament.uk/Qeou2KIY> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/Es4s1iwT> .\r\n<https://id.parliament.uk/Qeou2KIY>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/alYVrL7p>
+        .\r\n<https://id.parliament.uk/Es4s1iwT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/Es4s1iwT>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-16+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/Es4s1iwT> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/5LQ5Ar74> .\r\n<https://id.parliament.uk/alYVrL7p>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/alYVrL7p> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/ySndNUxm>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/ySndNUxm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/ySndNUxm>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/ySndNUxm> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 187\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/ySndNUxm> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 187\" .\r\n<https://id.parliament.uk/ySndNUxm>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"847\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/ySndNUxm> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 187\" .\r\n<https://id.parliament.uk/ySndNUxm>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/dAvXzDoh>
+        .\r\n<https://id.parliament.uk/ySndNUxm> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/Jqw7AKcM> .\r\n<https://id.parliament.uk/dAvXzDoh>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/dAvXzDoh> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-16+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/dAvXzDoh>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/BRTNQywN>
+        .\r\n<https://id.parliament.uk/Jqw7AKcM> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/Jqw7AKcM>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/zVuPoOWp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/zVuPoOWp>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/zVuPoOWp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/zVuPoOWp>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 188\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/zVuPoOWp>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 188\" .\r\n<https://id.parliament.uk/zVuPoOWp> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"858\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/zVuPoOWp>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 188\" .\r\n<https://id.parliament.uk/zVuPoOWp> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/JRyvYZXd> .\r\n<https://id.parliament.uk/zVuPoOWp>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/8zjP35K1>
+        .\r\n<https://id.parliament.uk/JRyvYZXd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/JRyvYZXd>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-17+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/JRyvYZXd> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/HYfypSOE> .\r\n<https://id.parliament.uk/8zjP35K1>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/8zjP35K1> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/DS1GQhA5>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/DS1GQhA5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/DS1GQhA5>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/DS1GQhA5> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 189\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/DS1GQhA5> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 189\" .\r\n<https://id.parliament.uk/DS1GQhA5>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"0\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/DS1GQhA5> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 189\" .\r\n<https://id.parliament.uk/DS1GQhA5>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/0oJHqI9L>
+        .\r\n<https://id.parliament.uk/DS1GQhA5> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/xVDuhFhy> .\r\n<https://id.parliament.uk/0oJHqI9L>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/0oJHqI9L> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-18+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/0oJHqI9L>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/yiuTaSI4>
+        .\r\n<https://id.parliament.uk/xVDuhFhy> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/xVDuhFhy>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/m6w1ruLC> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/m6w1ruLC>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/m6w1ruLC> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/m6w1ruLC>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 190\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/m6w1ruLC>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 190\" .\r\n<https://id.parliament.uk/m6w1ruLC> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"0\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/m6w1ruLC>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 190\" .\r\n<https://id.parliament.uk/m6w1ruLC> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/bWBbaJiz> .\r\n<https://id.parliament.uk/m6w1ruLC>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/k2fiopk4>
+        .\r\n<https://id.parliament.uk/bWBbaJiz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/bWBbaJiz>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-18+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/bWBbaJiz> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/DkHdH4kZ> .\r\n<https://id.parliament.uk/k2fiopk4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/k2fiopk4> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/VXLHPnoP>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/VXLHPnoP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/VXLHPnoP>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/VXLHPnoP> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 191\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/VXLHPnoP> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 191\" .\r\n<https://id.parliament.uk/VXLHPnoP>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"841\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/VXLHPnoP> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 191\" .\r\n<https://id.parliament.uk/VXLHPnoP>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/z1cXXUlX>
+        .\r\n<https://id.parliament.uk/VXLHPnoP> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/WNbpxbb2> .\r\n<https://id.parliament.uk/z1cXXUlX>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/z1cXXUlX> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-18+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/z1cXXUlX>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/JVJB3tuB>
+        .\r\n<https://id.parliament.uk/WNbpxbb2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/WNbpxbb2>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/uPVA7EvA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/uPVA7EvA>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/uPVA7EvA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/uPVA7EvA>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 192\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/uPVA7EvA>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 192\" .\r\n<https://id.parliament.uk/uPVA7EvA> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"0\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/uPVA7EvA>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 192\" .\r\n<https://id.parliament.uk/uPVA7EvA> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/2Xu3cFqr> .\r\n<https://id.parliament.uk/uPVA7EvA>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/skuLtkzM>
+        .\r\n<https://id.parliament.uk/2Xu3cFqr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/2Xu3cFqr>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-19+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/2Xu3cFqr> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/ni8aOEk3> .\r\n<https://id.parliament.uk/skuLtkzM>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/skuLtkzM> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/Uhsvsfdn>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/Uhsvsfdn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/Uhsvsfdn>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/Uhsvsfdn> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 193\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/Uhsvsfdn> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 193\" .\r\n<https://id.parliament.uk/Uhsvsfdn>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"851\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/Uhsvsfdn> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 193\" .\r\n<https://id.parliament.uk/Uhsvsfdn>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/MAHrwKV2>
+        .\r\n<https://id.parliament.uk/Uhsvsfdn> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/RxC0FtSg> .\r\n<https://id.parliament.uk/MAHrwKV2>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/MAHrwKV2> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-19+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/MAHrwKV2>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/NDZSYjeE>
+        .\r\n<https://id.parliament.uk/RxC0FtSg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/RxC0FtSg>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/QI5WArIQ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/QI5WArIQ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/QI5WArIQ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/QI5WArIQ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 194\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/QI5WArIQ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 194\" .\r\n<https://id.parliament.uk/QI5WArIQ> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"0\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/QI5WArIQ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 194\" .\r\n<https://id.parliament.uk/QI5WArIQ> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/FDFI2J2G> .\r\n<https://id.parliament.uk/QI5WArIQ>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/bm6TrRXM>
+        .\r\n<https://id.parliament.uk/FDFI2J2G> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/FDFI2J2G>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-19+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/FDFI2J2G> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XouN12Ow> .\r\n<https://id.parliament.uk/bm6TrRXM>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/bm6TrRXM> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/a8wT3ym2>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/a8wT3ym2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/a8wT3ym2>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/a8wT3ym2> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 195\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/a8wT3ym2> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 195\" .\r\n<https://id.parliament.uk/a8wT3ym2>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"869\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/a8wT3ym2> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 195\" .\r\n<https://id.parliament.uk/a8wT3ym2>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/FzvGkYUO>
+        .\r\n<https://id.parliament.uk/a8wT3ym2> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/aU26TzPE> .\r\n<https://id.parliament.uk/FzvGkYUO>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/FzvGkYUO> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-19+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/FzvGkYUO>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/ZU3IXBtP>
+        .\r\n<https://id.parliament.uk/aU26TzPE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/aU26TzPE>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/M3L8iguJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/M3L8iguJ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/M3L8iguJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/M3L8iguJ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 196\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/M3L8iguJ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 196\" .\r\n<https://id.parliament.uk/M3L8iguJ> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"866\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/M3L8iguJ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 196\" .\r\n<https://id.parliament.uk/M3L8iguJ> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/TGtwlRb9> .\r\n<https://id.parliament.uk/M3L8iguJ>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/Foc4rbD1>
+        .\r\n<https://id.parliament.uk/TGtwlRb9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/TGtwlRb9>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-19+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/TGtwlRb9> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/79sn5e3n> .\r\n<https://id.parliament.uk/Foc4rbD1>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/Foc4rbD1> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/EqisWZtW>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/EqisWZtW> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/EqisWZtW>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/EqisWZtW> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 197\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/EqisWZtW> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 197\" .\r\n<https://id.parliament.uk/EqisWZtW>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"872\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/EqisWZtW> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 197\" .\r\n<https://id.parliament.uk/EqisWZtW>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/mpHFbBPU>
+        .\r\n<https://id.parliament.uk/EqisWZtW> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/hAmklf7q> .\r\n<https://id.parliament.uk/mpHFbBPU>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/mpHFbBPU> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-19+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/mpHFbBPU>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/nFL8Pq3e>
+        .\r\n<https://id.parliament.uk/hAmklf7q> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/hAmklf7q>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/BP4IoUgX> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/BP4IoUgX>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/BP4IoUgX> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/BP4IoUgX>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 198\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/BP4IoUgX>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 198\" .\r\n<https://id.parliament.uk/BP4IoUgX> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"861\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/BP4IoUgX>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 198\" .\r\n<https://id.parliament.uk/BP4IoUgX> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/rflh2rcM> .\r\n<https://id.parliament.uk/BP4IoUgX>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/8vXQJ2xK>
+        .\r\n<https://id.parliament.uk/rflh2rcM> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/rflh2rcM>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-18+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/rflh2rcM> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/HYfypSOE> .\r\n<https://id.parliament.uk/8vXQJ2xK>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/8vXQJ2xK> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/xItHTyZP>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/xItHTyZP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/xItHTyZP>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/xItHTyZP> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 199\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/xItHTyZP> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 199\" .\r\n<https://id.parliament.uk/xItHTyZP>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"0\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/xItHTyZP> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 199\" .\r\n<https://id.parliament.uk/xItHTyZP>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/sK45Ez26>
+        .\r\n<https://id.parliament.uk/xItHTyZP> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/nUXQzBUI> .\r\n<https://id.parliament.uk/sK45Ez26>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/sK45Ez26> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-19+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/sK45Ez26>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/KSMOf7aM>
+        .\r\n<https://id.parliament.uk/KSMOf7aM> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Group> .\r\n<https://id.parliament.uk/KSMOf7aM>
+        <https://id.parliament.uk/schema/groupName> \"groupName - 22\" .\r\n<https://id.parliament.uk/nUXQzBUI>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/nUXQzBUI> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/pyflzxxb>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/pyflzxxb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/pyflzxxb>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/pyflzxxb> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 200\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/pyflzxxb> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 200\" .\r\n<https://id.parliament.uk/pyflzxxb>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"0\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/pyflzxxb> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 200\" .\r\n<https://id.parliament.uk/pyflzxxb>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/QfOk6t8o>
+        .\r\n<https://id.parliament.uk/pyflzxxb> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/fYStL7le> .\r\n<https://id.parliament.uk/QfOk6t8o>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/QfOk6t8o> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-19+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/QfOk6t8o>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/yiuTaSI4>
+        .\r\n<https://id.parliament.uk/fYStL7le> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/fYStL7le>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/bnrksmBb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/bnrksmBb>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/bnrksmBb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/bnrksmBb>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 201\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/bnrksmBb>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 201\" .\r\n<https://id.parliament.uk/bnrksmBb> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"0\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/bnrksmBb>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 201\" .\r\n<https://id.parliament.uk/bnrksmBb> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/FqjhORVJ> .\r\n<https://id.parliament.uk/bnrksmBb>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/eWrOts77>
+        .\r\n<https://id.parliament.uk/FqjhORVJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/FqjhORVJ>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-19+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/FqjhORVJ> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/HYfypSOE> .\r\n<https://id.parliament.uk/eWrOts77>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/eWrOts77> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/ORfYwwEX>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/ORfYwwEX> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/ORfYwwEX>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/ORfYwwEX> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 202\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/ORfYwwEX> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 202\" .\r\n<https://id.parliament.uk/ORfYwwEX>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"0\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/ORfYwwEX> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 202\" .\r\n<https://id.parliament.uk/ORfYwwEX>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/jg2LgPjI>
+        .\r\n<https://id.parliament.uk/ORfYwwEX> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/NHkRuD74> .\r\n<https://id.parliament.uk/jg2LgPjI>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/jg2LgPjI> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-19+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/jg2LgPjI>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/fpWTqVKh>
+        .\r\n<https://id.parliament.uk/NHkRuD74> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/NHkRuD74>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/SbxmGLcR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/SbxmGLcR>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/SbxmGLcR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/SbxmGLcR>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 203\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/SbxmGLcR>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 203\" .\r\n<https://id.parliament.uk/SbxmGLcR> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"875\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/SbxmGLcR>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 203\" .\r\n<https://id.parliament.uk/SbxmGLcR> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/vAu6L0Zc> .\r\n<https://id.parliament.uk/SbxmGLcR>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/eqBIsv19>
+        .\r\n<https://id.parliament.uk/vAu6L0Zc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/vAu6L0Zc>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-20+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/vAu6L0Zc> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/NDZSYjeE> .\r\n<https://id.parliament.uk/eqBIsv19>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/eqBIsv19> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/dHwDR0Xw>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/dHwDR0Xw> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/dHwDR0Xw>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/dHwDR0Xw> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 204\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/dHwDR0Xw> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 204\" .\r\n<https://id.parliament.uk/dHwDR0Xw>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"0\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/dHwDR0Xw> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 204\" .\r\n<https://id.parliament.uk/dHwDR0Xw>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/D8EFDOPR>
+        .\r\n<https://id.parliament.uk/dHwDR0Xw> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/FJdkYpZ5> .\r\n<https://id.parliament.uk/D8EFDOPR>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/D8EFDOPR> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/D8EFDOPR>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/7dSvuueH>
+        .\r\n<https://id.parliament.uk/FJdkYpZ5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/FJdkYpZ5>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/ePPVgmgN> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/ePPVgmgN>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/ePPVgmgN> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/ePPVgmgN>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 205\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/ePPVgmgN>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 205\" .\r\n<https://id.parliament.uk/ePPVgmgN> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"0\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/ePPVgmgN>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 205\" .\r\n<https://id.parliament.uk/ePPVgmgN> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/72UR3b5X> .\r\n<https://id.parliament.uk/ePPVgmgN>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/RTAa8Xxs>
+        .\r\n<https://id.parliament.uk/72UR3b5X> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/72UR3b5X>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/72UR3b5X> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XouN12Ow> .\r\n<https://id.parliament.uk/RTAa8Xxs>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/RTAa8Xxs> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/qRweamaE>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/qRweamaE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/qRweamaE>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/qRweamaE> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 206\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/qRweamaE> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 206\" .\r\n<https://id.parliament.uk/qRweamaE>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"0\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/qRweamaE> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 206\" .\r\n<https://id.parliament.uk/qRweamaE>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/Bc9nWfWq>
+        .\r\n<https://id.parliament.uk/qRweamaE> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/DdWTiUjw> .\r\n<https://id.parliament.uk/Bc9nWfWq>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/Bc9nWfWq> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/Bc9nWfWq>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/XouN12Ow>
+        .\r\n<https://id.parliament.uk/DdWTiUjw> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/DdWTiUjw>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/zRBB7JhE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/zRBB7JhE>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/zRBB7JhE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/zRBB7JhE>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 207\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/zRBB7JhE>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 207\" .\r\n<https://id.parliament.uk/zRBB7JhE> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"0\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/zRBB7JhE>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 207\" .\r\n<https://id.parliament.uk/zRBB7JhE> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/AP8xkl7P> .\r\n<https://id.parliament.uk/zRBB7JhE>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/rDRNBssE>
+        .\r\n<https://id.parliament.uk/AP8xkl7P> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/AP8xkl7P>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/AP8xkl7P> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/7dSvuueH> .\r\n<https://id.parliament.uk/rDRNBssE>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/rDRNBssE> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/pg1MaN6V>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/pg1MaN6V> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/pg1MaN6V>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/pg1MaN6V> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 208\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/pg1MaN6V> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 208\" .\r\n<https://id.parliament.uk/pg1MaN6V>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"0\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/pg1MaN6V> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 208\" .\r\n<https://id.parliament.uk/pg1MaN6V>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/evLLP3No>
+        .\r\n<https://id.parliament.uk/pg1MaN6V> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/P3nQG8UQ> .\r\n<https://id.parliament.uk/evLLP3No>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/evLLP3No> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/evLLP3No>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/KSMOf7aM>
+        .\r\n<https://id.parliament.uk/P3nQG8UQ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/P3nQG8UQ>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/j0R3vR5s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/j0R3vR5s>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/j0R3vR5s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/j0R3vR5s>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 209\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/j0R3vR5s>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 209\" .\r\n<https://id.parliament.uk/j0R3vR5s> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"0\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/j0R3vR5s>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 209\" .\r\n<https://id.parliament.uk/j0R3vR5s> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/XEGCwVKv> .\r\n<https://id.parliament.uk/j0R3vR5s>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/83lMBlLs>
+        .\r\n<https://id.parliament.uk/XEGCwVKv> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/XEGCwVKv>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/XEGCwVKv> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/7dSvuueH> .\r\n<https://id.parliament.uk/83lMBlLs>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/83lMBlLs> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/xRUG9ARI>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/xRUG9ARI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/xRUG9ARI>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/xRUG9ARI> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 210\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/xRUG9ARI> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 210\" .\r\n<https://id.parliament.uk/xRUG9ARI>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"0\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/xRUG9ARI> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 210\" .\r\n<https://id.parliament.uk/xRUG9ARI>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/7tpTjp7H>
+        .\r\n<https://id.parliament.uk/xRUG9ARI> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/Elsc9n58> .\r\n<https://id.parliament.uk/7tpTjp7H>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/7tpTjp7H> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/7tpTjp7H>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/7dSvuueH>
+        .\r\n<https://id.parliament.uk/Elsc9n58> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/Elsc9n58>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/DVgODdNe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/DVgODdNe>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/DVgODdNe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/DVgODdNe>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 211\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/DVgODdNe>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 211\" .\r\n<https://id.parliament.uk/DVgODdNe> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"0\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/DVgODdNe>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 211\" .\r\n<https://id.parliament.uk/DVgODdNe> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/jnt1PLtp> .\r\n<https://id.parliament.uk/DVgODdNe>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/h5Fp2H9d>
+        .\r\n<https://id.parliament.uk/jnt1PLtp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/jnt1PLtp>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/jnt1PLtp> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/7dSvuueH> .\r\n<https://id.parliament.uk/h5Fp2H9d>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/h5Fp2H9d> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/2JipSGt3>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/2JipSGt3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/2JipSGt3>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/2JipSGt3> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 212\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/2JipSGt3> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 212\" .\r\n<https://id.parliament.uk/2JipSGt3>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"0\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/2JipSGt3> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 212\" .\r\n<https://id.parliament.uk/2JipSGt3>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/SOGo1tod>
+        .\r\n<https://id.parliament.uk/2JipSGt3> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/AFYBjHvC> .\r\n<https://id.parliament.uk/SOGo1tod>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/SOGo1tod> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/SOGo1tod>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/7dSvuueH>
+        .\r\n<https://id.parliament.uk/AFYBjHvC> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/AFYBjHvC>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/YdIWHZS3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/YdIWHZS3>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/YdIWHZS3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/YdIWHZS3>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 213\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/YdIWHZS3>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 213\" .\r\n<https://id.parliament.uk/YdIWHZS3> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"874\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/YdIWHZS3>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 213\" .\r\n<https://id.parliament.uk/YdIWHZS3> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/WwdgeYfb> .\r\n<https://id.parliament.uk/YdIWHZS3>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/oLsZBZZy>
+        .\r\n<https://id.parliament.uk/WwdgeYfb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/WwdgeYfb>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/WwdgeYfb> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XouN12Ow> .\r\n<https://id.parliament.uk/oLsZBZZy>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/oLsZBZZy> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/I22Wlejq>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/I22Wlejq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/I22Wlejq>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/I22Wlejq> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 214\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/I22Wlejq> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 214\" .\r\n<https://id.parliament.uk/I22Wlejq>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 214\" .\r\n<https://id.parliament.uk/I22Wlejq> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/s2yCncQX> .\r\n<https://id.parliament.uk/I22Wlejq>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/BOeaxUck>
+        .\r\n<https://id.parliament.uk/s2yCncQX> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/s2yCncQX>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-24+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/s2yCncQX> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fKqMNz79> .\r\n<https://id.parliament.uk/BOeaxUck>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/BOeaxUck> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/uIHeCzNz>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/uIHeCzNz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/uIHeCzNz>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/uIHeCzNz> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 215\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/uIHeCzNz> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 215\" .\r\n<https://id.parliament.uk/uIHeCzNz>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 215\" .\r\n<https://id.parliament.uk/uIHeCzNz> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/QbhSYBUT> .\r\n<https://id.parliament.uk/uIHeCzNz>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/a5kzSCS7>
+        .\r\n<https://id.parliament.uk/QbhSYBUT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/QbhSYBUT>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-24+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/QbhSYBUT> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/DkHdH4kZ> .\r\n<https://id.parliament.uk/a5kzSCS7>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/a5kzSCS7> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/tlSbgoyG>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/tlSbgoyG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/tlSbgoyG>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/tlSbgoyG> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 216\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/tlSbgoyG> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 216\" .\r\n<https://id.parliament.uk/tlSbgoyG>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"894\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/tlSbgoyG> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 216\" .\r\n<https://id.parliament.uk/tlSbgoyG>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/OKImXzFs>
+        .\r\n<https://id.parliament.uk/tlSbgoyG> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/1wA2fFJh> .\r\n<https://id.parliament.uk/OKImXzFs>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/OKImXzFs> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-24+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/OKImXzFs>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/ni8aOEk3>
+        .\r\n<https://id.parliament.uk/1wA2fFJh> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/1wA2fFJh>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/3Iw5OmCs> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/3Iw5OmCs>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/3Iw5OmCs> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/3Iw5OmCs>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 217\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/3Iw5OmCs>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 217\" .\r\n<https://id.parliament.uk/3Iw5OmCs> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 217\" .\r\n<https://id.parliament.uk/3Iw5OmCs>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/nHmQ7MZc>
+        .\r\n<https://id.parliament.uk/3Iw5OmCs> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/cDVt360N> .\r\n<https://id.parliament.uk/nHmQ7MZc>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/nHmQ7MZc> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-24+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/nHmQ7MZc>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/HYfypSOE>
+        .\r\n<https://id.parliament.uk/cDVt360N> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/cDVt360N>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/zo2QN0LF> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/zo2QN0LF>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/zo2QN0LF> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/zo2QN0LF>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 218\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/zo2QN0LF>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 218\" .\r\n<https://id.parliament.uk/zo2QN0LF> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 218\" .\r\n<https://id.parliament.uk/zo2QN0LF>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/JZZ4q14z>
+        .\r\n<https://id.parliament.uk/zo2QN0LF> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/YffANOfi> .\r\n<https://id.parliament.uk/JZZ4q14z>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/JZZ4q14z> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-24+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/JZZ4q14z>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/eup4DwE5>
+        .\r\n<https://id.parliament.uk/YffANOfi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/YffANOfi>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/gTgidljI>
+        .\r\n<https://id.parliament.uk/3ovJSqCK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/3ovJSqCK>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/3ovJSqCK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/3ovJSqCK>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 219\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/3ovJSqCK>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 219\" .\r\n<https://id.parliament.uk/3ovJSqCK> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 219\" .\r\n<https://id.parliament.uk/3ovJSqCK>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/ufUDatXl>
+        .\r\n<https://id.parliament.uk/3ovJSqCK> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/msKM10hC> .\r\n<https://id.parliament.uk/ufUDatXl>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/ufUDatXl> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-24+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/ufUDatXl>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/eup4DwE5>
+        .\r\n<https://id.parliament.uk/msKM10hC> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/msKM10hC>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/gTgidljI>
+        .\r\n<https://id.parliament.uk/URYwfkWz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/URYwfkWz>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/URYwfkWz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/URYwfkWz>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 220\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/URYwfkWz>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 220\" .\r\n<https://id.parliament.uk/URYwfkWz> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 220\" .\r\n<https://id.parliament.uk/URYwfkWz>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/FK5c5p1r>
+        .\r\n<https://id.parliament.uk/URYwfkWz> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/YZVMPIjK> .\r\n<https://id.parliament.uk/FK5c5p1r>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/FK5c5p1r> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-24+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/FK5c5p1r>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/eup4DwE5>
+        .\r\n<https://id.parliament.uk/YZVMPIjK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/YZVMPIjK>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/gTgidljI>
+        .\r\n<https://id.parliament.uk/KKMVpl6g> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/KKMVpl6g>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/KKMVpl6g> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/KKMVpl6g>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 221\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/KKMVpl6g>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 221\" .\r\n<https://id.parliament.uk/KKMVpl6g> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"901\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/KKMVpl6g>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 221\" .\r\n<https://id.parliament.uk/KKMVpl6g> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/1ZRRE2Ea> .\r\n<https://id.parliament.uk/KKMVpl6g>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/MQChNjSY>
+        .\r\n<https://id.parliament.uk/1ZRRE2Ea> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/1ZRRE2Ea>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-26+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/1ZRRE2Ea> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/7dSvuueH> .\r\n<https://id.parliament.uk/MQChNjSY>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/MQChNjSY> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/hLF7ZU6f>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/hLF7ZU6f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/hLF7ZU6f>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/hLF7ZU6f> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 222\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/hLF7ZU6f> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 222\" .\r\n<https://id.parliament.uk/hLF7ZU6f>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"902\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/hLF7ZU6f> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 222\" .\r\n<https://id.parliament.uk/hLF7ZU6f>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/biZLgqIV>
+        .\r\n<https://id.parliament.uk/hLF7ZU6f> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/lZwrpAHu> .\r\n<https://id.parliament.uk/biZLgqIV>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/biZLgqIV> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-26+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/biZLgqIV>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/NDZSYjeE>
+        .\r\n<https://id.parliament.uk/lZwrpAHu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/lZwrpAHu>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/MyKmEbhB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/MyKmEbhB>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/MyKmEbhB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/MyKmEbhB>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 223\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/MyKmEbhB>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 223\" .\r\n<https://id.parliament.uk/MyKmEbhB> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"910\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/MyKmEbhB>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 223\" .\r\n<https://id.parliament.uk/MyKmEbhB> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/heXs0Wrz> .\r\n<https://id.parliament.uk/MyKmEbhB>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/sOWsIoTo>
+        .\r\n<https://id.parliament.uk/heXs0Wrz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/heXs0Wrz>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-30+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/heXs0Wrz> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/5LQ5Ar74> .\r\n<https://id.parliament.uk/sOWsIoTo>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/sOWsIoTo> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/hNYeAr2M>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/hNYeAr2M> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/hNYeAr2M>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/hNYeAr2M> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 224\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/hNYeAr2M> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 224\" .\r\n<https://id.parliament.uk/hNYeAr2M>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"908\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/hNYeAr2M> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 224\" .\r\n<https://id.parliament.uk/hNYeAr2M>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/1ZEDgLFK>
+        .\r\n<https://id.parliament.uk/hNYeAr2M> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/wpuFhzm5> .\r\n<https://id.parliament.uk/1ZEDgLFK>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/1ZEDgLFK> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-27+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/1ZEDgLFK>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/5LQ5Ar74>
+        .\r\n<https://id.parliament.uk/wpuFhzm5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/wpuFhzm5>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/VqC2MUZE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/VqC2MUZE>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/VqC2MUZE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/VqC2MUZE>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 225\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/VqC2MUZE>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 225\" .\r\n<https://id.parliament.uk/VqC2MUZE> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"911\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/VqC2MUZE>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 225\" .\r\n<https://id.parliament.uk/VqC2MUZE> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/j0wZpU1d> .\r\n<https://id.parliament.uk/VqC2MUZE>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/eouZnE6o>
+        .\r\n<https://id.parliament.uk/j0wZpU1d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/j0wZpU1d>
+        <https://id.parliament.uk/schema/layingDate> \"2018-08-01+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/j0wZpU1d> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fKqMNz79> .\r\n<https://id.parliament.uk/eouZnE6o>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/eouZnE6o> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/QtfEa5YW>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/QtfEa5YW> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/QtfEa5YW>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/QtfEa5YW> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 226\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/QtfEa5YW> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 226\" .\r\n<https://id.parliament.uk/QtfEa5YW>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"915\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/QtfEa5YW> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 226\" .\r\n<https://id.parliament.uk/QtfEa5YW>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/JkGkZfQA>
+        .\r\n<https://id.parliament.uk/QtfEa5YW> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/WzY4kI4B> .\r\n<https://id.parliament.uk/JkGkZfQA>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/JkGkZfQA> <https://id.parliament.uk/schema/layingDate>
+        \"2018-08-02+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/JkGkZfQA>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/fKqMNz79>
+        .\r\n<https://id.parliament.uk/WzY4kI4B> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/WzY4kI4B>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/IlH0bFJC> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/IlH0bFJC>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/IlH0bFJC> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/IlH0bFJC>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 227\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/IlH0bFJC>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 227\" .\r\n<https://id.parliament.uk/IlH0bFJC> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"924\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/IlH0bFJC>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 227\" .\r\n<https://id.parliament.uk/IlH0bFJC> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/RA0Z5x0S> .\r\n<https://id.parliament.uk/IlH0bFJC>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/1dkAzf5G>
+        .\r\n<https://id.parliament.uk/RA0Z5x0S> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/RA0Z5x0S>
+        <https://id.parliament.uk/schema/layingDate> \"2018-08-06+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/RA0Z5x0S> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fKqMNz79> .\r\n<https://id.parliament.uk/1dkAzf5G>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/1dkAzf5G> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/evNAwjHg>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/evNAwjHg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/evNAwjHg>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/evNAwjHg> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 228\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/evNAwjHg> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 228\" .\r\n<https://id.parliament.uk/evNAwjHg>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"927\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/evNAwjHg> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 228\" .\r\n<https://id.parliament.uk/evNAwjHg>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/CzsYFrka>
+        .\r\n<https://id.parliament.uk/evNAwjHg> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/z7s90NTp> .\r\n<https://id.parliament.uk/CzsYFrka>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/CzsYFrka> <https://id.parliament.uk/schema/layingDate>
+        \"2018-08-08+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/CzsYFrka>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/7dSvuueH>
+        .\r\n<https://id.parliament.uk/z7s90NTp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/z7s90NTp>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/Wa2pnyo2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/Wa2pnyo2>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/Wa2pnyo2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/Wa2pnyo2>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 229\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/Wa2pnyo2>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 229\" .\r\n<https://id.parliament.uk/Wa2pnyo2> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"933\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/Wa2pnyo2>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 229\" .\r\n<https://id.parliament.uk/Wa2pnyo2> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/knwsOk1D> .\r\n<https://id.parliament.uk/Wa2pnyo2>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/j6FFo1kf>
+        .\r\n<https://id.parliament.uk/knwsOk1D> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/knwsOk1D>
+        <https://id.parliament.uk/schema/layingDate> \"2018-08-13+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/knwsOk1D> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/7dSvuueH> .\r\n<https://id.parliament.uk/j6FFo1kf>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/j6FFo1kf> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/qQXoON26>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/qQXoON26> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/qQXoON26>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/qQXoON26> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 230\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/qQXoON26> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 230\" .\r\n<https://id.parliament.uk/qQXoON26>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"930\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/qQXoON26> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 230\" .\r\n<https://id.parliament.uk/qQXoON26>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/8bnEskMz>
+        .\r\n<https://id.parliament.uk/qQXoON26> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/pjtvqXCz> .\r\n<https://id.parliament.uk/8bnEskMz>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/8bnEskMz> <https://id.parliament.uk/schema/layingDate>
+        \"2018-08-13+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/8bnEskMz>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/fKqMNz79>
+        .\r\n<https://id.parliament.uk/pjtvqXCz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/pjtvqXCz>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/GuV3tchN> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/GuV3tchN>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/GuV3tchN> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/GuV3tchN>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 231\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/GuV3tchN>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 231\" .\r\n<https://id.parliament.uk/GuV3tchN> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"932\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/GuV3tchN>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 231\" .\r\n<https://id.parliament.uk/GuV3tchN> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/tvf2XMq0> .\r\n<https://id.parliament.uk/GuV3tchN>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/gW4ShvE2>
+        .\r\n<https://id.parliament.uk/tvf2XMq0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/tvf2XMq0>
+        <https://id.parliament.uk/schema/layingDate> \"2018-08-15+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/tvf2XMq0> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XbTBTDMo> .\r\n<https://id.parliament.uk/gW4ShvE2>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/gW4ShvE2> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/GonuHKX2>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/GonuHKX2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/GonuHKX2>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/GonuHKX2> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 232\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/GonuHKX2> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 232\" .\r\n<https://id.parliament.uk/GonuHKX2>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"942\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/GonuHKX2> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 232\" .\r\n<https://id.parliament.uk/GonuHKX2>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/NBR4kWJn>
+        .\r\n<https://id.parliament.uk/GonuHKX2> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/lQQjF54h> .\r\n<https://id.parliament.uk/NBR4kWJn>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/NBR4kWJn> <https://id.parliament.uk/schema/layingDate>
+        \"2018-08-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/NBR4kWJn>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/5LQ5Ar74>
+        .\r\n<https://id.parliament.uk/lQQjF54h> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/lQQjF54h>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/n7DYBZTg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/n7DYBZTg>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/n7DYBZTg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/n7DYBZTg>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 233\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/n7DYBZTg>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 233\" .\r\n<https://id.parliament.uk/n7DYBZTg> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"939\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/n7DYBZTg>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 233\" .\r\n<https://id.parliament.uk/n7DYBZTg> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/vqpd5hRo> .\r\n<https://id.parliament.uk/n7DYBZTg>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/K1GI1d9e>
+        .\r\n<https://id.parliament.uk/vqpd5hRo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/vqpd5hRo>
+        <https://id.parliament.uk/schema/layingDate> \"2018-08-22+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/vqpd5hRo> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/ni8aOEk3> .\r\n<https://id.parliament.uk/K1GI1d9e>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/K1GI1d9e> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/8NOTbqcG>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/8NOTbqcG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/8NOTbqcG>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/8NOTbqcG> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 234\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/8NOTbqcG> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 234\" .\r\n<https://id.parliament.uk/8NOTbqcG>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"947\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/8NOTbqcG> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 234\" .\r\n<https://id.parliament.uk/8NOTbqcG>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/xSmvWpfZ>
+        .\r\n<https://id.parliament.uk/8NOTbqcG> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/vKAEAnJF> .\r\n<https://id.parliament.uk/xSmvWpfZ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/xSmvWpfZ> <https://id.parliament.uk/schema/layingDate>
+        \"2018-08-30+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/xSmvWpfZ>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/fKqMNz79>
+        .\r\n<https://id.parliament.uk/vKAEAnJF> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/vKAEAnJF>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/nuicNnFk> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/nuicNnFk>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/nuicNnFk> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/nuicNnFk>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 235\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/nuicNnFk>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 235\" .\r\n<https://id.parliament.uk/nuicNnFk> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"946\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/nuicNnFk>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 235\" .\r\n<https://id.parliament.uk/nuicNnFk> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/Fd8PgclA> .\r\n<https://id.parliament.uk/nuicNnFk>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/NoHwsgYC>
+        .\r\n<https://id.parliament.uk/Fd8PgclA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/Fd8PgclA>
+        <https://id.parliament.uk/schema/layingDate> \"2018-08-31+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/Fd8PgclA> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/7dSvuueH> .\r\n<https://id.parliament.uk/NoHwsgYC>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/NoHwsgYC> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/peR5eFWQ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/peR5eFWQ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/peR5eFWQ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/peR5eFWQ> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 236\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/peR5eFWQ> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 236\" .\r\n<https://id.parliament.uk/peR5eFWQ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"952\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/peR5eFWQ> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 236\" .\r\n<https://id.parliament.uk/peR5eFWQ>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/yS3Jzq50>
+        .\r\n<https://id.parliament.uk/peR5eFWQ> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/WHAQG0Ch> .\r\n<https://id.parliament.uk/yS3Jzq50>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/yS3Jzq50> <https://id.parliament.uk/schema/layingDate>
+        \"2018-08-31+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/yS3Jzq50>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/7gnSwbLO>
+        .\r\n<https://id.parliament.uk/WHAQG0Ch> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/WHAQG0Ch>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/jKZxBFHe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/jKZxBFHe>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/jKZxBFHe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/jKZxBFHe>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 237\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/jKZxBFHe>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 237\" .\r\n<https://id.parliament.uk/jKZxBFHe> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 237\" .\r\n<https://id.parliament.uk/jKZxBFHe>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/FBbatZym>
+        .\r\n<https://id.parliament.uk/jKZxBFHe> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/DL1I4kiC> .\r\n<https://id.parliament.uk/FBbatZym>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/FBbatZym> <https://id.parliament.uk/schema/layingDate>
+        \"2018-09-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/FBbatZym>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/79sn5e3n>
+        .\r\n<https://id.parliament.uk/DL1I4kiC> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/DL1I4kiC>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/RmycV0kO> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/RmycV0kO>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/RmycV0kO> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/RmycV0kO>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 238\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/RmycV0kO>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 238\" .\r\n<https://id.parliament.uk/RmycV0kO> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"961\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/RmycV0kO>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 238\" .\r\n<https://id.parliament.uk/RmycV0kO> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/8ymuy646> .\r\n<https://id.parliament.uk/RmycV0kO>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/kAWq2agx>
+        .\r\n<https://id.parliament.uk/8ymuy646> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/8ymuy646>
+        <https://id.parliament.uk/schema/layingDate> \"2018-09-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/8ymuy646> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/BRTNQywN> .\r\n<https://id.parliament.uk/kAWq2agx>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/kAWq2agx> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/8nULnQBi>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/8nULnQBi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/8nULnQBi>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/8nULnQBi> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 239\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/8nULnQBi> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 239\" .\r\n<https://id.parliament.uk/8nULnQBi>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 239\" .\r\n<https://id.parliament.uk/8nULnQBi> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/rvMGR4sj> .\r\n<https://id.parliament.uk/8nULnQBi>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/mFpCbqOz>
+        .\r\n<https://id.parliament.uk/rvMGR4sj> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/rvMGR4sj>
+        <https://id.parliament.uk/schema/layingDate> \"2018-09-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/rvMGR4sj> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/79sn5e3n> .\r\n<https://id.parliament.uk/mFpCbqOz>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/mFpCbqOz> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/fgDYoYbL>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/fgDYoYbL> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/fgDYoYbL>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/fgDYoYbL> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 240\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/fgDYoYbL> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 240\" .\r\n<https://id.parliament.uk/fgDYoYbL>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 240\" .\r\n<https://id.parliament.uk/fgDYoYbL> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/BUVreee5> .\r\n<https://id.parliament.uk/fgDYoYbL>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/E9yCU1c9>
+        .\r\n<https://id.parliament.uk/BUVreee5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/BUVreee5>
+        <https://id.parliament.uk/schema/layingDate> \"2018-09-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/BUVreee5> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/79sn5e3n> .\r\n<https://id.parliament.uk/E9yCU1c9>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/E9yCU1c9> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/QjdlkhkP>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/QjdlkhkP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/QjdlkhkP>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/QjdlkhkP> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 241\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/QjdlkhkP> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 241\" .\r\n<https://id.parliament.uk/QjdlkhkP>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 241\" .\r\n<https://id.parliament.uk/QjdlkhkP> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/k3z0eE4m> .\r\n<https://id.parliament.uk/QjdlkhkP>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/MyVni6Ej>
+        .\r\n<https://id.parliament.uk/k3z0eE4m> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/k3z0eE4m>
+        <https://id.parliament.uk/schema/layingDate> \"2018-09-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/k3z0eE4m> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fKqMNz79> .\r\n<https://id.parliament.uk/MyVni6Ej>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/MyVni6Ej> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/yPyq3chO>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/yPyq3chO> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/yPyq3chO>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/yPyq3chO> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 242\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/yPyq3chO> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 242\" .\r\n<https://id.parliament.uk/yPyq3chO>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"960\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/yPyq3chO> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 242\" .\r\n<https://id.parliament.uk/yPyq3chO>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/ooPYSalN>
+        .\r\n<https://id.parliament.uk/yPyq3chO> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/vxPj3xad> .\r\n<https://id.parliament.uk/ooPYSalN>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/ooPYSalN> <https://id.parliament.uk/schema/layingDate>
+        \"2018-09-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/ooPYSalN>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/BRTNQywN>
+        .\r\n<https://id.parliament.uk/vxPj3xad> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/vxPj3xad>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/tRaHj88K> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/tRaHj88K>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/tRaHj88K> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/tRaHj88K>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 243\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/tRaHj88K>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 243\" .\r\n<https://id.parliament.uk/tRaHj88K> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 243\" .\r\n<https://id.parliament.uk/tRaHj88K>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/TAPJzsYR>
+        .\r\n<https://id.parliament.uk/tRaHj88K> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/ZanXOGcI> .\r\n<https://id.parliament.uk/TAPJzsYR>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/TAPJzsYR> <https://id.parliament.uk/schema/layingDate>
+        \"2018-09-05+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/TAPJzsYR>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/yiuTaSI4>
+        .\r\n<https://id.parliament.uk/ZanXOGcI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/ZanXOGcI>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/TFdnSOeu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/TFdnSOeu>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/TFdnSOeu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/TFdnSOeu>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 244\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/TFdnSOeu>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 244\" .\r\n<https://id.parliament.uk/TFdnSOeu> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 244\" .\r\n<https://id.parliament.uk/TFdnSOeu>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/i4B3H1Cp>
+        .\r\n<https://id.parliament.uk/TFdnSOeu> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/IU7gREgJ> .\r\n<https://id.parliament.uk/i4B3H1Cp>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/i4B3H1Cp> <https://id.parliament.uk/schema/layingDate>
+        \"2018-09-05+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/i4B3H1Cp>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/7dSvuueH>
+        .\r\n<https://id.parliament.uk/IU7gREgJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/IU7gREgJ>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/9nwPn9YY> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/9nwPn9YY>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/9nwPn9YY> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/9nwPn9YY>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 245\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/9nwPn9YY>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 245\" .\r\n<https://id.parliament.uk/9nwPn9YY> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"964\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/9nwPn9YY>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 245\" .\r\n<https://id.parliament.uk/9nwPn9YY> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/ggxpUJ3C> .\r\n<https://id.parliament.uk/9nwPn9YY>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/aj8r4hAP>
+        .\r\n<https://id.parliament.uk/ggxpUJ3C> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/ggxpUJ3C>
+        <https://id.parliament.uk/schema/layingDate> \"2018-09-05+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/ggxpUJ3C> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/5LQ5Ar74> .\r\n<https://id.parliament.uk/aj8r4hAP>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/aj8r4hAP> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/J8EUQxAg>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/J8EUQxAg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/J8EUQxAg>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/J8EUQxAg> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 246\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/J8EUQxAg> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 246\" .\r\n<https://id.parliament.uk/J8EUQxAg>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 246\" .\r\n<https://id.parliament.uk/J8EUQxAg> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/HoC5X7Og> .\r\n<https://id.parliament.uk/J8EUQxAg>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/hpbakMhj>
+        .\r\n<https://id.parliament.uk/HoC5X7Og> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/HoC5X7Og>
+        <https://id.parliament.uk/schema/layingDate> \"2018-09-05+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/HoC5X7Og> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/HYfypSOE> .\r\n<https://id.parliament.uk/hpbakMhj>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/hpbakMhj> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/EAXHUZt7>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/EAXHUZt7> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/EAXHUZt7>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/EAXHUZt7> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 247\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/EAXHUZt7> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 247\" .\r\n<https://id.parliament.uk/EAXHUZt7>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"966\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/EAXHUZt7> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 247\" .\r\n<https://id.parliament.uk/EAXHUZt7>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/ugkRO7lo>
+        .\r\n<https://id.parliament.uk/EAXHUZt7> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/SrxpslCY> .\r\n<https://id.parliament.uk/ugkRO7lo>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/ugkRO7lo> <https://id.parliament.uk/schema/layingDate>
+        \"2018-09-06+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/ugkRO7lo>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/yiuTaSI4>
+        .\r\n<https://id.parliament.uk/SrxpslCY> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/SrxpslCY>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/DcVb33WY> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/DcVb33WY>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/DcVb33WY> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/DcVb33WY>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 248\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/DcVb33WY>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 248\" .\r\n<https://id.parliament.uk/DcVb33WY> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"975\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/DcVb33WY>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 248\" .\r\n<https://id.parliament.uk/DcVb33WY> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/gZF71mro> .\r\n<https://id.parliament.uk/DcVb33WY>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/EelSQMxX>
+        .\r\n<https://id.parliament.uk/gZF71mro> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/gZF71mro>
+        <https://id.parliament.uk/schema/layingDate> \"2018-09-06+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/gZF71mro> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/BRTNQywN> .\r\n<https://id.parliament.uk/EelSQMxX>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/EelSQMxX> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/fUqRRBH5>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/fUqRRBH5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/fUqRRBH5>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/fUqRRBH5> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 249\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/fUqRRBH5> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 249\" .\r\n<https://id.parliament.uk/fUqRRBH5>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"967\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/fUqRRBH5> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 249\" .\r\n<https://id.parliament.uk/fUqRRBH5>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/uSJGnOBq>
+        .\r\n<https://id.parliament.uk/fUqRRBH5> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/Wg3eh80v> .\r\n<https://id.parliament.uk/uSJGnOBq>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/uSJGnOBq> <https://id.parliament.uk/schema/layingDate>
+        \"2018-09-06+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/uSJGnOBq>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/yiuTaSI4>
+        .\r\n<https://id.parliament.uk/Wg3eh80v> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/Wg3eh80v>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/BuMKAKjA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/BuMKAKjA>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/BuMKAKjA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/BuMKAKjA>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 250\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/BuMKAKjA>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 250\" .\r\n<https://id.parliament.uk/BuMKAKjA> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"970\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/BuMKAKjA>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 250\" .\r\n<https://id.parliament.uk/BuMKAKjA> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/jNi948H2> .\r\n<https://id.parliament.uk/BuMKAKjA>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/bYtCFU4N>
+        .\r\n<https://id.parliament.uk/jNi948H2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/jNi948H2>
+        <https://id.parliament.uk/schema/layingDate> \"2018-09-06+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/jNi948H2> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/NDZSYjeE> .\r\n<https://id.parliament.uk/bYtCFU4N>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/bYtCFU4N> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/l05U8jIT>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/l05U8jIT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/l05U8jIT>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/l05U8jIT> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 251\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/l05U8jIT> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 251\" .\r\n<https://id.parliament.uk/l05U8jIT>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"971\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/l05U8jIT> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 251\" .\r\n<https://id.parliament.uk/l05U8jIT>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/8pfIlVcp>
+        .\r\n<https://id.parliament.uk/l05U8jIT> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/2O7xiVcu> .\r\n<https://id.parliament.uk/8pfIlVcp>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/8pfIlVcp> <https://id.parliament.uk/schema/layingDate>
+        \"2018-09-07+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/8pfIlVcp>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/XouN12Ow>
+        .\r\n<https://id.parliament.uk/2O7xiVcu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/2O7xiVcu>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/WBlaNvyq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/WBlaNvyq>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/WBlaNvyq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/WBlaNvyq>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 252\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/WBlaNvyq>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 252\" .\r\n<https://id.parliament.uk/WBlaNvyq> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"982\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/WBlaNvyq>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 252\" .\r\n<https://id.parliament.uk/WBlaNvyq> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/yGqCp359> .\r\n<https://id.parliament.uk/WBlaNvyq>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/3q8YccUw>
+        .\r\n<https://id.parliament.uk/yGqCp359> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/yGqCp359>
+        <https://id.parliament.uk/schema/layingDate> \"2018-09-10+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/yGqCp359> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/NDZSYjeE> .\r\n<https://id.parliament.uk/3q8YccUw>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/3q8YccUw> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/3iuaNj8A>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/3iuaNj8A> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/3iuaNj8A>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/3iuaNj8A> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 253\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/3iuaNj8A> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 253\" .\r\n<https://id.parliament.uk/3iuaNj8A>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"974\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/3iuaNj8A> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 253\" .\r\n<https://id.parliament.uk/3iuaNj8A>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/RqUBuUBD>
+        .\r\n<https://id.parliament.uk/3iuaNj8A> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/FB2aMTBN> .\r\n<https://id.parliament.uk/RqUBuUBD>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/RqUBuUBD> <https://id.parliament.uk/schema/layingDate>
+        \"2018-09-07+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/RqUBuUBD>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/5LQ5Ar74>
+        .\r\n<https://id.parliament.uk/FB2aMTBN> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/FB2aMTBN>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/n39tcDnk> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/n39tcDnk>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/n39tcDnk> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/n39tcDnk>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 254\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/n39tcDnk>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 254\" .\r\n<https://id.parliament.uk/n39tcDnk> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"985\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/n39tcDnk>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 254\" .\r\n<https://id.parliament.uk/n39tcDnk> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/uVArZwJx> .\r\n<https://id.parliament.uk/n39tcDnk>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/BJVsUfLW>
+        .\r\n<https://id.parliament.uk/uVArZwJx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/uVArZwJx>
+        <https://id.parliament.uk/schema/layingDate> \"2018-09-10+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/uVArZwJx> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XbTBTDMo> .\r\n<https://id.parliament.uk/BJVsUfLW>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/BJVsUfLW> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/pGJAClSs>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/pGJAClSs> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/pGJAClSs>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/pGJAClSs> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 255\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/pGJAClSs> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 255\" .\r\n<https://id.parliament.uk/pGJAClSs>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"980\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/pGJAClSs> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 255\" .\r\n<https://id.parliament.uk/pGJAClSs>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/i4sxEq6S>
+        .\r\n<https://id.parliament.uk/pGJAClSs> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/vu0GPgyl> .\r\n<https://id.parliament.uk/i4sxEq6S>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/i4sxEq6S> <https://id.parliament.uk/schema/layingDate>
+        \"2018-09-10+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/i4sxEq6S>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/yiuTaSI4>
+        .\r\n<https://id.parliament.uk/vu0GPgyl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/vu0GPgyl>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/d3F9OZoU> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/d3F9OZoU>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/d3F9OZoU> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/d3F9OZoU>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 256\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/d3F9OZoU>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 256\" .\r\n<https://id.parliament.uk/d3F9OZoU> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"988\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/d3F9OZoU>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 256\" .\r\n<https://id.parliament.uk/d3F9OZoU> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/CHm8aIF3> .\r\n<https://id.parliament.uk/d3F9OZoU>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/gQreLll1>
+        .\r\n<https://id.parliament.uk/CHm8aIF3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/CHm8aIF3>
+        <https://id.parliament.uk/schema/layingDate> \"2018-09-11+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/CHm8aIF3> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XbTBTDMo> .\r\n<https://id.parliament.uk/gQreLll1>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/gQreLll1> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/dj1ROT0l>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/dj1ROT0l> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/dj1ROT0l>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/dj1ROT0l> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 257\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/dj1ROT0l> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 257\" .\r\n<https://id.parliament.uk/dj1ROT0l>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"989\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/dj1ROT0l> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 257\" .\r\n<https://id.parliament.uk/dj1ROT0l>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/jwVRKtQU>
+        .\r\n<https://id.parliament.uk/dj1ROT0l> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/RlbS8X8u> .\r\n<https://id.parliament.uk/jwVRKtQU>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/jwVRKtQU> <https://id.parliament.uk/schema/layingDate>
+        \"2018-09-11+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/jwVRKtQU>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/XbTBTDMo>
+        .\r\n<https://id.parliament.uk/RlbS8X8u> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/RlbS8X8u>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/FoxP8Wi7> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/FoxP8Wi7>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/FoxP8Wi7> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/FoxP8Wi7>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 258\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/FoxP8Wi7>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 258\" .\r\n<https://id.parliament.uk/FoxP8Wi7> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 258\" .\r\n<https://id.parliament.uk/FoxP8Wi7>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/fpD5NOqa>
+        .\r\n<https://id.parliament.uk/FoxP8Wi7> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/cRe5nDqS> .\r\n<https://id.parliament.uk/fpD5NOqa>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/fpD5NOqa> <https://id.parliament.uk/schema/layingDate>
+        \"2018-09-12+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/fpD5NOqa>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/XbTBTDMo>
+        .\r\n<https://id.parliament.uk/cRe5nDqS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/cRe5nDqS>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/CoWkZnVU> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/CoWkZnVU>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/CoWkZnVU> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/CoWkZnVU>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 259\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/CoWkZnVU>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 259\" .\r\n<https://id.parliament.uk/CoWkZnVU> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"993\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/CoWkZnVU>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 259\" .\r\n<https://id.parliament.uk/CoWkZnVU> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/1rss0fox> .\r\n<https://id.parliament.uk/CoWkZnVU>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/mmJtbuq0>
+        .\r\n<https://id.parliament.uk/1rss0fox> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/1rss0fox>
+        <https://id.parliament.uk/schema/layingDate> \"2018-09-12+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/1rss0fox> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/7dSvuueH> .\r\n<https://id.parliament.uk/mmJtbuq0>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/mmJtbuq0> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/v9p3YHSe>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/v9p3YHSe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/v9p3YHSe>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/v9p3YHSe> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 260\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/v9p3YHSe> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 260\" .\r\n<https://id.parliament.uk/v9p3YHSe>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"995\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/v9p3YHSe> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 260\" .\r\n<https://id.parliament.uk/v9p3YHSe>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/w6nwZ5Qi>
+        .\r\n<https://id.parliament.uk/v9p3YHSe> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/VGG0Gv4P> .\r\n<https://id.parliament.uk/w6nwZ5Qi>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/w6nwZ5Qi> <https://id.parliament.uk/schema/layingDate>
+        \"2018-09-12+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/w6nwZ5Qi>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/yiuTaSI4>
+        .\r\n<https://id.parliament.uk/VGG0Gv4P> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/VGG0Gv4P>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/lSRBYtGi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/lSRBYtGi>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/lSRBYtGi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/lSRBYtGi>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 261\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/lSRBYtGi>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 261\" .\r\n<https://id.parliament.uk/lSRBYtGi> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"999\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/lSRBYtGi>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 261\" .\r\n<https://id.parliament.uk/lSRBYtGi> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/4JKyg0Au> .\r\n<https://id.parliament.uk/lSRBYtGi>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/86fSY4P0>
+        .\r\n<https://id.parliament.uk/4JKyg0Au> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/4JKyg0Au>
+        <https://id.parliament.uk/schema/layingDate> \"2018-09-13+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/4JKyg0Au> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/NDZSYjeE> .\r\n<https://id.parliament.uk/86fSY4P0>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/86fSY4P0> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/H1uGO0VI>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/H1uGO0VI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/H1uGO0VI>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/H1uGO0VI> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 262\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/H1uGO0VI> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 262\" .\r\n<https://id.parliament.uk/H1uGO0VI>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"997\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/H1uGO0VI> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 262\" .\r\n<https://id.parliament.uk/H1uGO0VI>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/C6qh45v5>
+        .\r\n<https://id.parliament.uk/H1uGO0VI> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/CnbVFSFE> .\r\n<https://id.parliament.uk/C6qh45v5>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/C6qh45v5> <https://id.parliament.uk/schema/layingDate>
+        \"2018-09-13+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/C6qh45v5>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/NDZSYjeE>
+        .\r\n<https://id.parliament.uk/CnbVFSFE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/CnbVFSFE>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/IyxF7Re7> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/IyxF7Re7>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/IyxF7Re7> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/IyxF7Re7>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 263\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/IyxF7Re7>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 263\" .\r\n<https://id.parliament.uk/IyxF7Re7> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"984\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/IyxF7Re7>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 263\" .\r\n<https://id.parliament.uk/IyxF7Re7> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/O5x2bz0C> .\r\n<https://id.parliament.uk/IyxF7Re7>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/9mNfFnUB>
+        .\r\n<https://id.parliament.uk/O5x2bz0C> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/O5x2bz0C>
+        <https://id.parliament.uk/schema/layingDate> \"2018-09-13+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/O5x2bz0C> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XouN12Ow> .\r\n<https://id.parliament.uk/9mNfFnUB>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/9mNfFnUB> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/vWSvjJPY>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/vWSvjJPY> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/vWSvjJPY>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/vWSvjJPY> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 264\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/vWSvjJPY> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 264\" .\r\n<https://id.parliament.uk/vWSvjJPY>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 264\" .\r\n<https://id.parliament.uk/vWSvjJPY> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/BoIqC4vN> .\r\n<https://id.parliament.uk/vWSvjJPY>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/zefBXzh8>
+        .\r\n<https://id.parliament.uk/BoIqC4vN> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/BoIqC4vN>
+        <https://id.parliament.uk/schema/layingDate> \"2018-09-13+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/BoIqC4vN> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XouN12Ow> .\r\n<https://id.parliament.uk/zefBXzh8>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/zefBXzh8> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/558R1vHw>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/558R1vHw> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/558R1vHw>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/558R1vHw> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 265\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/558R1vHw> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 265\" .\r\n<https://id.parliament.uk/558R1vHw>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"1004\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/558R1vHw> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 265\" .\r\n<https://id.parliament.uk/558R1vHw>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/JO1GX0Yc>
+        .\r\n<https://id.parliament.uk/558R1vHw> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/5CAiPg2v> .\r\n<https://id.parliament.uk/JO1GX0Yc>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/JO1GX0Yc> <https://id.parliament.uk/schema/layingDate>
+        \"2018-09-17+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/JO1GX0Yc>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/XouN12Ow>
+        .\r\n<https://id.parliament.uk/5CAiPg2v> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/5CAiPg2v>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/gVLa6U8S> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/gVLa6U8S>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/gVLa6U8S> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/gVLa6U8S>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 266\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/gVLa6U8S>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 266\" .\r\n<https://id.parliament.uk/gVLa6U8S> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"998\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/gVLa6U8S>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 266\" .\r\n<https://id.parliament.uk/gVLa6U8S> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/1laD3RMi> .\r\n<https://id.parliament.uk/gVLa6U8S>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/oUyGCgS5>
+        .\r\n<https://id.parliament.uk/1laD3RMi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/1laD3RMi>
+        <https://id.parliament.uk/schema/layingDate> \"2018-09-14+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/1laD3RMi> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/7dSvuueH> .\r\n<https://id.parliament.uk/oUyGCgS5>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/oUyGCgS5> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/6gNGlxXz>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/6gNGlxXz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/6gNGlxXz>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/6gNGlxXz> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 267\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/6gNGlxXz> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 267\" .\r\n<https://id.parliament.uk/6gNGlxXz>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"1011\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/6gNGlxXz> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 267\" .\r\n<https://id.parliament.uk/6gNGlxXz>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/qsdwaP2w>
+        .\r\n<https://id.parliament.uk/6gNGlxXz> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/ZAc8K0r4> .\r\n<https://id.parliament.uk/qsdwaP2w>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/qsdwaP2w> <https://id.parliament.uk/schema/layingDate>
+        \"2018-09-20+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/qsdwaP2w>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/KSMOf7aM>
+        .\r\n<https://id.parliament.uk/ZAc8K0r4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/ZAc8K0r4>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/SSIdUxdK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/SSIdUxdK>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/SSIdUxdK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/SSIdUxdK>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 268\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/SSIdUxdK>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 268\" .\r\n<https://id.parliament.uk/SSIdUxdK> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"1012\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/SSIdUxdK>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 268\" .\r\n<https://id.parliament.uk/SSIdUxdK> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/clek4Qpe> .\r\n<https://id.parliament.uk/SSIdUxdK>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/xl31EYMX>
+        .\r\n<https://id.parliament.uk/clek4Qpe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/clek4Qpe>
+        <https://id.parliament.uk/schema/layingDate> \"2018-09-20+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/clek4Qpe> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/KSMOf7aM> .\r\n<https://id.parliament.uk/xl31EYMX>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/xl31EYMX> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/WMZkgw45>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/WMZkgw45> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/WMZkgw45>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/WMZkgw45> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 269\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/WMZkgw45> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 269\" .\r\n<https://id.parliament.uk/WMZkgw45>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"1026\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/WMZkgw45> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 269\" .\r\n<https://id.parliament.uk/WMZkgw45>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/Wp00cYcL>
+        .\r\n<https://id.parliament.uk/WMZkgw45> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/rINYVove> .\r\n<https://id.parliament.uk/Wp00cYcL>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/Wp00cYcL> <https://id.parliament.uk/schema/layingDate>
+        \"2018-09-26+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/Wp00cYcL>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/5LQ5Ar74>
+        .\r\n<https://id.parliament.uk/rINYVove> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/rINYVove>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/sUFFmPCo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/sUFFmPCo>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/sUFFmPCo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/sUFFmPCo>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 270\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/sUFFmPCo>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 270\" .\r\n<https://id.parliament.uk/sUFFmPCo> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"1025\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/sUFFmPCo>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 270\" .\r\n<https://id.parliament.uk/sUFFmPCo> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/GUK5AtG9> .\r\n<https://id.parliament.uk/sUFFmPCo>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/xrQp8wjo>
+        .\r\n<https://id.parliament.uk/GUK5AtG9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/GUK5AtG9>
+        <https://id.parliament.uk/schema/layingDate> \"2018-09-25+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/GUK5AtG9> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/5LQ5Ar74> .\r\n<https://id.parliament.uk/xrQp8wjo>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/xrQp8wjo> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/Ez5LhVPl>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/Ez5LhVPl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/Ez5LhVPl>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/Ez5LhVPl> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 271\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/Ez5LhVPl> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 271\" .\r\n<https://id.parliament.uk/Ez5LhVPl>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"1033\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/Ez5LhVPl> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 271\" .\r\n<https://id.parliament.uk/Ez5LhVPl>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/HkXhKKPX>
+        .\r\n<https://id.parliament.uk/Ez5LhVPl> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/SGkBjU1C> .\r\n<https://id.parliament.uk/HkXhKKPX>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/HkXhKKPX> <https://id.parliament.uk/schema/layingDate>
+        \"2018-09-27+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/HkXhKKPX>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/5LQ5Ar74>
+        .\r\n<https://id.parliament.uk/SGkBjU1C> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/SGkBjU1C>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/x1lCTIsz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/x1lCTIsz>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/x1lCTIsz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/x1lCTIsz>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 272\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/x1lCTIsz>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 272\" .\r\n<https://id.parliament.uk/x1lCTIsz> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"1034\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/x1lCTIsz>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 272\" .\r\n<https://id.parliament.uk/x1lCTIsz> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/oOTesb2Y> .\r\n<https://id.parliament.uk/x1lCTIsz>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/O1seG0Nv>
+        .\r\n<https://id.parliament.uk/oOTesb2Y> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/oOTesb2Y>
+        <https://id.parliament.uk/schema/layingDate> \"2018-09-27+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/oOTesb2Y> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/5LQ5Ar74> .\r\n<https://id.parliament.uk/O1seG0Nv>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/O1seG0Nv> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/V9OJief9>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/V9OJief9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/V9OJief9>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/V9OJief9> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 273\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/V9OJief9> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 273\" .\r\n<https://id.parliament.uk/V9OJief9>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"1038\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/V9OJief9> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 273\" .\r\n<https://id.parliament.uk/V9OJief9>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/mGTRkI6E>
+        .\r\n<https://id.parliament.uk/V9OJief9> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/zdW1LizR> .\r\n<https://id.parliament.uk/mGTRkI6E>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/mGTRkI6E> <https://id.parliament.uk/schema/layingDate>
+        \"2018-09-28+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/mGTRkI6E>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/HYfypSOE>
+        .\r\n<https://id.parliament.uk/zdW1LizR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/zdW1LizR>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/YeYkel8w> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/YeYkel8w>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/YeYkel8w> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/YeYkel8w>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 274\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/YeYkel8w>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 274\" .\r\n<https://id.parliament.uk/YeYkel8w> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 274\" .\r\n<https://id.parliament.uk/YeYkel8w>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/CfajRCrp>
+        .\r\n<https://id.parliament.uk/YeYkel8w> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/Zo9nO92C> .\r\n<https://id.parliament.uk/CfajRCrp>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/CfajRCrp> <https://id.parliament.uk/schema/layingDate>
+        \"2018-03-29+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/CfajRCrp>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/yiuTaSI4>
+        .\r\n<https://id.parliament.uk/Zo9nO92C> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/Zo9nO92C>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/XGB9Cj8C> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/XGB9Cj8C>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/XGB9Cj8C> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/XGB9Cj8C>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 275\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/XGB9Cj8C>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 275\" .\r\n<https://id.parliament.uk/XGB9Cj8C> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"507\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/XGB9Cj8C>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 275\" .\r\n<https://id.parliament.uk/XGB9Cj8C> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/L97rEr0s> .\r\n<https://id.parliament.uk/XGB9Cj8C>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/F8pP8ZhB>
+        .\r\n<https://id.parliament.uk/L97rEr0s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/L97rEr0s>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/L97rEr0s> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/79sn5e3n> .\r\n<https://id.parliament.uk/F8pP8ZhB>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/F8pP8ZhB> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/2zCfE0jG>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/2zCfE0jG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/2zCfE0jG>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/2zCfE0jG> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 276\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/2zCfE0jG> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 276\" .\r\n<https://id.parliament.uk/2zCfE0jG>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"899\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/2zCfE0jG> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 276\" .\r\n<https://id.parliament.uk/2zCfE0jG>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/3xRYolQn>
+        .\r\n<https://id.parliament.uk/3xRYolQn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/3xRYolQn>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/fqzYAhp8> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/fqzYAhp8>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/fqzYAhp8> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/fqzYAhp8>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 277\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/fqzYAhp8>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 277\" .\r\n<https://id.parliament.uk/fqzYAhp8> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"900\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/fqzYAhp8>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 277\" .\r\n<https://id.parliament.uk/fqzYAhp8> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/twB3lRXS> .\r\n<https://id.parliament.uk/twB3lRXS>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/twB3lRXS> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/AbFupFPb>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/AbFupFPb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/AbFupFPb>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/AbFupFPb> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 278\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/AbFupFPb> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 278\" .\r\n<https://id.parliament.uk/AbFupFPb>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"906\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/AbFupFPb> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 278\" .\r\n<https://id.parliament.uk/AbFupFPb>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/T1Z8xmPJ>
+        .\r\n<https://id.parliament.uk/T1Z8xmPJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/T1Z8xmPJ>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/LCvP8PWr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/LCvP8PWr>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/LCvP8PWr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/LCvP8PWr>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 279\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/LCvP8PWr>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 279\" .\r\n<https://id.parliament.uk/LCvP8PWr> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"1037\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/LCvP8PWr>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 279\" .\r\n<https://id.parliament.uk/LCvP8PWr> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/cGNDQyi9> .\r\n<https://id.parliament.uk/LCvP8PWr>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/nqDtLBR9>
+        .\r\n<https://id.parliament.uk/cGNDQyi9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/cGNDQyi9>
+        <https://id.parliament.uk/schema/layingDate> \"2018-09-28+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/cGNDQyi9> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/5LQ5Ar74> .\r\n<https://id.parliament.uk/nqDtLBR9>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/nqDtLBR9> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/VW7e0Sva>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/VW7e0Sva> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/VW7e0Sva>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/VW7e0Sva> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 280\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/VW7e0Sva> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 280\" .\r\n<https://id.parliament.uk/VW7e0Sva>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"1039\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/VW7e0Sva> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 280\" .\r\n<https://id.parliament.uk/VW7e0Sva>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/CyeKcrpK>
+        .\r\n<https://id.parliament.uk/VW7e0Sva> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/jaYLRoUo> .\r\n<https://id.parliament.uk/CyeKcrpK>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/CyeKcrpK> <https://id.parliament.uk/schema/layingDate>
+        \"2018-09-28+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/CyeKcrpK>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/HYfypSOE>
+        .\r\n<https://id.parliament.uk/jaYLRoUo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/jaYLRoUo>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/nmnBg42M> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/nmnBg42M>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/nmnBg42M> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/nmnBg42M>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 281\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/nmnBg42M>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 281\" .\r\n<https://id.parliament.uk/nmnBg42M> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"1043\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/nmnBg42M>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 281\" .\r\n<https://id.parliament.uk/nmnBg42M> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/HaM33HDN> .\r\n<https://id.parliament.uk/nmnBg42M>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/HHrQwR8D>
+        .\r\n<https://id.parliament.uk/HaM33HDN> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/HaM33HDN>
+        <https://id.parliament.uk/schema/layingDate> \"2018-10-05+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/HaM33HDN> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fKqMNz79> .\r\n<https://id.parliament.uk/HHrQwR8D>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/HHrQwR8D> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/HD6sJ5Bq>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/HD6sJ5Bq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/HD6sJ5Bq>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/HD6sJ5Bq> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 282\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/HD6sJ5Bq> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 282\" .\r\n<https://id.parliament.uk/HD6sJ5Bq>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 282\" .\r\n<https://id.parliament.uk/HD6sJ5Bq> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/CgLkkosK> .\r\n<https://id.parliament.uk/HD6sJ5Bq>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/fvbuf8S8>
+        .\r\n<https://id.parliament.uk/CgLkkosK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/CgLkkosK>
+        <https://id.parliament.uk/schema/layingDate> \"2018-10-09+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/CgLkkosK> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XouN12Ow> .\r\n<https://id.parliament.uk/fvbuf8S8>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/fvbuf8S8> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/AWmzydlB>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/AWmzydlB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/AWmzydlB>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/AWmzydlB> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 283\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/AWmzydlB> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 283\" .\r\n<https://id.parliament.uk/AWmzydlB>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"1053\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/AWmzydlB> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 283\" .\r\n<https://id.parliament.uk/AWmzydlB>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/9z7FUKoK>
+        .\r\n<https://id.parliament.uk/AWmzydlB> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/OEpUFoMB> .\r\n<https://id.parliament.uk/9z7FUKoK>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/9z7FUKoK> <https://id.parliament.uk/schema/layingDate>
+        \"2018-10-09+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/9z7FUKoK>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/BRTNQywN>
+        .\r\n<https://id.parliament.uk/OEpUFoMB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/OEpUFoMB>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/5ISSgu1W> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/5ISSgu1W>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/5ISSgu1W> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/5ISSgu1W>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 284\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/5ISSgu1W>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 284\" .\r\n<https://id.parliament.uk/5ISSgu1W> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 284\" .\r\n<https://id.parliament.uk/5ISSgu1W>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/MeQ6jkaq>
+        .\r\n<https://id.parliament.uk/5ISSgu1W> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/Tdu2Oxdn> .\r\n<https://id.parliament.uk/MeQ6jkaq>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/MeQ6jkaq> <https://id.parliament.uk/schema/layingDate>
+        \"2018-10-09+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/MeQ6jkaq>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/XouN12Ow>
+        .\r\n<https://id.parliament.uk/Tdu2Oxdn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/Tdu2Oxdn>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/hhJ7dD7c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/hhJ7dD7c>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/hhJ7dD7c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/hhJ7dD7c>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 285\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/hhJ7dD7c>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 285\" .\r\n<https://id.parliament.uk/hhJ7dD7c> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"1052\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/hhJ7dD7c>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 285\" .\r\n<https://id.parliament.uk/hhJ7dD7c> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/eVLueRWf> .\r\n<https://id.parliament.uk/hhJ7dD7c>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/l3feUJPF>
+        .\r\n<https://id.parliament.uk/eVLueRWf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/eVLueRWf>
+        <https://id.parliament.uk/schema/layingDate> \"2018-10-09+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/eVLueRWf> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/yiuTaSI4> .\r\n<https://id.parliament.uk/l3feUJPF>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/l3feUJPF> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/57kWuZb4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/57kWuZb4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/57kWuZb4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/57kWuZb4> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 286\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/57kWuZb4> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 286\" .\r\n<https://id.parliament.uk/57kWuZb4>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 286\" .\r\n<https://id.parliament.uk/57kWuZb4> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/VRwZK1dd> .\r\n<https://id.parliament.uk/57kWuZb4>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/A35mNYan>
+        .\r\n<https://id.parliament.uk/VRwZK1dd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/VRwZK1dd>
+        <https://id.parliament.uk/schema/layingDate> \"2018-10-09+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/VRwZK1dd> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/HYfypSOE> .\r\n<https://id.parliament.uk/A35mNYan>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/A35mNYan> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/mEVKpToG>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/mEVKpToG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/mEVKpToG>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/mEVKpToG> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 287\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/mEVKpToG> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 287\" .\r\n<https://id.parliament.uk/mEVKpToG>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 287\" .\r\n<https://id.parliament.uk/mEVKpToG> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/DK5agjiR> .\r\n<https://id.parliament.uk/mEVKpToG>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/JthygHIN>
+        .\r\n<https://id.parliament.uk/DK5agjiR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/DK5agjiR>
+        <https://id.parliament.uk/schema/layingDate> \"2018-10-09+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/DK5agjiR> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/HYfypSOE> .\r\n<https://id.parliament.uk/JthygHIN>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/JthygHIN> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/WFivvWVa>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/WFivvWVa> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/WFivvWVa>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/WFivvWVa> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 288\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/WFivvWVa> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 288\" .\r\n<https://id.parliament.uk/WFivvWVa>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 288\" .\r\n<https://id.parliament.uk/WFivvWVa> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/8AwnVijm> .\r\n<https://id.parliament.uk/WFivvWVa>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/khiR4R9R>
+        .\r\n<https://id.parliament.uk/8AwnVijm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/8AwnVijm>
+        <https://id.parliament.uk/schema/layingDate> \"2018-10-09+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/8AwnVijm> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/HYfypSOE> .\r\n<https://id.parliament.uk/khiR4R9R>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/khiR4R9R> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/Rcqh3lsI>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/Rcqh3lsI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/Rcqh3lsI>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/Rcqh3lsI> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 289\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/Rcqh3lsI> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 289\" .\r\n<https://id.parliament.uk/Rcqh3lsI>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"1047\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/Rcqh3lsI> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 289\" .\r\n<https://id.parliament.uk/Rcqh3lsI>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/zIcQBtiW>
+        .\r\n<https://id.parliament.uk/Rcqh3lsI> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/dcsrL0EB> .\r\n<https://id.parliament.uk/zIcQBtiW>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/zIcQBtiW> <https://id.parliament.uk/schema/layingDate>
+        \"2018-10-09+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/zIcQBtiW>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/ZU3IXBtP>
+        .\r\n<https://id.parliament.uk/dcsrL0EB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/dcsrL0EB>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/03b7Krn2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/03b7Krn2>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/03b7Krn2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/03b7Krn2>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 290\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/03b7Krn2>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 290\" .\r\n<https://id.parliament.uk/03b7Krn2> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 290\" .\r\n<https://id.parliament.uk/03b7Krn2>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/KPDgfIaG>
+        .\r\n<https://id.parliament.uk/03b7Krn2> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/1Tn8ZUle> .\r\n<https://id.parliament.uk/KPDgfIaG>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/KPDgfIaG> <https://id.parliament.uk/schema/layingDate>
+        \"2018-10-09+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/KPDgfIaG>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/HYfypSOE>
+        .\r\n<https://id.parliament.uk/1Tn8ZUle> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/1Tn8ZUle>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/EuWVmkrN> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/EuWVmkrN>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/EuWVmkrN> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/EuWVmkrN>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 291\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/EuWVmkrN>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 291\" .\r\n<https://id.parliament.uk/EuWVmkrN> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"1046\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/EuWVmkrN>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 291\" .\r\n<https://id.parliament.uk/EuWVmkrN> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/m6mEHuqF> .\r\n<https://id.parliament.uk/EuWVmkrN>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/QsaNlrbs>
+        .\r\n<https://id.parliament.uk/m6mEHuqF> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/m6mEHuqF>
+        <https://id.parliament.uk/schema/layingDate> \"2018-10-09+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/m6mEHuqF> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/yiuTaSI4> .\r\n<https://id.parliament.uk/QsaNlrbs>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/QsaNlrbs> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/k7Ytkpuk>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/k7Ytkpuk> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/k7Ytkpuk>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/k7Ytkpuk> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 292\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/k7Ytkpuk> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 292\" .\r\n<https://id.parliament.uk/k7Ytkpuk>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 292\" .\r\n<https://id.parliament.uk/k7Ytkpuk> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/uTZ2QVny> .\r\n<https://id.parliament.uk/k7Ytkpuk>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/lZAXVvXl>
+        .\r\n<https://id.parliament.uk/uTZ2QVny> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/uTZ2QVny>
+        <https://id.parliament.uk/schema/layingDate> \"2018-10-09+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/uTZ2QVny> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/HYfypSOE> .\r\n<https://id.parliament.uk/lZAXVvXl>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/lZAXVvXl> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/T8QuQbfp>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/T8QuQbfp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/T8QuQbfp>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/T8QuQbfp> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 293\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/T8QuQbfp> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 293\" .\r\n<https://id.parliament.uk/T8QuQbfp>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 293\" .\r\n<https://id.parliament.uk/T8QuQbfp> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/m3e3JF2S> .\r\n<https://id.parliament.uk/T8QuQbfp>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/VAKIqdsw>
+        .\r\n<https://id.parliament.uk/m3e3JF2S> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/m3e3JF2S>
+        <https://id.parliament.uk/schema/layingDate> \"2018-10-10+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/m3e3JF2S> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/yiuTaSI4> .\r\n<https://id.parliament.uk/VAKIqdsw>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/VAKIqdsw> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/HDMCkDND>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/HDMCkDND> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/HDMCkDND>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/HDMCkDND> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 294\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/HDMCkDND> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 294\" .\r\n<https://id.parliament.uk/HDMCkDND>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"1048\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/HDMCkDND> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 294\" .\r\n<https://id.parliament.uk/HDMCkDND>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/5zo0e99B>
+        .\r\n<https://id.parliament.uk/HDMCkDND> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/qAaoszxP> .\r\n<https://id.parliament.uk/5zo0e99B>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/5zo0e99B> <https://id.parliament.uk/schema/layingDate>
+        \"2018-10-10+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/5zo0e99B>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/5LQ5Ar74>
+        .\r\n<https://id.parliament.uk/qAaoszxP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/qAaoszxP>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/Y5wgjNCe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/Y5wgjNCe>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/Y5wgjNCe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/Y5wgjNCe>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 295\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/Y5wgjNCe>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 295\" .\r\n<https://id.parliament.uk/Y5wgjNCe> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"1044\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/Y5wgjNCe>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 295\" .\r\n<https://id.parliament.uk/Y5wgjNCe> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/b6EduGTz> .\r\n<https://id.parliament.uk/Y5wgjNCe>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/wNXTPpGh>
+        .\r\n<https://id.parliament.uk/b6EduGTz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/b6EduGTz>
+        <https://id.parliament.uk/schema/layingDate> \"2018-10-10+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/b6EduGTz> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XouN12Ow> .\r\n<https://id.parliament.uk/wNXTPpGh>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/wNXTPpGh> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/ogDjrUru>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/ogDjrUru> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/ogDjrUru>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/ogDjrUru> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 296\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/ogDjrUru> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 296\" .\r\n<https://id.parliament.uk/ogDjrUru>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 296\" .\r\n<https://id.parliament.uk/ogDjrUru> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/7Z61hi24> .\r\n<https://id.parliament.uk/ogDjrUru>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/OI2sXT42>
+        .\r\n<https://id.parliament.uk/7Z61hi24> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/7Z61hi24>
+        <https://id.parliament.uk/schema/layingDate> \"2018-10-10+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/7Z61hi24> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/ZU3IXBtP> .\r\n<https://id.parliament.uk/OI2sXT42>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/OI2sXT42> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/90n67zWF>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/90n67zWF> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/90n67zWF>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/90n67zWF> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 297\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/90n67zWF> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 297\" .\r\n<https://id.parliament.uk/90n67zWF>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"1051\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/90n67zWF> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 297\" .\r\n<https://id.parliament.uk/90n67zWF>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/5sGlX5ld>
+        .\r\n<https://id.parliament.uk/90n67zWF> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/PgzOMcNk> .\r\n<https://id.parliament.uk/5sGlX5ld>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/5sGlX5ld> <https://id.parliament.uk/schema/layingDate>
+        \"2018-10-10+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/5sGlX5ld>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/5LQ5Ar74>
+        .\r\n<https://id.parliament.uk/PgzOMcNk> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/PgzOMcNk>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/iKgIQsG9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/iKgIQsG9>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/iKgIQsG9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/iKgIQsG9>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 298\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/iKgIQsG9>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 298\" .\r\n<https://id.parliament.uk/iKgIQsG9> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 298\" .\r\n<https://id.parliament.uk/iKgIQsG9>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/JBmPy40P>
+        .\r\n<https://id.parliament.uk/iKgIQsG9> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/Goj1Zra6> .\r\n<https://id.parliament.uk/JBmPy40P>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/JBmPy40P> <https://id.parliament.uk/schema/layingDate>
+        \"2018-10-10+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/JBmPy40P>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/kv2Qqfn9>
+        .\r\n<https://id.parliament.uk/Goj1Zra6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/Goj1Zra6>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/qN5SIpKr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/qN5SIpKr>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/qN5SIpKr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/qN5SIpKr>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 299\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/qN5SIpKr>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 299\" .\r\n<https://id.parliament.uk/qN5SIpKr> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 299\" .\r\n<https://id.parliament.uk/qN5SIpKr>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/OTs9pC6Q>
+        .\r\n<https://id.parliament.uk/qN5SIpKr> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/YH5Tygda> .\r\n<https://id.parliament.uk/OTs9pC6Q>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/OTs9pC6Q> <https://id.parliament.uk/schema/layingDate>
+        \"2018-10-11+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/OTs9pC6Q>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/NDZSYjeE>
+        .\r\n<https://id.parliament.uk/YH5Tygda> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/YH5Tygda>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/WcxZPA5i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/WcxZPA5i>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/WcxZPA5i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/WcxZPA5i>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 300\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/WcxZPA5i>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 300\" .\r\n<https://id.parliament.uk/WcxZPA5i> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"1062\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/WcxZPA5i>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 300\" .\r\n<https://id.parliament.uk/WcxZPA5i> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/xxamoGFE> .\r\n<https://id.parliament.uk/WcxZPA5i>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/kz8tjyyh>
+        .\r\n<https://id.parliament.uk/xxamoGFE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/xxamoGFE>
+        <https://id.parliament.uk/schema/layingDate> \"2018-10-11+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/xxamoGFE> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/JVJB3tuB> .\r\n<https://id.parliament.uk/kz8tjyyh>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/kz8tjyyh> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/0l2kwZPW>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/0l2kwZPW> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/0l2kwZPW>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/0l2kwZPW> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 301\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/0l2kwZPW> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 301\" .\r\n<https://id.parliament.uk/0l2kwZPW>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"1055\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/0l2kwZPW> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 301\" .\r\n<https://id.parliament.uk/0l2kwZPW>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/HgDlGoDg>
+        .\r\n<https://id.parliament.uk/0l2kwZPW> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/aYjkd3c2> .\r\n<https://id.parliament.uk/HgDlGoDg>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/HgDlGoDg> <https://id.parliament.uk/schema/layingDate>
+        \"2018-10-11+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/HgDlGoDg>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/NDZSYjeE>
+        .\r\n<https://id.parliament.uk/aYjkd3c2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/aYjkd3c2>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/eOlu960r> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/eOlu960r>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/eOlu960r> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/eOlu960r>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 302\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/eOlu960r>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 302\" .\r\n<https://id.parliament.uk/eOlu960r> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"1056\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/eOlu960r>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 302\" .\r\n<https://id.parliament.uk/eOlu960r> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/dOYT5tSO> .\r\n<https://id.parliament.uk/eOlu960r>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/XO8Wq7au>
+        .\r\n<https://id.parliament.uk/dOYT5tSO> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/dOYT5tSO>
+        <https://id.parliament.uk/schema/layingDate> \"2018-10-11+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/dOYT5tSO> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fKqMNz79> .\r\n<https://id.parliament.uk/XO8Wq7au>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/XO8Wq7au> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/d2bXwUKW>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/d2bXwUKW> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/d2bXwUKW>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/d2bXwUKW> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 303\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/d2bXwUKW> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 303\" .\r\n<https://id.parliament.uk/d2bXwUKW>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 303\" .\r\n<https://id.parliament.uk/d2bXwUKW> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/R12ebcaQ> .\r\n<https://id.parliament.uk/d2bXwUKW>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/Fg6Xjml5>
+        .\r\n<https://id.parliament.uk/R12ebcaQ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/R12ebcaQ>
+        <https://id.parliament.uk/schema/layingDate> \"2018-10-11+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/R12ebcaQ> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/NDZSYjeE> .\r\n<https://id.parliament.uk/Fg6Xjml5>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/Fg6Xjml5> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/CFyWykUZ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/CFyWykUZ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/CFyWykUZ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/CFyWykUZ> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 304\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/CFyWykUZ> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 304\" .\r\n<https://id.parliament.uk/CFyWykUZ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"1059\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/CFyWykUZ> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 304\" .\r\n<https://id.parliament.uk/CFyWykUZ>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/i2utXKbv>
+        .\r\n<https://id.parliament.uk/CFyWykUZ> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/8wxb6BWd> .\r\n<https://id.parliament.uk/i2utXKbv>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/i2utXKbv> <https://id.parliament.uk/schema/layingDate>
+        \"2018-10-11+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/i2utXKbv>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/7dSvuueH>
+        .\r\n<https://id.parliament.uk/8wxb6BWd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/8wxb6BWd>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/J097gJjm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/J097gJjm>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/J097gJjm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/J097gJjm>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 305\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/J097gJjm>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 305\" .\r\n<https://id.parliament.uk/J097gJjm> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"1083\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/J097gJjm>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 305\" .\r\n<https://id.parliament.uk/J097gJjm> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/PhCUmQY7> .\r\n<https://id.parliament.uk/J097gJjm>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/mMJoin9d>
+        .\r\n<https://id.parliament.uk/PhCUmQY7> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/PhCUmQY7>
+        <https://id.parliament.uk/schema/layingDate> \"2018-10-15+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/PhCUmQY7> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/ZU3IXBtP> .\r\n<https://id.parliament.uk/mMJoin9d>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/mMJoin9d> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/4CQsOYHF>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/4CQsOYHF> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/4CQsOYHF>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/4CQsOYHF> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 306\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/4CQsOYHF> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 306\" .\r\n<https://id.parliament.uk/4CQsOYHF>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"1072\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/4CQsOYHF> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 306\" .\r\n<https://id.parliament.uk/4CQsOYHF>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/vWBoX8Kn>
+        .\r\n<https://id.parliament.uk/4CQsOYHF> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/sqake64i> .\r\n<https://id.parliament.uk/vWBoX8Kn>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/vWBoX8Kn> <https://id.parliament.uk/schema/layingDate>
+        \"2018-10-12+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/vWBoX8Kn>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/NDZSYjeE>
+        .\r\n<https://id.parliament.uk/sqake64i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/sqake64i>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/PdffL1zZ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/PdffL1zZ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/PdffL1zZ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/PdffL1zZ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 307\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/PdffL1zZ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 307\" .\r\n<https://id.parliament.uk/PdffL1zZ> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"1082\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/PdffL1zZ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 307\" .\r\n<https://id.parliament.uk/PdffL1zZ> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/ubciSMWL> .\r\n<https://id.parliament.uk/PdffL1zZ>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/HqIRueFW>
+        .\r\n<https://id.parliament.uk/ubciSMWL> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/ubciSMWL>
+        <https://id.parliament.uk/schema/layingDate> \"2018-10-15+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/ubciSMWL> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/yiuTaSI4> .\r\n<https://id.parliament.uk/HqIRueFW>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/HqIRueFW> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/VQdXrdx2>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/VQdXrdx2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/VQdXrdx2>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/VQdXrdx2> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 308\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/VQdXrdx2> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 308\" .\r\n<https://id.parliament.uk/VQdXrdx2>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"1086\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/VQdXrdx2> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 308\" .\r\n<https://id.parliament.uk/VQdXrdx2>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/MblgQ49Y>
+        .\r\n<https://id.parliament.uk/VQdXrdx2> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/1KElI7j4> .\r\n<https://id.parliament.uk/MblgQ49Y>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/MblgQ49Y> <https://id.parliament.uk/schema/layingDate>
+        \"2018-10-15+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/MblgQ49Y>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/ZU3IXBtP>
+        .\r\n<https://id.parliament.uk/1KElI7j4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/1KElI7j4>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/ykZHxqox> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/ykZHxqox>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/ykZHxqox> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/ykZHxqox>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 309\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/ykZHxqox>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 309\" .\r\n<https://id.parliament.uk/ykZHxqox> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 309\" .\r\n<https://id.parliament.uk/ykZHxqox>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/t155HrTe>
+        .\r\n<https://id.parliament.uk/ykZHxqox> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/kcEjmWpr> .\r\n<https://id.parliament.uk/t155HrTe>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/t155HrTe> <https://id.parliament.uk/schema/layingDate>
+        \"2018-10-16+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/t155HrTe>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/eup4DwE5>
+        .\r\n<https://id.parliament.uk/kcEjmWpr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/kcEjmWpr>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/gTgidljI>
+        .\r\n<https://id.parliament.uk/ig2TxYLa> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/ig2TxYLa>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/ig2TxYLa> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/ig2TxYLa>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 310\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/ig2TxYLa>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 310\" .\r\n<https://id.parliament.uk/ig2TxYLa> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 310\" .\r\n<https://id.parliament.uk/ig2TxYLa>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/3DMhopcY>
+        .\r\n<https://id.parliament.uk/ig2TxYLa> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/YTS410BP> .\r\n<https://id.parliament.uk/3DMhopcY>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/3DMhopcY> <https://id.parliament.uk/schema/layingDate>
+        \"2018-10-16+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/3DMhopcY>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/eup4DwE5>
+        .\r\n<https://id.parliament.uk/YTS410BP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/YTS410BP>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/gTgidljI>
+        .\r\n<https://id.parliament.uk/bV5IlI9d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/bV5IlI9d>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/bV5IlI9d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/bV5IlI9d>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 311\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/bV5IlI9d>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 311\" .\r\n<https://id.parliament.uk/bV5IlI9d> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 311\" .\r\n<https://id.parliament.uk/bV5IlI9d>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/1PEG8aEE>
+        .\r\n<https://id.parliament.uk/bV5IlI9d> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/p4h9qzxn> .\r\n<https://id.parliament.uk/1PEG8aEE>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/1PEG8aEE> <https://id.parliament.uk/schema/layingDate>
+        \"2018-10-16+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/1PEG8aEE>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/eup4DwE5>
+        .\r\n<https://id.parliament.uk/p4h9qzxn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/p4h9qzxn>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/gTgidljI>
+        .\r\n<https://id.parliament.uk/8NE6wEFF> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/8NE6wEFF>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/8NE6wEFF> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/8NE6wEFF>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 312\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/8NE6wEFF>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 312\" .\r\n<https://id.parliament.uk/8NE6wEFF> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 312\" .\r\n<https://id.parliament.uk/8NE6wEFF>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/Veq7J900>
+        .\r\n<https://id.parliament.uk/8NE6wEFF> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/jeyEtajA> .\r\n<https://id.parliament.uk/Veq7J900>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/Veq7J900> <https://id.parliament.uk/schema/layingDate>
+        \"2018-10-16+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/Veq7J900>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/eup4DwE5>
+        .\r\n<https://id.parliament.uk/jeyEtajA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/jeyEtajA>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/gTgidljI>
+        .\r\n<https://id.parliament.uk/yK2eW3VI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/yK2eW3VI>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/yK2eW3VI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/yK2eW3VI>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 313\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/yK2eW3VI>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 313\" .\r\n<https://id.parliament.uk/yK2eW3VI> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 313\" .\r\n<https://id.parliament.uk/yK2eW3VI>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/LQEg2yuf>
+        .\r\n<https://id.parliament.uk/yK2eW3VI> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/y8mNGRax> .\r\n<https://id.parliament.uk/LQEg2yuf>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/LQEg2yuf> <https://id.parliament.uk/schema/layingDate>
+        \"2018-10-16+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/LQEg2yuf>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/eup4DwE5>
+        .\r\n<https://id.parliament.uk/y8mNGRax> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/y8mNGRax>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/gTgidljI>
+        .\r\n"
+    http_version: 
+  recorded_at: Thu, 25 Oct 2018 11:24:20 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/GroupSortHelper/with_real_data/_sort_keys/sorts_a_hash_by_its_keys_correctly.yml
+++ b/spec/fixtures/vcr_cassettes/GroupSortHelper/with_real_data/_sort_keys/sorts_a_hash_by_its_keys_correctly.yml
@@ -1,0 +1,6755 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3030/statutory_instrument_index
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      - application/n-triples
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-store, must-revalidate, no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '40684'
+      Content-Type:
+      - application/n-triples
+      Expires:
+      - Thu, 25 Oct 2018 11:17:00 GMT
+      Request-Context:
+      - appId=cid-v1:330aa411-57af-491f-b22a-1cab7d08a6a9
+      Access-Control-Expose-Headers:
+      - Request-Context
+      Set-Cookie:
+      - ARRAffinity=77b2b22b62b6e0d158b9023c2ed0c9ea4be870072240a45c1bef0e3480502c58;Path=/;HttpOnly;Domain=fixedquery201810051005.azurewebsites.net
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Thu, 25 Oct 2018 11:16:59 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "<https://id.parliament.uk/QmvfCS3N> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/QmvfCS3N>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/QmvfCS3N> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/QmvfCS3N>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 1\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/QmvfCS3N>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 1\" .\r\n<https://id.parliament.uk/QmvfCS3N> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"751\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/QmvfCS3N>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 1\" .\r\n<https://id.parliament.uk/QmvfCS3N> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/Mcvmer52> .\r\n<https://id.parliament.uk/QmvfCS3N>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/tVWVmTCL>
+        .\r\n<https://id.parliament.uk/Mcvmer52> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/Mcvmer52>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-03+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/Mcvmer52> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fKqMNz79> .\r\n<https://id.parliament.uk/fKqMNz79>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Group>
+        .\r\n<https://id.parliament.uk/fKqMNz79> <https://id.parliament.uk/schema/groupName>
+        \"groupName - 1\" .\r\n<https://id.parliament.uk/tVWVmTCL> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/tVWVmTCL>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/H5YJQsK2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Procedure> .\r\n<https://id.parliament.uk/H5YJQsK2>
+        <https://id.parliament.uk/schema/procedureName> \"procedureName - 1\" .\r\n<https://id.parliament.uk/keUmDe6y>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/keUmDe6y> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/keUmDe6y>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/keUmDe6y> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 2\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/keUmDe6y> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 2\" .\r\n<https://id.parliament.uk/keUmDe6y>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"517\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/keUmDe6y> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 2\" .\r\n<https://id.parliament.uk/keUmDe6y>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/qaT30ffk>
+        .\r\n<https://id.parliament.uk/keUmDe6y> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/e8079KjV> .\r\n<https://id.parliament.uk/qaT30ffk>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/qaT30ffk> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-27+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/qaT30ffk>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/7dSvuueH>
+        .\r\n<https://id.parliament.uk/7dSvuueH> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Group> .\r\n<https://id.parliament.uk/7dSvuueH>
+        <https://id.parliament.uk/schema/groupName> \"groupName - 2\" .\r\n<https://id.parliament.uk/e8079KjV>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/e8079KjV> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/5S6p4YsP>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Procedure>
+        .\r\n<https://id.parliament.uk/5S6p4YsP> <https://id.parliament.uk/schema/procedureName>
+        \"procedureName - 2\" .\r\n<https://id.parliament.uk/R63aWjPi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/R63aWjPi>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/R63aWjPi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/R63aWjPi>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 3\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/R63aWjPi>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 3\" .\r\n<https://id.parliament.uk/R63aWjPi> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"566\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/R63aWjPi>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 3\" .\r\n<https://id.parliament.uk/R63aWjPi> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/NPExPXay> .\r\n<https://id.parliament.uk/R63aWjPi>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/lon9Uu05>
+        .\r\n<https://id.parliament.uk/NPExPXay> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/NPExPXay>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-08+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/NPExPXay> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fKqMNz79> .\r\n<https://id.parliament.uk/lon9Uu05>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/lon9Uu05> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/W0xWx2Iu>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/W0xWx2Iu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/W0xWx2Iu>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/W0xWx2Iu> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 4\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/W0xWx2Iu> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 4\" .\r\n<https://id.parliament.uk/W0xWx2Iu>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"498\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/W0xWx2Iu> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 4\" .\r\n<https://id.parliament.uk/W0xWx2Iu>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/QzUSqeLr>
+        .\r\n<https://id.parliament.uk/W0xWx2Iu> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/9XxmwGtU> .\r\n<https://id.parliament.uk/QzUSqeLr>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/QzUSqeLr> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-20+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/QzUSqeLr>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/BRTNQywN>
+        .\r\n<https://id.parliament.uk/BRTNQywN> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Group> .\r\n<https://id.parliament.uk/BRTNQywN>
+        <https://id.parliament.uk/schema/groupName> \"groupName - 3\" .\r\n<https://id.parliament.uk/9XxmwGtU>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/9XxmwGtU> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/On2R0Zeb>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/On2R0Zeb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/On2R0Zeb>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/On2R0Zeb> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 5\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/On2R0Zeb> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 5\" .\r\n<https://id.parliament.uk/On2R0Zeb>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"466\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/On2R0Zeb> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 5\" .\r\n<https://id.parliament.uk/On2R0Zeb>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/TQQt5wkr>
+        .\r\n<https://id.parliament.uk/On2R0Zeb> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/40Yq0PnR> .\r\n<https://id.parliament.uk/TQQt5wkr>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/TQQt5wkr> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/TQQt5wkr>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/7dSvuueH>
+        .\r\n<https://id.parliament.uk/40Yq0PnR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/40Yq0PnR>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/yxN0RDlj> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/yxN0RDlj>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/yxN0RDlj> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/yxN0RDlj>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 6\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/yxN0RDlj>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 6\" .\r\n<https://id.parliament.uk/yxN0RDlj> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"553\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/yxN0RDlj>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 6\" .\r\n<https://id.parliament.uk/yxN0RDlj> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/3ZbbcnKj> .\r\n<https://id.parliament.uk/yxN0RDlj>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/PjQFqiyZ>
+        .\r\n<https://id.parliament.uk/3ZbbcnKj> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/3ZbbcnKj>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-03+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/3ZbbcnKj> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fKqMNz79> .\r\n<https://id.parliament.uk/PjQFqiyZ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/PjQFqiyZ> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/tPkKG8ef>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/tPkKG8ef> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/tPkKG8ef>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/tPkKG8ef> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 7\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/tPkKG8ef> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 7\" .\r\n<https://id.parliament.uk/tPkKG8ef>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"549\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/tPkKG8ef> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 7\" .\r\n<https://id.parliament.uk/tPkKG8ef>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/uprc8alP>
+        .\r\n<https://id.parliament.uk/tPkKG8ef> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/9bXhF8oV> .\r\n<https://id.parliament.uk/uprc8alP>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/uprc8alP> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-01+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/uprc8alP>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/BRTNQywN>
+        .\r\n<https://id.parliament.uk/9bXhF8oV> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/9bXhF8oV>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/9PuVurua> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/9PuVurua>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/9PuVurua> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/9PuVurua>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 8\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/9PuVurua>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 8\" .\r\n<https://id.parliament.uk/9PuVurua> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"538\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/9PuVurua>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 8\" .\r\n<https://id.parliament.uk/9PuVurua> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/2iDuQtrK> .\r\n<https://id.parliament.uk/9PuVurua>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/zhi6ZHnQ>
+        .\r\n<https://id.parliament.uk/2iDuQtrK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/2iDuQtrK>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-30+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/2iDuQtrK> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/79sn5e3n> .\r\n<https://id.parliament.uk/79sn5e3n>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Group>
+        .\r\n<https://id.parliament.uk/79sn5e3n> <https://id.parliament.uk/schema/groupName>
+        \"groupName - 4\" .\r\n<https://id.parliament.uk/zhi6ZHnQ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/zhi6ZHnQ>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/ITuNnxmw> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/ITuNnxmw>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/ITuNnxmw> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/ITuNnxmw>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 9\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/ITuNnxmw>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 9\" .\r\n<https://id.parliament.uk/ITuNnxmw> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"797\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/ITuNnxmw>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 9\" .\r\n<https://id.parliament.uk/ITuNnxmw> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/1AR7f0NW> .\r\n<https://id.parliament.uk/ITuNnxmw>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/PsB0pq0l>
+        .\r\n<https://id.parliament.uk/1AR7f0NW> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/1AR7f0NW>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-30+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/1AR7f0NW> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/yiuTaSI4> .\r\n<https://id.parliament.uk/yiuTaSI4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Group>
+        .\r\n<https://id.parliament.uk/yiuTaSI4> <https://id.parliament.uk/schema/groupName>
+        \"groupName - 5\" .\r\n<https://id.parliament.uk/PsB0pq0l> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/PsB0pq0l>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/bS94erG6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/bS94erG6>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/bS94erG6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/bS94erG6>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 10\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/bS94erG6>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 10\" .\r\n<https://id.parliament.uk/bS94erG6> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"587\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/bS94erG6>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 10\" .\r\n<https://id.parliament.uk/bS94erG6> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/NagVnt8h> .\r\n<https://id.parliament.uk/bS94erG6>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/I4duwcuB>
+        .\r\n<https://id.parliament.uk/NagVnt8h> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/NagVnt8h>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-11+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/NagVnt8h> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/BRTNQywN> .\r\n<https://id.parliament.uk/I4duwcuB>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/I4duwcuB> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/upP2FHa4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/upP2FHa4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/upP2FHa4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/upP2FHa4> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 11\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/upP2FHa4> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 11\" .\r\n<https://id.parliament.uk/upP2FHa4>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"575\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/upP2FHa4> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 11\" .\r\n<https://id.parliament.uk/upP2FHa4>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/cfbEYJ86>
+        .\r\n<https://id.parliament.uk/upP2FHa4> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/KAaIQyCC> .\r\n<https://id.parliament.uk/cfbEYJ86>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/cfbEYJ86> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-10+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/cfbEYJ86>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/5LQ5Ar74>
+        .\r\n<https://id.parliament.uk/5LQ5Ar74> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Group> .\r\n<https://id.parliament.uk/5LQ5Ar74>
+        <https://id.parliament.uk/schema/groupName> \"groupName - 6\" .\r\n<https://id.parliament.uk/KAaIQyCC>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/KAaIQyCC> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/0VJbg1Pa>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/0VJbg1Pa> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/0VJbg1Pa>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/0VJbg1Pa> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 12\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/0VJbg1Pa> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 12\" .\r\n<https://id.parliament.uk/0VJbg1Pa>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"485\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/0VJbg1Pa> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 12\" .\r\n<https://id.parliament.uk/0VJbg1Pa>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/auOf4Epa>
+        .\r\n<https://id.parliament.uk/auOf4Epa> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/auOf4Epa>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/XnLvIexa> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/XnLvIexa>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/XnLvIexa> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/XnLvIexa>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 13\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/XnLvIexa>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 13\" .\r\n<https://id.parliament.uk/XnLvIexa> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"472\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/XnLvIexa>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 13\" .\r\n<https://id.parliament.uk/XnLvIexa> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/f9w5NpTb> .\r\n<https://id.parliament.uk/XnLvIexa>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/WmlTLQiJ>
+        .\r\n<https://id.parliament.uk/f9w5NpTb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/f9w5NpTb>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-13+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/f9w5NpTb> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/7dSvuueH> .\r\n<https://id.parliament.uk/WmlTLQiJ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/WmlTLQiJ> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/GOOyVBR4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/GOOyVBR4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/GOOyVBR4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/GOOyVBR4> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 14\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/GOOyVBR4> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 14\" .\r\n<https://id.parliament.uk/GOOyVBR4>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"831\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/GOOyVBR4> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 14\" .\r\n<https://id.parliament.uk/GOOyVBR4>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/v6kwIWtt>
+        .\r\n<https://id.parliament.uk/GOOyVBR4> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/zJLB2rbN> .\r\n<https://id.parliament.uk/v6kwIWtt>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/v6kwIWtt> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-09+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/v6kwIWtt>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/HYfypSOE>
+        .\r\n<https://id.parliament.uk/HYfypSOE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Group> .\r\n<https://id.parliament.uk/HYfypSOE>
+        <https://id.parliament.uk/schema/groupName> \"groupName - 7\" .\r\n<https://id.parliament.uk/zJLB2rbN>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/zJLB2rbN> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/8I8GntKQ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/8I8GntKQ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/8I8GntKQ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/8I8GntKQ> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 15\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/8I8GntKQ> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 15\" .\r\n<https://id.parliament.uk/8I8GntKQ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"537\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/8I8GntKQ> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 15\" .\r\n<https://id.parliament.uk/8I8GntKQ>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/3dED0LgI>
+        .\r\n<https://id.parliament.uk/8I8GntKQ> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/PwLQp4Rk> .\r\n<https://id.parliament.uk/3dED0LgI>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/3dED0LgI> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-30+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/3dED0LgI>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/7gnSwbLO>
+        .\r\n<https://id.parliament.uk/7gnSwbLO> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Group> .\r\n<https://id.parliament.uk/7gnSwbLO>
+        <https://id.parliament.uk/schema/groupName> \"groupName - 8\" .\r\n<https://id.parliament.uk/PwLQp4Rk>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/PwLQp4Rk> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/Tw34pUb3>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/Tw34pUb3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/Tw34pUb3>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/Tw34pUb3> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 16\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/Tw34pUb3> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 16\" .\r\n<https://id.parliament.uk/Tw34pUb3>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"546\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/Tw34pUb3> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 16\" .\r\n<https://id.parliament.uk/Tw34pUb3>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/QRLFhjUD>
+        .\r\n<https://id.parliament.uk/Tw34pUb3> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/F3ClsH20> .\r\n<https://id.parliament.uk/QRLFhjUD>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/QRLFhjUD> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-01+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/QRLFhjUD>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/HYfypSOE>
+        .\r\n<https://id.parliament.uk/F3ClsH20> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/F3ClsH20>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/rAkViDvo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/rAkViDvo>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/rAkViDvo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/rAkViDvo>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 17\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/rAkViDvo>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 17\" .\r\n<https://id.parliament.uk/rAkViDvo> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"800\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/rAkViDvo>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 17\" .\r\n<https://id.parliament.uk/rAkViDvo> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/AtyGfoYi> .\r\n<https://id.parliament.uk/rAkViDvo>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/c8P8nJgq>
+        .\r\n<https://id.parliament.uk/AtyGfoYi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/AtyGfoYi>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/AtyGfoYi> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/yiuTaSI4> .\r\n<https://id.parliament.uk/c8P8nJgq>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/c8P8nJgq> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/FCcBOrUo>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/FCcBOrUo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/FCcBOrUo>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/FCcBOrUo> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 18\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/FCcBOrUo> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 18\" .\r\n<https://id.parliament.uk/FCcBOrUo>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"510\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/FCcBOrUo> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 18\" .\r\n<https://id.parliament.uk/FCcBOrUo>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/Nhuev5Ry>
+        .\r\n<https://id.parliament.uk/FCcBOrUo> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/Ic57bsvz> .\r\n<https://id.parliament.uk/Nhuev5Ry>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/Nhuev5Ry> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/Nhuev5Ry>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/5LQ5Ar74>
+        .\r\n<https://id.parliament.uk/Ic57bsvz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/Ic57bsvz>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/tjxWFlR2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/tjxWFlR2>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/tjxWFlR2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/tjxWFlR2>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 19\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/tjxWFlR2>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 19\" .\r\n<https://id.parliament.uk/tjxWFlR2> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"541\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/tjxWFlR2>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 19\" .\r\n<https://id.parliament.uk/tjxWFlR2> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/FcPf17jF> .\r\n<https://id.parliament.uk/tjxWFlR2>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/diYZkVb4>
+        .\r\n<https://id.parliament.uk/FcPf17jF> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/FcPf17jF>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-30+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/FcPf17jF> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/BRTNQywN> .\r\n<https://id.parliament.uk/diYZkVb4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/diYZkVb4> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/e1nEbjRI>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/e1nEbjRI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/e1nEbjRI>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/e1nEbjRI> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 20\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/e1nEbjRI> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 20\" .\r\n<https://id.parliament.uk/e1nEbjRI>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"514\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/e1nEbjRI> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 20\" .\r\n<https://id.parliament.uk/e1nEbjRI>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/HkngXyxl>
+        .\r\n<https://id.parliament.uk/e1nEbjRI> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/dFnbME4A> .\r\n<https://id.parliament.uk/HkngXyxl>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/HkngXyxl> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-24+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/HkngXyxl>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/yiuTaSI4>
+        .\r\n<https://id.parliament.uk/dFnbME4A> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/dFnbME4A>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/xic2yu5i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/xic2yu5i>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/xic2yu5i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/xic2yu5i>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 21\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/xic2yu5i>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 21\" .\r\n<https://id.parliament.uk/xic2yu5i> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"488\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/xic2yu5i>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 21\" .\r\n<https://id.parliament.uk/xic2yu5i> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/c240s9cD> .\r\n<https://id.parliament.uk/xic2yu5i>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/EgDK23iB>
+        .\r\n<https://id.parliament.uk/c240s9cD> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/c240s9cD>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-20+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/c240s9cD> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XouN12Ow> .\r\n<https://id.parliament.uk/XouN12Ow>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Group>
+        .\r\n<https://id.parliament.uk/XouN12Ow> <https://id.parliament.uk/schema/groupName>
+        \"groupName - 9\" .\r\n<https://id.parliament.uk/EgDK23iB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/EgDK23iB>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/TKqREWHZ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/TKqREWHZ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/TKqREWHZ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/TKqREWHZ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 22\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/TKqREWHZ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 22\" .\r\n<https://id.parliament.uk/TKqREWHZ> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 22\" .\r\n<https://id.parliament.uk/TKqREWHZ>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/Mw7umRDD>
+        .\r\n<https://id.parliament.uk/TKqREWHZ> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/eCsYdAM3> .\r\n<https://id.parliament.uk/Mw7umRDD>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/Mw7umRDD> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-03+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/Mw7umRDD>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/fKqMNz79>
+        .\r\n<https://id.parliament.uk/eCsYdAM3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/eCsYdAM3>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/ADR23Zyx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/ADR23Zyx>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/ADR23Zyx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/ADR23Zyx>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 23\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/ADR23Zyx>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 23\" .\r\n<https://id.parliament.uk/ADR23Zyx> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"92\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/ADR23Zyx>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 23\" .\r\n<https://id.parliament.uk/ADR23Zyx> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/OSdTYDeS> .\r\n<https://id.parliament.uk/ADR23Zyx>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/EdGVZDEz>
+        .\r\n<https://id.parliament.uk/OSdTYDeS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/OSdTYDeS>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-16+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/OSdTYDeS> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XbTBTDMo> .\r\n<https://id.parliament.uk/XbTBTDMo>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Group>
+        .\r\n<https://id.parliament.uk/XbTBTDMo> <https://id.parliament.uk/schema/groupName>
+        \"groupName - 10\" .\r\n<https://id.parliament.uk/EdGVZDEz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/EdGVZDEz>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/hNQPUtRs> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/hNQPUtRs>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/hNQPUtRs> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/hNQPUtRs>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 24\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/hNQPUtRs>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 24\" .\r\n<https://id.parliament.uk/hNQPUtRs> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"735\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/hNQPUtRs>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 24\" .\r\n<https://id.parliament.uk/hNQPUtRs> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/njlVbk2J> .\r\n<https://id.parliament.uk/hNQPUtRs>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/W7YZ1i4T>
+        .\r\n<https://id.parliament.uk/njlVbk2J> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/njlVbk2J>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-26+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/njlVbk2J> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/ZU3IXBtP> .\r\n<https://id.parliament.uk/ZU3IXBtP>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Group>
+        .\r\n<https://id.parliament.uk/ZU3IXBtP> <https://id.parliament.uk/schema/groupName>
+        \"groupName - 11\" .\r\n<https://id.parliament.uk/W7YZ1i4T> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/W7YZ1i4T>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/YFkBxYkE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/YFkBxYkE>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/YFkBxYkE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/YFkBxYkE>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 25\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/YFkBxYkE>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 25\" .\r\n<https://id.parliament.uk/YFkBxYkE> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"483\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/YFkBxYkE>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 25\" .\r\n<https://id.parliament.uk/YFkBxYkE> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/nrMzeLJ5> .\r\n<https://id.parliament.uk/YFkBxYkE>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/IHy5RkQv>
+        .\r\n<https://id.parliament.uk/nrMzeLJ5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/nrMzeLJ5>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-17+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/nrMzeLJ5> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/HYfypSOE> .\r\n<https://id.parliament.uk/IHy5RkQv>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/IHy5RkQv> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/k6waZgmJ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/k6waZgmJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/k6waZgmJ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/k6waZgmJ> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 26\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/k6waZgmJ> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 26\" .\r\n<https://id.parliament.uk/k6waZgmJ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"493\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/k6waZgmJ> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 26\" .\r\n<https://id.parliament.uk/k6waZgmJ>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/H3U1WIOm>
+        .\r\n<https://id.parliament.uk/k6waZgmJ> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/XDilT5Ce> .\r\n<https://id.parliament.uk/H3U1WIOm>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/H3U1WIOm> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-19+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/H3U1WIOm>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/fKqMNz79>
+        .\r\n<https://id.parliament.uk/XDilT5Ce> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/XDilT5Ce>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/O8GS8jnH> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/O8GS8jnH>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/O8GS8jnH> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/O8GS8jnH>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 27\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/O8GS8jnH>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 27\" .\r\n<https://id.parliament.uk/O8GS8jnH> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"423\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/O8GS8jnH>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 27\" .\r\n<https://id.parliament.uk/O8GS8jnH> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/KgB4r60a> .\r\n<https://id.parliament.uk/O8GS8jnH>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/QN1c7sKE>
+        .\r\n<https://id.parliament.uk/KgB4r60a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/KgB4r60a>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-03+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/KgB4r60a> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XouN12Ow> .\r\n<https://id.parliament.uk/QN1c7sKE>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/QN1c7sKE> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/WSBR9sBz>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/WSBR9sBz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/WSBR9sBz>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/WSBR9sBz> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 28\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/WSBR9sBz> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 28\" .\r\n<https://id.parliament.uk/WSBR9sBz>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 28\" .\r\n<https://id.parliament.uk/WSBR9sBz> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/SildA8v4> .\r\n<https://id.parliament.uk/WSBR9sBz>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/7qN3AkCI>
+        .\r\n<https://id.parliament.uk/SildA8v4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/SildA8v4>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-01+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/SildA8v4> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/eup4DwE5> .\r\n<https://id.parliament.uk/eup4DwE5>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Group>
+        .\r\n<https://id.parliament.uk/eup4DwE5> <https://id.parliament.uk/schema/groupName>
+        \"groupName - 12\" .\r\n<https://id.parliament.uk/7qN3AkCI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/7qN3AkCI>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/gTgidljI>
+        .\r\n<https://id.parliament.uk/gTgidljI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Procedure> .\r\n<https://id.parliament.uk/gTgidljI>
+        <https://id.parliament.uk/schema/procedureName> \"procedureName - 3\" .\r\n<https://id.parliament.uk/QbI1sir4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/QbI1sir4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/QbI1sir4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/QbI1sir4> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 29\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/QbI1sir4> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 29\" .\r\n<https://id.parliament.uk/QbI1sir4>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"832\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/QbI1sir4> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 29\" .\r\n<https://id.parliament.uk/QbI1sir4>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/xCcwgdvQ>
+        .\r\n<https://id.parliament.uk/QbI1sir4> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/bONPJ56c> .\r\n<https://id.parliament.uk/xCcwgdvQ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/xCcwgdvQ> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-30+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/xCcwgdvQ>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/HYfypSOE>
+        .\r\n<https://id.parliament.uk/bONPJ56c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/bONPJ56c>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/VIqyNL58> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/VIqyNL58>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/VIqyNL58> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/VIqyNL58>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 30\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/VIqyNL58>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 30\" .\r\n<https://id.parliament.uk/VIqyNL58> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"674\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/VIqyNL58>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 30\" .\r\n<https://id.parliament.uk/VIqyNL58> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/FvuNhGmO> .\r\n<https://id.parliament.uk/VIqyNL58>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/zlDxL3xS>
+        .\r\n<https://id.parliament.uk/FvuNhGmO> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/FvuNhGmO>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-16+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/FvuNhGmO> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/7dSvuueH> .\r\n<https://id.parliament.uk/zlDxL3xS>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/zlDxL3xS> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/AaXxxzda>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/AaXxxzda> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/AaXxxzda>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/AaXxxzda> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 31\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/AaXxxzda> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 31\" .\r\n<https://id.parliament.uk/AaXxxzda>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"406\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/AaXxxzda> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 31\" .\r\n<https://id.parliament.uk/AaXxxzda>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/Phw9bTAd>
+        .\r\n<https://id.parliament.uk/AaXxxzda> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/KGrfWbku> .\r\n<https://id.parliament.uk/Phw9bTAd>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/Phw9bTAd> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-03+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/Phw9bTAd>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/XouN12Ow>
+        .\r\n<https://id.parliament.uk/KGrfWbku> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/KGrfWbku>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/C2rRbqeQ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/C2rRbqeQ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/C2rRbqeQ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/C2rRbqeQ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 32\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/C2rRbqeQ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 32\" .\r\n<https://id.parliament.uk/C2rRbqeQ> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"482\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/C2rRbqeQ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 32\" .\r\n<https://id.parliament.uk/C2rRbqeQ> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/tSHwlzxI> .\r\n<https://id.parliament.uk/C2rRbqeQ>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/UsdZhECl>
+        .\r\n<https://id.parliament.uk/tSHwlzxI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/tSHwlzxI>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-17+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/tSHwlzxI> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/yiuTaSI4> .\r\n<https://id.parliament.uk/UsdZhECl>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/UsdZhECl> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/5urR0FTa>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/5urR0FTa> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/5urR0FTa>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/5urR0FTa> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 33\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/5urR0FTa> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 33\" .\r\n<https://id.parliament.uk/5urR0FTa>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"489\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/5urR0FTa> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 33\" .\r\n<https://id.parliament.uk/5urR0FTa>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/GydEOlpQ>
+        .\r\n<https://id.parliament.uk/5urR0FTa> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/BBNF0hzl> .\r\n<https://id.parliament.uk/GydEOlpQ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/GydEOlpQ> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-18+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/GydEOlpQ>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/BRTNQywN>
+        .\r\n<https://id.parliament.uk/BBNF0hzl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/BBNF0hzl>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/KZpExrdI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/KZpExrdI>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/KZpExrdI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/KZpExrdI>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 34\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/KZpExrdI>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 34\" .\r\n<https://id.parliament.uk/KZpExrdI> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"527\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/KZpExrdI>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 34\" .\r\n<https://id.parliament.uk/KZpExrdI> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/AvYw0KZ2> .\r\n<https://id.parliament.uk/KZpExrdI>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/K8jg57DX>
+        .\r\n<https://id.parliament.uk/AvYw0KZ2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/AvYw0KZ2>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-26+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/AvYw0KZ2> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/5LQ5Ar74> .\r\n<https://id.parliament.uk/K8jg57DX>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/K8jg57DX> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/daySypEn>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/daySypEn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/daySypEn>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/daySypEn> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 35\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/daySypEn> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 35\" .\r\n<https://id.parliament.uk/daySypEn>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"439\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/daySypEn> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 35\" .\r\n<https://id.parliament.uk/daySypEn>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/pg0TWSqT>
+        .\r\n<https://id.parliament.uk/daySypEn> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/5wUN28za> .\r\n<https://id.parliament.uk/pg0TWSqT>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/pg0TWSqT> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-03+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/pg0TWSqT>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/XouN12Ow>
+        .\r\n<https://id.parliament.uk/5wUN28za> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/5wUN28za>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/i9hQEgyv> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/i9hQEgyv>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/i9hQEgyv> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/i9hQEgyv>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 36\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/i9hQEgyv>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 36\" .\r\n<https://id.parliament.uk/i9hQEgyv> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"634\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/i9hQEgyv>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 36\" .\r\n<https://id.parliament.uk/i9hQEgyv> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/nsrSFKGl> .\r\n<https://id.parliament.uk/i9hQEgyv>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/QXHttLOh>
+        .\r\n<https://id.parliament.uk/nsrSFKGl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/nsrSFKGl>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-16+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/nsrSFKGl> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/yiuTaSI4> .\r\n<https://id.parliament.uk/QXHttLOh>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/QXHttLOh> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/QV9rpep6>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/QV9rpep6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/QV9rpep6>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/QV9rpep6> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 37\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/QV9rpep6> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 37\" .\r\n<https://id.parliament.uk/QV9rpep6>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"530\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/QV9rpep6> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 37\" .\r\n<https://id.parliament.uk/QV9rpep6>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/FrRQLlKT>
+        .\r\n<https://id.parliament.uk/QV9rpep6> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/i5LP8krv> .\r\n<https://id.parliament.uk/FrRQLlKT>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/FrRQLlKT> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-27+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/FrRQLlKT>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/NDZSYjeE>
+        .\r\n<https://id.parliament.uk/NDZSYjeE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Group> .\r\n<https://id.parliament.uk/NDZSYjeE>
+        <https://id.parliament.uk/schema/groupName> \"groupName - 13\" .\r\n<https://id.parliament.uk/i5LP8krv>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/i5LP8krv> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/1fStCnaK>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/1fStCnaK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/1fStCnaK>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/1fStCnaK> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 38\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/1fStCnaK> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 38\" .\r\n<https://id.parliament.uk/1fStCnaK>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"633\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/1fStCnaK> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 38\" .\r\n<https://id.parliament.uk/1fStCnaK>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/gnxq0RIe>
+        .\r\n<https://id.parliament.uk/1fStCnaK> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/ku4HUUqp> .\r\n<https://id.parliament.uk/gnxq0RIe>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/gnxq0RIe> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-16+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/gnxq0RIe>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/HYfypSOE>
+        .\r\n<https://id.parliament.uk/ku4HUUqp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/ku4HUUqp>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/PqyD6lfd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/PqyD6lfd>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/PqyD6lfd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/PqyD6lfd>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 39\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/PqyD6lfd>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 39\" .\r\n<https://id.parliament.uk/PqyD6lfd> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"479\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/PqyD6lfd>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 39\" .\r\n<https://id.parliament.uk/PqyD6lfd> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/EbKNmOQl> .\r\n<https://id.parliament.uk/PqyD6lfd>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/uBG5MdZZ>
+        .\r\n<https://id.parliament.uk/EbKNmOQl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/EbKNmOQl>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-16+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/EbKNmOQl> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/BRTNQywN> .\r\n<https://id.parliament.uk/uBG5MdZZ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/uBG5MdZZ> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/FXiTnP7V>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/FXiTnP7V> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/FXiTnP7V>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/FXiTnP7V> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 40\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/FXiTnP7V> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 40\" .\r\n<https://id.parliament.uk/FXiTnP7V>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"511\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/FXiTnP7V> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 40\" .\r\n<https://id.parliament.uk/FXiTnP7V>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/B1ZazNey>
+        .\r\n<https://id.parliament.uk/FXiTnP7V> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/JsU0fHFW> .\r\n<https://id.parliament.uk/B1ZazNey>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/B1ZazNey> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/B1ZazNey>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/79sn5e3n>
+        .\r\n<https://id.parliament.uk/JsU0fHFW> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/JsU0fHFW>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/Y70OJpm2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/Y70OJpm2>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/Y70OJpm2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/Y70OJpm2>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 41\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/Y70OJpm2>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 41\" .\r\n<https://id.parliament.uk/Y70OJpm2> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 41\" .\r\n<https://id.parliament.uk/Y70OJpm2>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/qqCvPYtF>
+        .\r\n<https://id.parliament.uk/Y70OJpm2> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/0zyGzme2> .\r\n<https://id.parliament.uk/qqCvPYtF>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/qqCvPYtF> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-01+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/qqCvPYtF>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/eup4DwE5>
+        .\r\n<https://id.parliament.uk/0zyGzme2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/0zyGzme2>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/gTgidljI>
+        .\r\n<https://id.parliament.uk/LxPDdl92> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/LxPDdl92>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/LxPDdl92> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/LxPDdl92>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 42\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/LxPDdl92>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 42\" .\r\n<https://id.parliament.uk/LxPDdl92> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"506\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/LxPDdl92>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 42\" .\r\n<https://id.parliament.uk/LxPDdl92> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/HAkdtnsW> .\r\n<https://id.parliament.uk/LxPDdl92>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/JJ45Soew>
+        .\r\n<https://id.parliament.uk/HAkdtnsW> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/HAkdtnsW>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-20+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/HAkdtnsW> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/ZU3IXBtP> .\r\n<https://id.parliament.uk/JJ45Soew>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/JJ45Soew> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/HJ7BlYte>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/HJ7BlYte> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/HJ7BlYte>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/HJ7BlYte> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 43\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/HJ7BlYte> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 43\" .\r\n<https://id.parliament.uk/HJ7BlYte>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"560\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/HJ7BlYte> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 43\" .\r\n<https://id.parliament.uk/HJ7BlYte>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/p064wsz5>
+        .\r\n<https://id.parliament.uk/HJ7BlYte> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/E5XlAFS8> .\r\n<https://id.parliament.uk/p064wsz5>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/p064wsz5> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-08+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/p064wsz5>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/NDZSYjeE>
+        .\r\n<https://id.parliament.uk/E5XlAFS8> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/E5XlAFS8>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/Ly5VtVqc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/Ly5VtVqc>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/Ly5VtVqc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/Ly5VtVqc>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 44\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/Ly5VtVqc>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 44\" .\r\n<https://id.parliament.uk/Ly5VtVqc> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"465\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/Ly5VtVqc>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 44\" .\r\n<https://id.parliament.uk/Ly5VtVqc> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/AqPd0Iyl> .\r\n<https://id.parliament.uk/Ly5VtVqc>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/y5Pki10i>
+        .\r\n<https://id.parliament.uk/AqPd0Iyl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/AqPd0Iyl>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/AqPd0Iyl> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/7dSvuueH> .\r\n<https://id.parliament.uk/y5Pki10i>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/y5Pki10i> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/T3N7uNwm>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/T3N7uNwm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/T3N7uNwm>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/T3N7uNwm> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 45\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/T3N7uNwm> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 45\" .\r\n<https://id.parliament.uk/T3N7uNwm>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"539\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/T3N7uNwm> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 45\" .\r\n<https://id.parliament.uk/T3N7uNwm>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/fVAUVm37>
+        .\r\n<https://id.parliament.uk/T3N7uNwm> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/cfS0QBck> .\r\n<https://id.parliament.uk/fVAUVm37>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/fVAUVm37> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-30+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/fVAUVm37>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/HYfypSOE>
+        .\r\n<https://id.parliament.uk/cfS0QBck> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/cfS0QBck>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/5trFJNih> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/5trFJNih>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/5trFJNih> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/5trFJNih>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 46\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/5trFJNih>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 46\" .\r\n<https://id.parliament.uk/5trFJNih> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"509\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/5trFJNih>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 46\" .\r\n<https://id.parliament.uk/5trFJNih> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/PSi2j23h> .\r\n<https://id.parliament.uk/5trFJNih>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/rlJaCEwJ>
+        .\r\n<https://id.parliament.uk/PSi2j23h> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/PSi2j23h>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/PSi2j23h> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/BRTNQywN> .\r\n<https://id.parliament.uk/rlJaCEwJ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/rlJaCEwJ> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/z0dWm7t5>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/z0dWm7t5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/z0dWm7t5>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/z0dWm7t5> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 47\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/z0dWm7t5> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 47\" .\r\n<https://id.parliament.uk/z0dWm7t5>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"490\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/z0dWm7t5> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 47\" .\r\n<https://id.parliament.uk/z0dWm7t5>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/BPlGOTOt>
+        .\r\n<https://id.parliament.uk/z0dWm7t5> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/vJoUN8Af> .\r\n<https://id.parliament.uk/BPlGOTOt>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/BPlGOTOt> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-18+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/BPlGOTOt>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/HYfypSOE>
+        .\r\n<https://id.parliament.uk/vJoUN8Af> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/vJoUN8Af>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/98FJSLox> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/98FJSLox>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/98FJSLox> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/98FJSLox>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 48\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/98FJSLox>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 48\" .\r\n<https://id.parliament.uk/98FJSLox> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 48\" .\r\n<https://id.parliament.uk/98FJSLox>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/iikpYh7G>
+        .\r\n<https://id.parliament.uk/98FJSLox> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/Gcba35Qd> .\r\n<https://id.parliament.uk/iikpYh7G>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/iikpYh7G> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-08+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/iikpYh7G>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/XbTBTDMo>
+        .\r\n<https://id.parliament.uk/Gcba35Qd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/Gcba35Qd>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/3dAYwLoB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/3dAYwLoB>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/3dAYwLoB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/3dAYwLoB>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 49\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/3dAYwLoB>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 49\" .\r\n<https://id.parliament.uk/3dAYwLoB> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"451\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/3dAYwLoB>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 49\" .\r\n<https://id.parliament.uk/3dAYwLoB> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/ZQsu6c18> .\r\n<https://id.parliament.uk/3dAYwLoB>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/DRTwwjtS>
+        .\r\n<https://id.parliament.uk/ZQsu6c18> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/ZQsu6c18>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-03+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/ZQsu6c18> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/NDZSYjeE> .\r\n<https://id.parliament.uk/DRTwwjtS>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/DRTwwjtS> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/eD6E73Ne>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/eD6E73Ne> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/eD6E73Ne>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/eD6E73Ne> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 50\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/eD6E73Ne> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 50\" .\r\n<https://id.parliament.uk/eD6E73Ne>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"540\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/eD6E73Ne> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 50\" .\r\n<https://id.parliament.uk/eD6E73Ne>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/VHI2llf1>
+        .\r\n<https://id.parliament.uk/eD6E73Ne> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/9Zgnj98t> .\r\n<https://id.parliament.uk/VHI2llf1>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/VHI2llf1> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-30+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/VHI2llf1>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/BRTNQywN>
+        .\r\n<https://id.parliament.uk/9Zgnj98t> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/9Zgnj98t>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/TuBqZl6z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/TuBqZl6z>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/TuBqZl6z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/TuBqZl6z>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 51\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/TuBqZl6z>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 51\" .\r\n<https://id.parliament.uk/TuBqZl6z> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"798\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/TuBqZl6z>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 51\" .\r\n<https://id.parliament.uk/TuBqZl6z> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/40fYpO9c> .\r\n<https://id.parliament.uk/TuBqZl6z>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/k5jw9Nhv>
+        .\r\n<https://id.parliament.uk/40fYpO9c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/40fYpO9c>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-24+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/40fYpO9c> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/yiuTaSI4> .\r\n<https://id.parliament.uk/k5jw9Nhv>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/k5jw9Nhv> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/5U4yBcY4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/5U4yBcY4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/5U4yBcY4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/5U4yBcY4> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 52\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/5U4yBcY4> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 52\" .\r\n<https://id.parliament.uk/5U4yBcY4>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"121\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/5U4yBcY4> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 52\" .\r\n<https://id.parliament.uk/5U4yBcY4>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/sPjZPCb0>
+        .\r\n<https://id.parliament.uk/5U4yBcY4> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/0ifq7ERi> .\r\n<https://id.parliament.uk/sPjZPCb0>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/sPjZPCb0> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-17+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/sPjZPCb0>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/XbTBTDMo>
+        .\r\n<https://id.parliament.uk/0ifq7ERi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/0ifq7ERi>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/dNxWbKuU> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/dNxWbKuU>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/dNxWbKuU> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/dNxWbKuU>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 53\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/dNxWbKuU>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 53\" .\r\n<https://id.parliament.uk/dNxWbKuU> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"607\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/dNxWbKuU>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 53\" .\r\n<https://id.parliament.uk/dNxWbKuU> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/E5mpMWcg> .\r\n<https://id.parliament.uk/dNxWbKuU>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/yuPpm1jw>
+        .\r\n<https://id.parliament.uk/E5mpMWcg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/E5mpMWcg>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/E5mpMWcg> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/7dSvuueH> .\r\n<https://id.parliament.uk/yuPpm1jw>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/yuPpm1jw> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/rjzMGG28>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/rjzMGG28> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/rjzMGG28>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/rjzMGG28> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 54\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/rjzMGG28> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 54\" .\r\n<https://id.parliament.uk/rjzMGG28>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"829\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/rjzMGG28> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 54\" .\r\n<https://id.parliament.uk/rjzMGG28>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/rWaK4CZm>
+        .\r\n<https://id.parliament.uk/rjzMGG28> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/wMkdwlCh> .\r\n<https://id.parliament.uk/rWaK4CZm>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/rWaK4CZm> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-21+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/rWaK4CZm>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/NDZSYjeE>
+        .\r\n<https://id.parliament.uk/wMkdwlCh> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/wMkdwlCh>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/9PfnbabC> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/9PfnbabC>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/9PfnbabC> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/9PfnbabC>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 55\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/9PfnbabC>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 55\" .\r\n<https://id.parliament.uk/9PfnbabC> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"592\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/9PfnbabC>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 55\" .\r\n<https://id.parliament.uk/9PfnbabC> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/4ckl6Ecn> .\r\n<https://id.parliament.uk/9PfnbabC>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/Ix8dPawU>
+        .\r\n<https://id.parliament.uk/4ckl6Ecn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/4ckl6Ecn>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-16+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/4ckl6Ecn> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XouN12Ow> .\r\n<https://id.parliament.uk/Ix8dPawU>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/Ix8dPawU> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/uNiGNHey>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/uNiGNHey> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/uNiGNHey>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/uNiGNHey> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 56\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/uNiGNHey> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 56\" .\r\n<https://id.parliament.uk/uNiGNHey>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"618\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/uNiGNHey> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 56\" .\r\n<https://id.parliament.uk/uNiGNHey>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/8nTtARxa>
+        .\r\n<https://id.parliament.uk/uNiGNHey> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/A3hB6Aj4> .\r\n<https://id.parliament.uk/8nTtARxa>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/8nTtARxa> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-24+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/8nTtARxa>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/NDZSYjeE>
+        .\r\n<https://id.parliament.uk/A3hB6Aj4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/A3hB6Aj4>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/LFLdzMuO> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/LFLdzMuO>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/LFLdzMuO> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/LFLdzMuO>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 57\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/LFLdzMuO>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 57\" .\r\n<https://id.parliament.uk/LFLdzMuO> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"593\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/LFLdzMuO>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 57\" .\r\n<https://id.parliament.uk/LFLdzMuO> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/2i869NR9> .\r\n<https://id.parliament.uk/LFLdzMuO>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/lq49zoKs>
+        .\r\n<https://id.parliament.uk/2i869NR9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/2i869NR9>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-14+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/2i869NR9> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/yiuTaSI4> .\r\n<https://id.parliament.uk/lq49zoKs>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/lq49zoKs> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/lh2dYuHD>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/lh2dYuHD> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/lh2dYuHD>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/lh2dYuHD> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 58\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/lh2dYuHD> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 58\" .\r\n<https://id.parliament.uk/lh2dYuHD>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"599\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/lh2dYuHD> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 58\" .\r\n<https://id.parliament.uk/lh2dYuHD>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/F6QnrHlj>
+        .\r\n<https://id.parliament.uk/lh2dYuHD> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/jvQpwIVt> .\r\n<https://id.parliament.uk/F6QnrHlj>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/F6QnrHlj> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-21+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/F6QnrHlj>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/7dSvuueH>
+        .\r\n<https://id.parliament.uk/jvQpwIVt> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/jvQpwIVt>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/8HUWJm9e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/8HUWJm9e>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/8HUWJm9e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/8HUWJm9e>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 59\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/8HUWJm9e>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 59\" .\r\n<https://id.parliament.uk/8HUWJm9e> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"598\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/8HUWJm9e>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 59\" .\r\n<https://id.parliament.uk/8HUWJm9e> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/S0ebryc4> .\r\n<https://id.parliament.uk/8HUWJm9e>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/0A9lArUa>
+        .\r\n<https://id.parliament.uk/S0ebryc4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/S0ebryc4>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-18+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/S0ebryc4> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/NDZSYjeE> .\r\n<https://id.parliament.uk/0A9lArUa>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/0A9lArUa> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/BdanAxAh>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/BdanAxAh> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/BdanAxAh>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/BdanAxAh> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 60\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/BdanAxAh> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 60\" .\r\n<https://id.parliament.uk/BdanAxAh>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"635\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/BdanAxAh> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 60\" .\r\n<https://id.parliament.uk/BdanAxAh>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/5fbXtiCF>
+        .\r\n<https://id.parliament.uk/BdanAxAh> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/TvrrHZTL> .\r\n<https://id.parliament.uk/5fbXtiCF>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/5fbXtiCF> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-29+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/5fbXtiCF>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/yiuTaSI4>
+        .\r\n<https://id.parliament.uk/TvrrHZTL> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/TvrrHZTL>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/bUEOr4ad> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/bUEOr4ad>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/bUEOr4ad> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/bUEOr4ad>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 61\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/bUEOr4ad>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 61\" .\r\n<https://id.parliament.uk/bUEOr4ad> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"597\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/bUEOr4ad>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 61\" .\r\n<https://id.parliament.uk/bUEOr4ad> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/WX7uzApY> .\r\n<https://id.parliament.uk/bUEOr4ad>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/Xd5yfp3V>
+        .\r\n<https://id.parliament.uk/WX7uzApY> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/WX7uzApY>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-18+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/WX7uzApY> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/yiuTaSI4> .\r\n<https://id.parliament.uk/Xd5yfp3V>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/Xd5yfp3V> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/Q2dC6z5O>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/Q2dC6z5O> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/Q2dC6z5O>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/Q2dC6z5O> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 62\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/Q2dC6z5O> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 62\" .\r\n<https://id.parliament.uk/Q2dC6z5O>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"591\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/Q2dC6z5O> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 62\" .\r\n<https://id.parliament.uk/Q2dC6z5O>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/5QMvNHCV>
+        .\r\n<https://id.parliament.uk/Q2dC6z5O> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/26Y9ftes> .\r\n<https://id.parliament.uk/5QMvNHCV>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/5QMvNHCV> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-14+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/5QMvNHCV>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/5LQ5Ar74>
+        .\r\n<https://id.parliament.uk/26Y9ftes> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/26Y9ftes>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/RcGToJSJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/RcGToJSJ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/RcGToJSJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/RcGToJSJ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 63\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/RcGToJSJ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 63\" .\r\n<https://id.parliament.uk/RcGToJSJ> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"629\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/RcGToJSJ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 63\" .\r\n<https://id.parliament.uk/RcGToJSJ> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/4DXV4KGc> .\r\n<https://id.parliament.uk/RcGToJSJ>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/cWSEaAzA>
+        .\r\n<https://id.parliament.uk/4DXV4KGc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/4DXV4KGc>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-24+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/4DXV4KGc> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/ZU3IXBtP> .\r\n<https://id.parliament.uk/cWSEaAzA>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/cWSEaAzA> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/YOVMhcqy>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/YOVMhcqy> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/YOVMhcqy>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/YOVMhcqy> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 64\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/YOVMhcqy> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 64\" .\r\n<https://id.parliament.uk/YOVMhcqy>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"647\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/YOVMhcqy> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 64\" .\r\n<https://id.parliament.uk/YOVMhcqy>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/uJMNrUDs>
+        .\r\n<https://id.parliament.uk/YOVMhcqy> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/K83vusrm> .\r\n<https://id.parliament.uk/uJMNrUDs>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/uJMNrUDs> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-30+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/uJMNrUDs>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/kv2Qqfn9>
+        .\r\n<https://id.parliament.uk/kv2Qqfn9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Group> .\r\n<https://id.parliament.uk/kv2Qqfn9>
+        <https://id.parliament.uk/schema/groupName> \"groupName - 14\" .\r\n<https://id.parliament.uk/K83vusrm>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/K83vusrm> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/5pJMwiMT>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/5pJMwiMT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/5pJMwiMT>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/5pJMwiMT> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 65\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/5pJMwiMT> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 65\" .\r\n<https://id.parliament.uk/5pJMwiMT>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"643\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/5pJMwiMT> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 65\" .\r\n<https://id.parliament.uk/5pJMwiMT>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/zTdUgdFx>
+        .\r\n<https://id.parliament.uk/5pJMwiMT> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/t070fIUe> .\r\n<https://id.parliament.uk/zTdUgdFx>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/zTdUgdFx> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-25+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/zTdUgdFx>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/5LQ5Ar74>
+        .\r\n<https://id.parliament.uk/t070fIUe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/t070fIUe>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/ZIUjUqOY> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/ZIUjUqOY>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/ZIUjUqOY> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/ZIUjUqOY>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 66\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/ZIUjUqOY>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 66\" .\r\n<https://id.parliament.uk/ZIUjUqOY> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"912\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/ZIUjUqOY>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 66\" .\r\n<https://id.parliament.uk/ZIUjUqOY> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/vgTfN5KX> .\r\n<https://id.parliament.uk/ZIUjUqOY>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/imgmtCq9>
+        .\r\n<https://id.parliament.uk/vgTfN5KX> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/vgTfN5KX>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-17+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/vgTfN5KX> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/7gnSwbLO> .\r\n<https://id.parliament.uk/imgmtCq9>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/imgmtCq9> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/ijAPvpBd>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/ijAPvpBd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/ijAPvpBd>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/ijAPvpBd> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 67\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/ijAPvpBd> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 67\" .\r\n<https://id.parliament.uk/ijAPvpBd>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"888\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/ijAPvpBd> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 67\" .\r\n<https://id.parliament.uk/ijAPvpBd>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/26Qu3wQF>
+        .\r\n<https://id.parliament.uk/ijAPvpBd> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/2hbUBGLm> .\r\n<https://id.parliament.uk/26Qu3wQF>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/26Qu3wQF> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-21+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/26Qu3wQF>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/7gnSwbLO>
+        .\r\n<https://id.parliament.uk/2hbUBGLm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/2hbUBGLm>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/4EdTvost> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/4EdTvost>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/4EdTvost> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/4EdTvost>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 68\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/4EdTvost>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 68\" .\r\n<https://id.parliament.uk/4EdTvost> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"664\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/4EdTvost>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 68\" .\r\n<https://id.parliament.uk/4EdTvost> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/lmZu2cSE> .\r\n<https://id.parliament.uk/4EdTvost>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/Th3KBYE1>
+        .\r\n<https://id.parliament.uk/lmZu2cSE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/lmZu2cSE>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-01+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/lmZu2cSE> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/5LQ5Ar74> .\r\n<https://id.parliament.uk/Th3KBYE1>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/Th3KBYE1> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/v2fDLDBe>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/v2fDLDBe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/v2fDLDBe>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/v2fDLDBe> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 69\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/v2fDLDBe> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 69\" .\r\n<https://id.parliament.uk/v2fDLDBe>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"879\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/v2fDLDBe> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 69\" .\r\n<https://id.parliament.uk/v2fDLDBe>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/dFKcNjk8>
+        .\r\n<https://id.parliament.uk/v2fDLDBe> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/F1z92xaj> .\r\n<https://id.parliament.uk/dFKcNjk8>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/dFKcNjk8> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/dFKcNjk8>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/fKqMNz79>
+        .\r\n<https://id.parliament.uk/F1z92xaj> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/F1z92xaj>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/yvJQZWRS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/yvJQZWRS>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/yvJQZWRS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/yvJQZWRS>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 70\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/yvJQZWRS>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 70\" .\r\n<https://id.parliament.uk/yvJQZWRS> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"658\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/yvJQZWRS>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 70\" .\r\n<https://id.parliament.uk/yvJQZWRS> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/g48hkvPn> .\r\n<https://id.parliament.uk/yvJQZWRS>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/Y6Fg96Qc>
+        .\r\n<https://id.parliament.uk/g48hkvPn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/g48hkvPn>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-01+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/g48hkvPn> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/nFL8Pq3e> .\r\n<https://id.parliament.uk/nFL8Pq3e>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Group>
+        .\r\n<https://id.parliament.uk/nFL8Pq3e> <https://id.parliament.uk/schema/groupName>
+        \"groupName - 15\" .\r\n<https://id.parliament.uk/Y6Fg96Qc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/Y6Fg96Qc>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/NRSdVnQe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/NRSdVnQe>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/NRSdVnQe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/NRSdVnQe>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 71\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/NRSdVnQe>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 71\" .\r\n<https://id.parliament.uk/NRSdVnQe> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"655\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/NRSdVnQe>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 71\" .\r\n<https://id.parliament.uk/NRSdVnQe> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/HEwFBLoc> .\r\n<https://id.parliament.uk/NRSdVnQe>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/rB4zy7ZP>
+        .\r\n<https://id.parliament.uk/HEwFBLoc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/HEwFBLoc>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/HEwFBLoc> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/7dSvuueH> .\r\n<https://id.parliament.uk/rB4zy7ZP>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/rB4zy7ZP> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/eqmSAYR6>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/eqmSAYR6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/eqmSAYR6>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/eqmSAYR6> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 72\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/eqmSAYR6> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 72\" .\r\n<https://id.parliament.uk/eqmSAYR6>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"665\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/eqmSAYR6> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 72\" .\r\n<https://id.parliament.uk/eqmSAYR6>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/waT2amjz>
+        .\r\n<https://id.parliament.uk/eqmSAYR6> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/HNyM3I1B> .\r\n<https://id.parliament.uk/waT2amjz>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/waT2amjz> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-01+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/waT2amjz>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/BRTNQywN>
+        .\r\n<https://id.parliament.uk/HNyM3I1B> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/HNyM3I1B>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/58xXcnw9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/58xXcnw9>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/58xXcnw9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/58xXcnw9>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 73\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/58xXcnw9>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 73\" .\r\n<https://id.parliament.uk/58xXcnw9> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"654\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/58xXcnw9>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 73\" .\r\n<https://id.parliament.uk/58xXcnw9> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/6rdQLNSS> .\r\n<https://id.parliament.uk/58xXcnw9>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/4NTQX1GP>
+        .\r\n<https://id.parliament.uk/6rdQLNSS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/6rdQLNSS>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-01+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/6rdQLNSS> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/7dSvuueH> .\r\n<https://id.parliament.uk/4NTQX1GP>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/4NTQX1GP> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/ez3sdNNT>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/ez3sdNNT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/ez3sdNNT>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/ez3sdNNT> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 74\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/ez3sdNNT> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 74\" .\r\n<https://id.parliament.uk/ez3sdNNT>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"657\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/ez3sdNNT> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 74\" .\r\n<https://id.parliament.uk/ez3sdNNT>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/Je3lAVxM>
+        .\r\n<https://id.parliament.uk/ez3sdNNT> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/ufLIT2Or> .\r\n<https://id.parliament.uk/Je3lAVxM>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/Je3lAVxM> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/Je3lAVxM>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/NDZSYjeE>
+        .\r\n<https://id.parliament.uk/ufLIT2Or> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/ufLIT2Or>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/181ZoViL> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/181ZoViL>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/181ZoViL> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/181ZoViL>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 75\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/181ZoViL>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 75\" .\r\n<https://id.parliament.uk/181ZoViL> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"878\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/181ZoViL>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 75\" .\r\n<https://id.parliament.uk/181ZoViL> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/LKbEOamb> .\r\n<https://id.parliament.uk/181ZoViL>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/EMd5zhNn>
+        .\r\n<https://id.parliament.uk/LKbEOamb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/LKbEOamb>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/LKbEOamb> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fKqMNz79> .\r\n<https://id.parliament.uk/EMd5zhNn>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/EMd5zhNn> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/z0qrw2Ka>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/z0qrw2Ka> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/z0qrw2Ka>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/z0qrw2Ka> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 76\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/z0qrw2Ka> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 76\" .\r\n<https://id.parliament.uk/z0qrw2Ka>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"877\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/z0qrw2Ka> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 76\" .\r\n<https://id.parliament.uk/z0qrw2Ka>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/PvgJFfzu>
+        .\r\n<https://id.parliament.uk/z0qrw2Ka> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/bAycZdhj> .\r\n<https://id.parliament.uk/PvgJFfzu>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/PvgJFfzu> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/PvgJFfzu>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/fKqMNz79>
+        .\r\n<https://id.parliament.uk/bAycZdhj> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/bAycZdhj>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/KUKpCZa3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/KUKpCZa3>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/KUKpCZa3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/KUKpCZa3>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 77\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/KUKpCZa3>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 77\" .\r\n<https://id.parliament.uk/KUKpCZa3> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"893\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/KUKpCZa3>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 77\" .\r\n<https://id.parliament.uk/KUKpCZa3> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/DaC29Iwv> .\r\n<https://id.parliament.uk/KUKpCZa3>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/zTTK3xwl>
+        .\r\n<https://id.parliament.uk/DaC29Iwv> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/DaC29Iwv>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/DaC29Iwv> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/7dSvuueH> .\r\n<https://id.parliament.uk/zTTK3xwl>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/zTTK3xwl> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/oPe8W6LR>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/oPe8W6LR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/oPe8W6LR>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/oPe8W6LR> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 78\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/oPe8W6LR> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 78\" .\r\n<https://id.parliament.uk/oPe8W6LR>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"896\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/oPe8W6LR> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 78\" .\r\n<https://id.parliament.uk/oPe8W6LR>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/bcwSXGsX>
+        .\r\n<https://id.parliament.uk/oPe8W6LR> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/LZZDP3oe> .\r\n<https://id.parliament.uk/bcwSXGsX>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/bcwSXGsX> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/bcwSXGsX>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/yiuTaSI4>
+        .\r\n<https://id.parliament.uk/LZZDP3oe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/LZZDP3oe>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/pw7G14pf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/pw7G14pf>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/pw7G14pf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/pw7G14pf>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 79\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/pw7G14pf>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 79\" .\r\n<https://id.parliament.uk/pw7G14pf> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"917\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/pw7G14pf>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 79\" .\r\n<https://id.parliament.uk/pw7G14pf> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/MPd5Ld9M> .\r\n<https://id.parliament.uk/pw7G14pf>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/sCsUv9LP>
+        .\r\n<https://id.parliament.uk/MPd5Ld9M> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/MPd5Ld9M>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/MPd5Ld9M> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/DkHdH4kZ> .\r\n<https://id.parliament.uk/DkHdH4kZ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Group>
+        .\r\n<https://id.parliament.uk/DkHdH4kZ> <https://id.parliament.uk/schema/groupName>
+        \"groupName - 16\" .\r\n<https://id.parliament.uk/sCsUv9LP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/sCsUv9LP>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/9WjR8ian> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/9WjR8ian>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/9WjR8ian> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/9WjR8ian>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 80\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/9WjR8ian>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 80\" .\r\n<https://id.parliament.uk/9WjR8ian> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"891\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/9WjR8ian>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 80\" .\r\n<https://id.parliament.uk/9WjR8ian> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/GmuvWRZO> .\r\n<https://id.parliament.uk/9WjR8ian>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/LtEJxMbn>
+        .\r\n<https://id.parliament.uk/GmuvWRZO> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/GmuvWRZO>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/GmuvWRZO> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fKqMNz79> .\r\n<https://id.parliament.uk/LtEJxMbn>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/LtEJxMbn> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/ZZqT1pd0>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/ZZqT1pd0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/ZZqT1pd0>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/ZZqT1pd0> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 81\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/ZZqT1pd0> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 81\" .\r\n<https://id.parliament.uk/ZZqT1pd0>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"663\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/ZZqT1pd0> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 81\" .\r\n<https://id.parliament.uk/ZZqT1pd0>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/XInX9awv>
+        .\r\n<https://id.parliament.uk/ZZqT1pd0> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/YO89Z75K> .\r\n<https://id.parliament.uk/XInX9awv>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/XInX9awv> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-01+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/XInX9awv>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/5LQ5Ar74>
+        .\r\n<https://id.parliament.uk/YO89Z75K> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/YO89Z75K>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/cmbxjWzh> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/cmbxjWzh>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/cmbxjWzh> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/cmbxjWzh>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 82\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/cmbxjWzh>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 82\" .\r\n<https://id.parliament.uk/cmbxjWzh> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"666\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/cmbxjWzh>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 82\" .\r\n<https://id.parliament.uk/cmbxjWzh> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/25iK4k3e> .\r\n<https://id.parliament.uk/cmbxjWzh>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/sVns1L8Y>
+        .\r\n<https://id.parliament.uk/25iK4k3e> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/25iK4k3e>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-01+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/25iK4k3e> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/5LQ5Ar74> .\r\n<https://id.parliament.uk/sVns1L8Y>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/sVns1L8Y> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/hs0US9Hw>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/hs0US9Hw> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/hs0US9Hw>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/hs0US9Hw> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 83\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/hs0US9Hw> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 83\" .\r\n<https://id.parliament.uk/hs0US9Hw>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"895\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/hs0US9Hw> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 83\" .\r\n<https://id.parliament.uk/hs0US9Hw>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/t07Oxwwk>
+        .\r\n<https://id.parliament.uk/hs0US9Hw> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/VKMmNyZw> .\r\n<https://id.parliament.uk/t07Oxwwk>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/t07Oxwwk> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-06+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/t07Oxwwk>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/yiuTaSI4>
+        .\r\n<https://id.parliament.uk/VKMmNyZw> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/VKMmNyZw>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/b9hRtbhC> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/b9hRtbhC>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/b9hRtbhC> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/b9hRtbhC>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 84\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/b9hRtbhC>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 84\" .\r\n<https://id.parliament.uk/b9hRtbhC> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"857\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/b9hRtbhC>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 84\" .\r\n<https://id.parliament.uk/b9hRtbhC> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/K6kip00x> .\r\n<https://id.parliament.uk/b9hRtbhC>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/qOj7JAd8>
+        .\r\n<https://id.parliament.uk/K6kip00x> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/K6kip00x>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-05+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/K6kip00x> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/eup4DwE5> .\r\n<https://id.parliament.uk/qOj7JAd8>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/qOj7JAd8> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/gTgidljI> .\r\n<https://id.parliament.uk/YZnLn72f>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/YZnLn72f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/YZnLn72f>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/YZnLn72f> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 85\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/YZnLn72f> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 85\" .\r\n<https://id.parliament.uk/YZnLn72f>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"855\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/YZnLn72f> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 85\" .\r\n<https://id.parliament.uk/YZnLn72f>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/brnEXxQN>
+        .\r\n<https://id.parliament.uk/YZnLn72f> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/lV20Bjux> .\r\n<https://id.parliament.uk/brnEXxQN>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/brnEXxQN> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-05+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/brnEXxQN>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/eup4DwE5>
+        .\r\n<https://id.parliament.uk/lV20Bjux> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/lV20Bjux>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/gTgidljI>
+        .\r\n<https://id.parliament.uk/olhuTQTg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/olhuTQTg>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/olhuTQTg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/olhuTQTg>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 86\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/olhuTQTg>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 86\" .\r\n<https://id.parliament.uk/olhuTQTg> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"853\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/olhuTQTg>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 86\" .\r\n<https://id.parliament.uk/olhuTQTg> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/s8eduPJU> .\r\n<https://id.parliament.uk/olhuTQTg>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/1UXwbopq>
+        .\r\n<https://id.parliament.uk/s8eduPJU> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/s8eduPJU>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-05+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/s8eduPJU> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/eup4DwE5> .\r\n<https://id.parliament.uk/1UXwbopq>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/1UXwbopq> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/gTgidljI> .\r\n<https://id.parliament.uk/w3m931qg>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/w3m931qg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/w3m931qg>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/w3m931qg> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 87\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/w3m931qg> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 87\" .\r\n<https://id.parliament.uk/w3m931qg>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"682\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/w3m931qg> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 87\" .\r\n<https://id.parliament.uk/w3m931qg>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/TZR852WV>
+        .\r\n<https://id.parliament.uk/w3m931qg> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/WKnAjjLi> .\r\n<https://id.parliament.uk/TZR852WV>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/TZR852WV> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-06+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/TZR852WV>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/NDZSYjeE>
+        .\r\n<https://id.parliament.uk/WKnAjjLi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/WKnAjjLi>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/CHZfxISd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/CHZfxISd>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/CHZfxISd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/CHZfxISd>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 88\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/CHZfxISd>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 88\" .\r\n<https://id.parliament.uk/CHZfxISd> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"854\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/CHZfxISd>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 88\" .\r\n<https://id.parliament.uk/CHZfxISd> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/KzKXutmB> .\r\n<https://id.parliament.uk/CHZfxISd>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/V8H9QZ1p>
+        .\r\n<https://id.parliament.uk/KzKXutmB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/KzKXutmB>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-05+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/KzKXutmB> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/eup4DwE5> .\r\n<https://id.parliament.uk/V8H9QZ1p>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/V8H9QZ1p> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/gTgidljI> .\r\n<https://id.parliament.uk/T7oi7f0E>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/T7oi7f0E> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/T7oi7f0E>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/T7oi7f0E> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 89\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/T7oi7f0E> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 89\" .\r\n<https://id.parliament.uk/T7oi7f0E>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"856\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/T7oi7f0E> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 89\" .\r\n<https://id.parliament.uk/T7oi7f0E>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/elHq7PWF>
+        .\r\n<https://id.parliament.uk/T7oi7f0E> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/WdlP3RL1> .\r\n<https://id.parliament.uk/elHq7PWF>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/elHq7PWF> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-05+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/elHq7PWF>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/eup4DwE5>
+        .\r\n<https://id.parliament.uk/WdlP3RL1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/WdlP3RL1>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/gTgidljI>
+        .\r\n<https://id.parliament.uk/IYqCRJN5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/IYqCRJN5>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/IYqCRJN5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/IYqCRJN5>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 90\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/IYqCRJN5>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 90\" .\r\n<https://id.parliament.uk/IYqCRJN5> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"676\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/IYqCRJN5>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 90\" .\r\n<https://id.parliament.uk/IYqCRJN5> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/QlXTuSAp> .\r\n<https://id.parliament.uk/IYqCRJN5>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/MVnuNAsM>
+        .\r\n<https://id.parliament.uk/QlXTuSAp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/QlXTuSAp>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-06+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/QlXTuSAp> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XbTBTDMo> .\r\n<https://id.parliament.uk/MVnuNAsM>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/MVnuNAsM> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/wzOpc7Aj>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/wzOpc7Aj> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/wzOpc7Aj>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/wzOpc7Aj> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 91\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/wzOpc7Aj> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 91\" .\r\n<https://id.parliament.uk/wzOpc7Aj>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"691\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/wzOpc7Aj> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 91\" .\r\n<https://id.parliament.uk/wzOpc7Aj>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/c2j7TK3q>
+        .\r\n<https://id.parliament.uk/wzOpc7Aj> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/rGmwrYWm> .\r\n<https://id.parliament.uk/c2j7TK3q>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/c2j7TK3q> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-07+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/c2j7TK3q>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/ZU3IXBtP>
+        .\r\n<https://id.parliament.uk/rGmwrYWm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/rGmwrYWm>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/8xNcqHgV> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/8xNcqHgV>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/8xNcqHgV> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/8xNcqHgV>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 92\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/8xNcqHgV>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 92\" .\r\n<https://id.parliament.uk/8xNcqHgV> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"667\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/8xNcqHgV>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 92\" .\r\n<https://id.parliament.uk/8xNcqHgV> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/jzdEemyP> .\r\n<https://id.parliament.uk/8xNcqHgV>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/uIv7V5Fh>
+        .\r\n<https://id.parliament.uk/jzdEemyP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/jzdEemyP>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-07+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/jzdEemyP> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XouN12Ow> .\r\n<https://id.parliament.uk/uIv7V5Fh>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/uIv7V5Fh> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/tiA7a71r>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/tiA7a71r> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/tiA7a71r>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/tiA7a71r> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 93\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/tiA7a71r> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 93\" .\r\n<https://id.parliament.uk/tiA7a71r>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"688\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/tiA7a71r> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 93\" .\r\n<https://id.parliament.uk/tiA7a71r>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/Qm5qIh0P>
+        .\r\n<https://id.parliament.uk/tiA7a71r> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/R6OYbZOe> .\r\n<https://id.parliament.uk/Qm5qIh0P>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/Qm5qIh0P> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-07+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/Qm5qIh0P>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/7dSvuueH>
+        .\r\n<https://id.parliament.uk/R6OYbZOe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/R6OYbZOe>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/Keztycwl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/Keztycwl>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/Keztycwl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/Keztycwl>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 94\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/Keztycwl>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 94\" .\r\n<https://id.parliament.uk/Keztycwl> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"880\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/Keztycwl>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 94\" .\r\n<https://id.parliament.uk/Keztycwl> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/crlcWHt2> .\r\n<https://id.parliament.uk/Keztycwl>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/NPsTtMcv>
+        .\r\n<https://id.parliament.uk/crlcWHt2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/crlcWHt2>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-07+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/crlcWHt2> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fKqMNz79> .\r\n<https://id.parliament.uk/NPsTtMcv>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/NPsTtMcv> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/PhwmELqG>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/PhwmELqG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/PhwmELqG>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/PhwmELqG> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 95\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/PhwmELqG> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 95\" .\r\n<https://id.parliament.uk/PhwmELqG>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"696\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/PhwmELqG> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 95\" .\r\n<https://id.parliament.uk/PhwmELqG>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/630Ft4k4>
+        .\r\n<https://id.parliament.uk/PhwmELqG> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/kgC76Ime> .\r\n<https://id.parliament.uk/630Ft4k4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/630Ft4k4> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-08+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/630Ft4k4>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/NDZSYjeE>
+        .\r\n<https://id.parliament.uk/kgC76Ime> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/kgC76Ime>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/1IUldWII> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/1IUldWII>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/1IUldWII> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/1IUldWII>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 96\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/1IUldWII>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 96\" .\r\n<https://id.parliament.uk/1IUldWII> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"695\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/1IUldWII>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 96\" .\r\n<https://id.parliament.uk/1IUldWII> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/wTM8MSS7> .\r\n<https://id.parliament.uk/1IUldWII>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/ThkRNxvE>
+        .\r\n<https://id.parliament.uk/wTM8MSS7> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/wTM8MSS7>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-08+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/wTM8MSS7> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fKqMNz79> .\r\n<https://id.parliament.uk/ThkRNxvE>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/ThkRNxvE> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/Z1VEYuzd>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/Z1VEYuzd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/Z1VEYuzd>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/Z1VEYuzd> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 97\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/Z1VEYuzd> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 97\" .\r\n<https://id.parliament.uk/Z1VEYuzd>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"703\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/Z1VEYuzd> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 97\" .\r\n<https://id.parliament.uk/Z1VEYuzd>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/iC7vA0Z9>
+        .\r\n<https://id.parliament.uk/Z1VEYuzd> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/4hcgudSd> .\r\n<https://id.parliament.uk/iC7vA0Z9>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/iC7vA0Z9> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-11+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/iC7vA0Z9>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/5LQ5Ar74>
+        .\r\n<https://id.parliament.uk/4hcgudSd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/4hcgudSd>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/WOETQ8oL> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/WOETQ8oL>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/WOETQ8oL> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/WOETQ8oL>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 98\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/WOETQ8oL>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 98\" .\r\n<https://id.parliament.uk/WOETQ8oL> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"860\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/WOETQ8oL>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 98\" .\r\n<https://id.parliament.uk/WOETQ8oL> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/tPANiKqA> .\r\n<https://id.parliament.uk/WOETQ8oL>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/mEw7S9ov>
+        .\r\n<https://id.parliament.uk/tPANiKqA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/tPANiKqA>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-11+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/tPANiKqA> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/yiuTaSI4> .\r\n<https://id.parliament.uk/mEw7S9ov>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/mEw7S9ov> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/jKgfbLZG>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/jKgfbLZG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/jKgfbLZG>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/jKgfbLZG> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 99\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/jKgfbLZG> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 99\" .\r\n<https://id.parliament.uk/jKgfbLZG>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"698\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/jKgfbLZG> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 99\" .\r\n<https://id.parliament.uk/jKgfbLZG>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/5GvYaS8l>
+        .\r\n<https://id.parliament.uk/jKgfbLZG> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/4OyKxSz9> .\r\n<https://id.parliament.uk/5GvYaS8l>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/5GvYaS8l> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-11+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/5GvYaS8l>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/HYfypSOE>
+        .\r\n<https://id.parliament.uk/4OyKxSz9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/4OyKxSz9>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/BN7ucM8o> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/BN7ucM8o>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/BN7ucM8o> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/BN7ucM8o>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 100\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/BN7ucM8o>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 100\" .\r\n<https://id.parliament.uk/BN7ucM8o> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"687\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/BN7ucM8o>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 100\" .\r\n<https://id.parliament.uk/BN7ucM8o> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/ngVa6Qf3> .\r\n<https://id.parliament.uk/BN7ucM8o>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/j4YnKrGQ>
+        .\r\n<https://id.parliament.uk/ngVa6Qf3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/ngVa6Qf3>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-08+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/ngVa6Qf3> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fpWTqVKh> .\r\n<https://id.parliament.uk/fpWTqVKh>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Group>
+        .\r\n<https://id.parliament.uk/fpWTqVKh> <https://id.parliament.uk/schema/groupName>
+        \"groupName - 17\" .\r\n<https://id.parliament.uk/j4YnKrGQ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/j4YnKrGQ>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/PyLlquNq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/PyLlquNq>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/PyLlquNq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/PyLlquNq>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 101\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/PyLlquNq>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 101\" .\r\n<https://id.parliament.uk/PyLlquNq> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"677\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/PyLlquNq>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 101\" .\r\n<https://id.parliament.uk/PyLlquNq> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/koKeyDBh> .\r\n<https://id.parliament.uk/PyLlquNq>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/Q5DIXbsV>
+        .\r\n<https://id.parliament.uk/koKeyDBh> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/koKeyDBh>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-08+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/koKeyDBh> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fpWTqVKh> .\r\n<https://id.parliament.uk/Q5DIXbsV>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/Q5DIXbsV> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/LldrrMNS>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/LldrrMNS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/LldrrMNS>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/LldrrMNS> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 102\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/LldrrMNS> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 102\" .\r\n<https://id.parliament.uk/LldrrMNS>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"673\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/LldrrMNS> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 102\" .\r\n<https://id.parliament.uk/LldrrMNS>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/21jNcoz8>
+        .\r\n<https://id.parliament.uk/LldrrMNS> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/ZkjV9gWZ> .\r\n<https://id.parliament.uk/21jNcoz8>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/21jNcoz8> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-08+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/21jNcoz8>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/XouN12Ow>
+        .\r\n<https://id.parliament.uk/ZkjV9gWZ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/ZkjV9gWZ>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/nohxpB6K> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/nohxpB6K>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/nohxpB6K> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/nohxpB6K>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 103\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/nohxpB6K>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 103\" .\r\n<https://id.parliament.uk/nohxpB6K> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"670\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/nohxpB6K>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 103\" .\r\n<https://id.parliament.uk/nohxpB6K> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/buWmokrg> .\r\n<https://id.parliament.uk/nohxpB6K>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/DKrpinkq>
+        .\r\n<https://id.parliament.uk/buWmokrg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/buWmokrg>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-08+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/buWmokrg> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XouN12Ow> .\r\n<https://id.parliament.uk/DKrpinkq>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/DKrpinkq> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/aQaZuLyK>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/aQaZuLyK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/aQaZuLyK>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/aQaZuLyK> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 104\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/aQaZuLyK> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 104\" .\r\n<https://id.parliament.uk/aQaZuLyK>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"905\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/aQaZuLyK> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 104\" .\r\n<https://id.parliament.uk/aQaZuLyK>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/SKzgadiu>
+        .\r\n<https://id.parliament.uk/aQaZuLyK> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/d3zxRvk4> .\r\n<https://id.parliament.uk/SKzgadiu>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/SKzgadiu> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-13+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/SKzgadiu>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/NDZSYjeE>
+        .\r\n<https://id.parliament.uk/d3zxRvk4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/d3zxRvk4>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/nky6NCi1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/nky6NCi1>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/nky6NCi1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/nky6NCi1>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 105\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/nky6NCi1>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 105\" .\r\n<https://id.parliament.uk/nky6NCi1> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"653\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/nky6NCi1>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 105\" .\r\n<https://id.parliament.uk/nky6NCi1> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/Wwwxqo4J> .\r\n<https://id.parliament.uk/nky6NCi1>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/kiJwF0d5>
+        .\r\n<https://id.parliament.uk/Wwwxqo4J> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/Wwwxqo4J>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-31+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/Wwwxqo4J> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fKqMNz79> .\r\n<https://id.parliament.uk/kiJwF0d5>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/kiJwF0d5> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/66skcwzN>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/66skcwzN> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/66skcwzN>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/66skcwzN> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 106\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/66skcwzN> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 106\" .\r\n<https://id.parliament.uk/66skcwzN>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"898\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/66skcwzN> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 106\" .\r\n<https://id.parliament.uk/66skcwzN>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/AHFOvb9h>
+        .\r\n<https://id.parliament.uk/66skcwzN> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/okoEwpBW> .\r\n<https://id.parliament.uk/AHFOvb9h>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/AHFOvb9h> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-13+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/AHFOvb9h>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/yiuTaSI4>
+        .\r\n<https://id.parliament.uk/okoEwpBW> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/okoEwpBW>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/I9rWxORS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/I9rWxORS>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/I9rWxORS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/I9rWxORS>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 107\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/I9rWxORS>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 107\" .\r\n<https://id.parliament.uk/I9rWxORS> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"715\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/I9rWxORS>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 107\" .\r\n<https://id.parliament.uk/I9rWxORS> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/nBIracyf> .\r\n<https://id.parliament.uk/I9rWxORS>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/Fwns2363>
+        .\r\n<https://id.parliament.uk/nBIracyf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/nBIracyf>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-13+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/nBIracyf> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/NDZSYjeE> .\r\n<https://id.parliament.uk/Fwns2363>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/Fwns2363> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/leJaKS5E>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/leJaKS5E> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/leJaKS5E>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/leJaKS5E> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 108\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/leJaKS5E> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 108\" .\r\n<https://id.parliament.uk/leJaKS5E>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"909\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/leJaKS5E> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 108\" .\r\n<https://id.parliament.uk/leJaKS5E>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/4yz9ib7D>
+        .\r\n<https://id.parliament.uk/leJaKS5E> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/PuKCWhOF> .\r\n<https://id.parliament.uk/4yz9ib7D>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/4yz9ib7D> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-14+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/4yz9ib7D>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/yiuTaSI4>
+        .\r\n<https://id.parliament.uk/PuKCWhOF> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/PuKCWhOF>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/N3pbTe7F> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/N3pbTe7F>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/N3pbTe7F> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/N3pbTe7F>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 109\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/N3pbTe7F>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 109\" .\r\n<https://id.parliament.uk/N3pbTe7F> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"719\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/N3pbTe7F>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 109\" .\r\n<https://id.parliament.uk/N3pbTe7F> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/qWQujVpH> .\r\n<https://id.parliament.uk/N3pbTe7F>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/SE7Aj9Hz>
+        .\r\n<https://id.parliament.uk/qWQujVpH> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/qWQujVpH>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-14+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/qWQujVpH> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fKqMNz79> .\r\n<https://id.parliament.uk/SE7Aj9Hz>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/SE7Aj9Hz> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/itrbNOwE>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/itrbNOwE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/itrbNOwE>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/itrbNOwE> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 110\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/itrbNOwE> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 110\" .\r\n<https://id.parliament.uk/itrbNOwE>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"1067\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/itrbNOwE> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 110\" .\r\n<https://id.parliament.uk/itrbNOwE>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/aFyadxgl>
+        .\r\n<https://id.parliament.uk/itrbNOwE> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/rSOd6At4> .\r\n<https://id.parliament.uk/aFyadxgl>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/aFyadxgl> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/aFyadxgl>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/UIV7W27r>
+        .\r\n<https://id.parliament.uk/UIV7W27r> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Group> .\r\n<https://id.parliament.uk/UIV7W27r>
+        <https://id.parliament.uk/schema/groupName> \"groupName - 18\" .\r\n<https://id.parliament.uk/rSOd6At4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/rSOd6At4> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/Y5ihrxeg>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/Y5ihrxeg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/Y5ihrxeg>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/Y5ihrxeg> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 111\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/Y5ihrxeg> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 111\" .\r\n<https://id.parliament.uk/Y5ihrxeg>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"1065\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/Y5ihrxeg> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 111\" .\r\n<https://id.parliament.uk/Y5ihrxeg>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/2lKySoAc>
+        .\r\n<https://id.parliament.uk/Y5ihrxeg> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/GjPYe6E4> .\r\n<https://id.parliament.uk/2lKySoAc>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/2lKySoAc> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/2lKySoAc>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/UIV7W27r>
+        .\r\n<https://id.parliament.uk/GjPYe6E4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/GjPYe6E4>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/rMrXIRPv> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/rMrXIRPv>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/rMrXIRPv> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/rMrXIRPv>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 112\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/rMrXIRPv>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 112\" .\r\n<https://id.parliament.uk/rMrXIRPv> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"1063\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/rMrXIRPv>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 112\" .\r\n<https://id.parliament.uk/rMrXIRPv> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/FpWprriy> .\r\n<https://id.parliament.uk/rMrXIRPv>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/CNezzmKU>
+        .\r\n<https://id.parliament.uk/FpWprriy> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/FpWprriy>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/FpWprriy> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/UIV7W27r> .\r\n<https://id.parliament.uk/CNezzmKU>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/CNezzmKU> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/hMaj7XDd>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/hMaj7XDd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/hMaj7XDd>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/hMaj7XDd> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 113\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/hMaj7XDd> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 113\" .\r\n<https://id.parliament.uk/hMaj7XDd>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"1066\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/hMaj7XDd> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 113\" .\r\n<https://id.parliament.uk/hMaj7XDd>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/WpWJdjxe>
+        .\r\n<https://id.parliament.uk/hMaj7XDd> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/KRoYyf39> .\r\n<https://id.parliament.uk/WpWJdjxe>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/WpWJdjxe> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/WpWJdjxe>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/UIV7W27r>
+        .\r\n<https://id.parliament.uk/KRoYyf39> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/KRoYyf39>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/uhL6bPvV> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/uhL6bPvV>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/uhL6bPvV> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/uhL6bPvV>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 114\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/uhL6bPvV>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 114\" .\r\n<https://id.parliament.uk/uhL6bPvV> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"1068\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/uhL6bPvV>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 114\" .\r\n<https://id.parliament.uk/uhL6bPvV> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/LwV1dWdD> .\r\n<https://id.parliament.uk/uhL6bPvV>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/eCC4xqSd>
+        .\r\n<https://id.parliament.uk/LwV1dWdD> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/LwV1dWdD>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/LwV1dWdD> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/UIV7W27r> .\r\n<https://id.parliament.uk/eCC4xqSd>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/eCC4xqSd> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/MJRZgm6X>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/MJRZgm6X> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/MJRZgm6X>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/MJRZgm6X> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 115\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/MJRZgm6X> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 115\" .\r\n<https://id.parliament.uk/MJRZgm6X>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"1070\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/MJRZgm6X> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 115\" .\r\n<https://id.parliament.uk/MJRZgm6X>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/plKvEflr>
+        .\r\n<https://id.parliament.uk/MJRZgm6X> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/8MyEStfv> .\r\n<https://id.parliament.uk/plKvEflr>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/plKvEflr> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/plKvEflr>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/UIV7W27r>
+        .\r\n<https://id.parliament.uk/8MyEStfv> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/8MyEStfv>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/9Nv0gELe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/9Nv0gELe>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/9Nv0gELe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/9Nv0gELe>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 116\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/9Nv0gELe>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 116\" .\r\n<https://id.parliament.uk/9Nv0gELe> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"709\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/9Nv0gELe>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 116\" .\r\n<https://id.parliament.uk/9Nv0gELe> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/ktlPPWYD> .\r\n<https://id.parliament.uk/9Nv0gELe>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/VwdFcdKq>
+        .\r\n<https://id.parliament.uk/ktlPPWYD> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/ktlPPWYD>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-15+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/ktlPPWYD> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/NDZSYjeE> .\r\n<https://id.parliament.uk/VwdFcdKq>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/VwdFcdKq> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/rdYNYrB9>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/rdYNYrB9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/rdYNYrB9>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/rdYNYrB9> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 117\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/rdYNYrB9> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 117\" .\r\n<https://id.parliament.uk/rdYNYrB9>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"717\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/rdYNYrB9> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 117\" .\r\n<https://id.parliament.uk/rdYNYrB9>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/mAHMh7zR>
+        .\r\n<https://id.parliament.uk/rdYNYrB9> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/QA1PcSCp> .\r\n<https://id.parliament.uk/mAHMh7zR>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/mAHMh7zR> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-15+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/mAHMh7zR>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/XouN12Ow>
+        .\r\n<https://id.parliament.uk/QA1PcSCp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/QA1PcSCp>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/D9vkxjm0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/D9vkxjm0>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/D9vkxjm0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/D9vkxjm0>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 118\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/D9vkxjm0>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 118\" .\r\n<https://id.parliament.uk/D9vkxjm0> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 118\" .\r\n<https://id.parliament.uk/D9vkxjm0>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/gYHg7QFf>
+        .\r\n<https://id.parliament.uk/D9vkxjm0> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/jTuty5ho> .\r\n<https://id.parliament.uk/gYHg7QFf>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/gYHg7QFf> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-15+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/gYHg7QFf>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/7dSvuueH>
+        .\r\n<https://id.parliament.uk/jTuty5ho> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/jTuty5ho>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/vPuOxy1B> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/vPuOxy1B>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/vPuOxy1B> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/vPuOxy1B>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 119\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/vPuOxy1B>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 119\" .\r\n<https://id.parliament.uk/vPuOxy1B> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"779\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/vPuOxy1B>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 119\" .\r\n<https://id.parliament.uk/vPuOxy1B> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/9ZAdr8BY> .\r\n<https://id.parliament.uk/vPuOxy1B>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/QVLaGR9L>
+        .\r\n<https://id.parliament.uk/9ZAdr8BY> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/9ZAdr8BY>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/9ZAdr8BY> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/79sn5e3n> .\r\n<https://id.parliament.uk/QVLaGR9L>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/QVLaGR9L> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/tZhWfLGW>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/tZhWfLGW> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/tZhWfLGW>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/tZhWfLGW> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 120\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/tZhWfLGW> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 120\" .\r\n<https://id.parliament.uk/tZhWfLGW>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"778\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/tZhWfLGW> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 120\" .\r\n<https://id.parliament.uk/tZhWfLGW>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/vgqGQbkm>
+        .\r\n<https://id.parliament.uk/tZhWfLGW> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/KWpudKrZ> .\r\n<https://id.parliament.uk/vgqGQbkm>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/vgqGQbkm> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/vgqGQbkm>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/79sn5e3n>
+        .\r\n<https://id.parliament.uk/KWpudKrZ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/KWpudKrZ>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/avoNURrR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/avoNURrR>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/avoNURrR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/avoNURrR>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 121\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/avoNURrR>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 121\" .\r\n<https://id.parliament.uk/avoNURrR> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"628\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/avoNURrR>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 121\" .\r\n<https://id.parliament.uk/avoNURrR> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/WkSMeKah> .\r\n<https://id.parliament.uk/avoNURrR>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/BYngh8z1>
+        .\r\n<https://id.parliament.uk/WkSMeKah> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/WkSMeKah>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-16+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/WkSMeKah> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/79sn5e3n> .\r\n<https://id.parliament.uk/BYngh8z1>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/BYngh8z1> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/s75qT4mw>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/s75qT4mw> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/s75qT4mw>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/s75qT4mw> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 122\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/s75qT4mw> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 122\" .\r\n<https://id.parliament.uk/s75qT4mw>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"840\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/s75qT4mw> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 122\" .\r\n<https://id.parliament.uk/s75qT4mw>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/DOGB8Le4>
+        .\r\n<https://id.parliament.uk/s75qT4mw> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/3HrW7G3b> .\r\n<https://id.parliament.uk/DOGB8Le4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/DOGB8Le4> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/DOGB8Le4>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/79sn5e3n>
+        .\r\n<https://id.parliament.uk/3HrW7G3b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/3HrW7G3b>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/YdZGzcJA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/YdZGzcJA>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/YdZGzcJA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/YdZGzcJA>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 123\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/YdZGzcJA>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 123\" .\r\n<https://id.parliament.uk/YdZGzcJA> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"730\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/YdZGzcJA>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 123\" .\r\n<https://id.parliament.uk/YdZGzcJA> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/97Woii31> .\r\n<https://id.parliament.uk/YdZGzcJA>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/dnBED32B>
+        .\r\n<https://id.parliament.uk/97Woii31> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/97Woii31>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-18+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/97Woii31> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fKqMNz79> .\r\n<https://id.parliament.uk/dnBED32B>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/dnBED32B> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/N1TcXxev>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/N1TcXxev> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/N1TcXxev>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/N1TcXxev> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 124\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/N1TcXxev> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 124\" .\r\n<https://id.parliament.uk/N1TcXxev>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"706\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/N1TcXxev> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 124\" .\r\n<https://id.parliament.uk/N1TcXxev>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/3H2a62MQ>
+        .\r\n<https://id.parliament.uk/N1TcXxev> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/665mjGeq> .\r\n<https://id.parliament.uk/3H2a62MQ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/3H2a62MQ> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-18+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/3H2a62MQ>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/5LQ5Ar74>
+        .\r\n<https://id.parliament.uk/665mjGeq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/665mjGeq>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/u2nfODML> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/u2nfODML>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/u2nfODML> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/u2nfODML>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 125\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/u2nfODML>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 125\" .\r\n<https://id.parliament.uk/u2nfODML> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"707\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/u2nfODML>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 125\" .\r\n<https://id.parliament.uk/u2nfODML> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/XEgy9gKK> .\r\n<https://id.parliament.uk/u2nfODML>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/tWfu2Nyq>
+        .\r\n<https://id.parliament.uk/XEgy9gKK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/XEgy9gKK>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-18+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/XEgy9gKK> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/5LQ5Ar74> .\r\n<https://id.parliament.uk/tWfu2Nyq>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/tWfu2Nyq> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/GHIocidH>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/GHIocidH> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/GHIocidH>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/GHIocidH> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 126\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/GHIocidH> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 126\" .\r\n<https://id.parliament.uk/GHIocidH>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"839\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/GHIocidH> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 126\" .\r\n<https://id.parliament.uk/GHIocidH>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/YhyvgA49>
+        .\r\n<https://id.parliament.uk/GHIocidH> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/WmTUL82V> .\r\n<https://id.parliament.uk/YhyvgA49>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/YhyvgA49> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-30+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/YhyvgA49>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/79sn5e3n>
+        .\r\n<https://id.parliament.uk/WmTUL82V> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/WmTUL82V>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/YhMNMpYo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/YhMNMpYo>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/YhMNMpYo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/YhMNMpYo>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 127\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/YhMNMpYo>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 127\" .\r\n<https://id.parliament.uk/YhMNMpYo> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"729\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/YhMNMpYo>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 127\" .\r\n<https://id.parliament.uk/YhMNMpYo> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/yzmWisVv> .\r\n<https://id.parliament.uk/YhMNMpYo>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/iwUtxq6V>
+        .\r\n<https://id.parliament.uk/yzmWisVv> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/yzmWisVv>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-18+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/yzmWisVv> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/NDZSYjeE> .\r\n<https://id.parliament.uk/iwUtxq6V>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/iwUtxq6V> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/kqzXWiAO>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/kqzXWiAO> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/kqzXWiAO>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/kqzXWiAO> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 128\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/kqzXWiAO> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 128\" .\r\n<https://id.parliament.uk/kqzXWiAO>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"526\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/kqzXWiAO> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 128\" .\r\n<https://id.parliament.uk/kqzXWiAO>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/1lAV8kaU>
+        .\r\n<https://id.parliament.uk/kqzXWiAO> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/V2jm1mhC> .\r\n<https://id.parliament.uk/1lAV8kaU>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/1lAV8kaU> <https://id.parliament.uk/schema/layingDate>
+        \"2018-04-26+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/1lAV8kaU>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/fpWTqVKh>
+        .\r\n<https://id.parliament.uk/V2jm1mhC> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/V2jm1mhC>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/xa91QFSm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/xa91QFSm>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/xa91QFSm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/xa91QFSm>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 129\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/xa91QFSm>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 129\" .\r\n<https://id.parliament.uk/xa91QFSm> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"838\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/xa91QFSm>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 129\" .\r\n<https://id.parliament.uk/xa91QFSm> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/Wgm9YGFV> .\r\n<https://id.parliament.uk/xa91QFSm>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/7ayWbhIK>
+        .\r\n<https://id.parliament.uk/Wgm9YGFV> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/Wgm9YGFV>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-17+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/Wgm9YGFV> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fpWTqVKh> .\r\n<https://id.parliament.uk/7ayWbhIK>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/7ayWbhIK> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/ITytkRlT>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/ITytkRlT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/ITytkRlT>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/ITytkRlT> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 130\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/ITytkRlT> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 130\" .\r\n<https://id.parliament.uk/ITytkRlT>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"522\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/ITytkRlT> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 130\" .\r\n<https://id.parliament.uk/ITytkRlT>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/pA6X11np>
+        .\r\n<https://id.parliament.uk/ITytkRlT> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/DX1ZptHJ> .\r\n<https://id.parliament.uk/pA6X11np>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/pA6X11np> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-01+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/pA6X11np>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/JVJB3tuB>
+        .\r\n<https://id.parliament.uk/JVJB3tuB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Group> .\r\n<https://id.parliament.uk/JVJB3tuB>
+        <https://id.parliament.uk/schema/groupName> \"groupName - 19\" .\r\n<https://id.parliament.uk/DX1ZptHJ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/DX1ZptHJ> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/7uCF2qgm>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/7uCF2qgm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/7uCF2qgm>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/7uCF2qgm> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 131\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/7uCF2qgm> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 131\" .\r\n<https://id.parliament.uk/7uCF2qgm>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"521\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/7uCF2qgm> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 131\" .\r\n<https://id.parliament.uk/7uCF2qgm>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/B7FoleTf>
+        .\r\n<https://id.parliament.uk/7uCF2qgm> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/sSDUxi1Q> .\r\n<https://id.parliament.uk/B7FoleTf>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/B7FoleTf> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-01+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/B7FoleTf>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/JVJB3tuB>
+        .\r\n<https://id.parliament.uk/sSDUxi1Q> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/sSDUxi1Q>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/vBqvzucr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/vBqvzucr>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/vBqvzucr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/vBqvzucr>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 132\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/vBqvzucr>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 132\" .\r\n<https://id.parliament.uk/vBqvzucr> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"513\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/vBqvzucr>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 132\" .\r\n<https://id.parliament.uk/vBqvzucr> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/AhLtGgwE> .\r\n<https://id.parliament.uk/vBqvzucr>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/oaeGqOmW>
+        .\r\n<https://id.parliament.uk/AhLtGgwE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/AhLtGgwE>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-26+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/AhLtGgwE> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fpWTqVKh> .\r\n<https://id.parliament.uk/oaeGqOmW>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/oaeGqOmW> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/4e7ROEBU>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/4e7ROEBU> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/4e7ROEBU>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/4e7ROEBU> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 133\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/4e7ROEBU> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 133\" .\r\n<https://id.parliament.uk/4e7ROEBU>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"626\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/4e7ROEBU> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 133\" .\r\n<https://id.parliament.uk/4e7ROEBU>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/uXgMiiXW>
+        .\r\n<https://id.parliament.uk/4e7ROEBU> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/NY96FUuV> .\r\n<https://id.parliament.uk/uXgMiiXW>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/uXgMiiXW> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-30+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/uXgMiiXW>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/JVJB3tuB>
+        .\r\n<https://id.parliament.uk/NY96FUuV> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/NY96FUuV>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/9S89Uofh> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/9S89Uofh>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/9S89Uofh> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/9S89Uofh>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 134\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/9S89Uofh>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 134\" .\r\n<https://id.parliament.uk/9S89Uofh> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"623\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/9S89Uofh>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 134\" .\r\n<https://id.parliament.uk/9S89Uofh> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/6Rz43qvX> .\r\n<https://id.parliament.uk/9S89Uofh>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/nR6OHhoL>
+        .\r\n<https://id.parliament.uk/6Rz43qvX> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/6Rz43qvX>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-30+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/6Rz43qvX> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/JVJB3tuB> .\r\n<https://id.parliament.uk/nR6OHhoL>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/nR6OHhoL> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/4bwmdrUh>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/4bwmdrUh> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/4bwmdrUh>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/4bwmdrUh> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 135\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/4bwmdrUh> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 135\" .\r\n<https://id.parliament.uk/4bwmdrUh>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"620\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/4bwmdrUh> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 135\" .\r\n<https://id.parliament.uk/4bwmdrUh>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/9NDpK6YH>
+        .\r\n<https://id.parliament.uk/4bwmdrUh> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/PXfg6pxB> .\r\n<https://id.parliament.uk/9NDpK6YH>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/9NDpK6YH> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-30+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/9NDpK6YH>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/JVJB3tuB>
+        .\r\n<https://id.parliament.uk/PXfg6pxB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/PXfg6pxB>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/YI5L3LfM> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/YI5L3LfM>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/YI5L3LfM> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/YI5L3LfM>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 136\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/YI5L3LfM>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 136\" .\r\n<https://id.parliament.uk/YI5L3LfM> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"622\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/YI5L3LfM>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 136\" .\r\n<https://id.parliament.uk/YI5L3LfM> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/4i2IW9JJ> .\r\n<https://id.parliament.uk/YI5L3LfM>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/uMC04oEu>
+        .\r\n<https://id.parliament.uk/4i2IW9JJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/4i2IW9JJ>
+        <https://id.parliament.uk/schema/layingDate> \"2018-05-30+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/4i2IW9JJ> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/JVJB3tuB> .\r\n<https://id.parliament.uk/uMC04oEu>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/uMC04oEu> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/X9tJrtug>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/X9tJrtug> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/X9tJrtug>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/X9tJrtug> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 137\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/X9tJrtug> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 137\" .\r\n<https://id.parliament.uk/X9tJrtug>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"837\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/X9tJrtug> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 137\" .\r\n<https://id.parliament.uk/X9tJrtug>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/BoG0LUiU>
+        .\r\n<https://id.parliament.uk/X9tJrtug> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/hTZ6jXdk> .\r\n<https://id.parliament.uk/BoG0LUiU>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/BoG0LUiU> <https://id.parliament.uk/schema/layingDate>
+        \"2018-05-21+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/BoG0LUiU>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/ni8aOEk3>
+        .\r\n<https://id.parliament.uk/ni8aOEk3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Group> .\r\n<https://id.parliament.uk/ni8aOEk3>
+        <https://id.parliament.uk/schema/groupName> \"groupName - 20\" .\r\n<https://id.parliament.uk/hTZ6jXdk>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/hTZ6jXdk> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/MJ4ILVps>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/MJ4ILVps> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/MJ4ILVps>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/MJ4ILVps> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 138\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/MJ4ILVps> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 138\" .\r\n<https://id.parliament.uk/MJ4ILVps>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"734\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/MJ4ILVps> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 138\" .\r\n<https://id.parliament.uk/MJ4ILVps>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/b3UIQwJ8>
+        .\r\n<https://id.parliament.uk/MJ4ILVps> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/O2X0qWrg> .\r\n<https://id.parliament.uk/b3UIQwJ8>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/b3UIQwJ8> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-19+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/b3UIQwJ8>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/HYfypSOE>
+        .\r\n<https://id.parliament.uk/O2X0qWrg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/O2X0qWrg>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/6XQ6ig48> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/6XQ6ig48>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/6XQ6ig48> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/6XQ6ig48>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 139\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/6XQ6ig48>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 139\" .\r\n<https://id.parliament.uk/6XQ6ig48> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"731\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/6XQ6ig48>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 139\" .\r\n<https://id.parliament.uk/6XQ6ig48> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/OKq4nd7o> .\r\n<https://id.parliament.uk/6XQ6ig48>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/hj1bbx7c>
+        .\r\n<https://id.parliament.uk/OKq4nd7o> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/OKq4nd7o>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-18+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/OKq4nd7o> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/5LQ5Ar74> .\r\n<https://id.parliament.uk/hj1bbx7c>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/hj1bbx7c> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/GVXkRR2M>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/GVXkRR2M> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/GVXkRR2M>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/GVXkRR2M> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 140\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/GVXkRR2M> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 140\" .\r\n<https://id.parliament.uk/GVXkRR2M>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"1030\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/GVXkRR2M> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 140\" .\r\n<https://id.parliament.uk/GVXkRR2M>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/wgdGvoby>
+        .\r\n<https://id.parliament.uk/GVXkRR2M> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/k6e1O3T7> .\r\n<https://id.parliament.uk/wgdGvoby>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/wgdGvoby> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-18+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/wgdGvoby>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/XbTBTDMo>
+        .\r\n<https://id.parliament.uk/k6e1O3T7> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/k6e1O3T7>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/HNjL6uzv> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/HNjL6uzv>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/HNjL6uzv> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/HNjL6uzv>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 141\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/HNjL6uzv>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 141\" .\r\n<https://id.parliament.uk/HNjL6uzv> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"737\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/HNjL6uzv>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 141\" .\r\n<https://id.parliament.uk/HNjL6uzv> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/i3eQ1NDK> .\r\n<https://id.parliament.uk/HNjL6uzv>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/yPbxlCFH>
+        .\r\n<https://id.parliament.uk/i3eQ1NDK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/i3eQ1NDK>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-20+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/i3eQ1NDK> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/HYfypSOE> .\r\n<https://id.parliament.uk/yPbxlCFH>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/yPbxlCFH> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/OohXDEMJ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/OohXDEMJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/OohXDEMJ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/OohXDEMJ> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 142\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/OohXDEMJ> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 142\" .\r\n<https://id.parliament.uk/OohXDEMJ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"904\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/OohXDEMJ> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 142\" .\r\n<https://id.parliament.uk/OohXDEMJ>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/07mwhqiT>
+        .\r\n<https://id.parliament.uk/OohXDEMJ> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/QbzwUe17> .\r\n<https://id.parliament.uk/07mwhqiT>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/07mwhqiT> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-20+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/07mwhqiT>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/g8hByIik>
+        .\r\n<https://id.parliament.uk/g8hByIik> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Group> .\r\n<https://id.parliament.uk/g8hByIik>
+        <https://id.parliament.uk/schema/groupName> \"groupName - 21\" .\r\n<https://id.parliament.uk/QbzwUe17>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/QbzwUe17> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/4kSUJ4K2>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/4kSUJ4K2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/4kSUJ4K2>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/4kSUJ4K2> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 143\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/4kSUJ4K2> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 143\" .\r\n<https://id.parliament.uk/4kSUJ4K2>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"739\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/4kSUJ4K2> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 143\" .\r\n<https://id.parliament.uk/4kSUJ4K2>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/Jz5ayidS>
+        .\r\n<https://id.parliament.uk/4kSUJ4K2> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/vdp9GgsX> .\r\n<https://id.parliament.uk/Jz5ayidS>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/Jz5ayidS> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-20+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/Jz5ayidS>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/5LQ5Ar74>
+        .\r\n<https://id.parliament.uk/vdp9GgsX> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/vdp9GgsX>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/VdxVTQ0L> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/VdxVTQ0L>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/VdxVTQ0L> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/VdxVTQ0L>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 144\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/VdxVTQ0L>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 144\" .\r\n<https://id.parliament.uk/VdxVTQ0L> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"738\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/VdxVTQ0L>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 144\" .\r\n<https://id.parliament.uk/VdxVTQ0L> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/j9IPPPC9> .\r\n<https://id.parliament.uk/VdxVTQ0L>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/1B8DSj6y>
+        .\r\n<https://id.parliament.uk/j9IPPPC9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/j9IPPPC9>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-25+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/j9IPPPC9> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/7dSvuueH> .\r\n<https://id.parliament.uk/1B8DSj6y>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/1B8DSj6y> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/CMCJ3a82>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/CMCJ3a82> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/CMCJ3a82>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/CMCJ3a82> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 145\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/CMCJ3a82> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 145\" .\r\n<https://id.parliament.uk/CMCJ3a82>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"897\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/CMCJ3a82> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 145\" .\r\n<https://id.parliament.uk/CMCJ3a82>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/Llq9prcO>
+        .\r\n<https://id.parliament.uk/CMCJ3a82> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/NNZyLkm8> .\r\n<https://id.parliament.uk/Llq9prcO>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/Llq9prcO> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-25+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/Llq9prcO>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/HYfypSOE>
+        .\r\n<https://id.parliament.uk/NNZyLkm8> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/NNZyLkm8>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/mRgc1Qvc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/mRgc1Qvc>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/mRgc1Qvc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/mRgc1Qvc>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 146\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/mRgc1Qvc>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 146\" .\r\n<https://id.parliament.uk/mRgc1Qvc> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"761\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/mRgc1Qvc>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 146\" .\r\n<https://id.parliament.uk/mRgc1Qvc> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/wFTQha8D> .\r\n<https://id.parliament.uk/mRgc1Qvc>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/snpPLUSB>
+        .\r\n<https://id.parliament.uk/wFTQha8D> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/wFTQha8D>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-25+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/wFTQha8D> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/5LQ5Ar74> .\r\n<https://id.parliament.uk/snpPLUSB>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/snpPLUSB> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/h8w2BHwS>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/h8w2BHwS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/h8w2BHwS>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/h8w2BHwS> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 147\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/h8w2BHwS> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 147\" .\r\n<https://id.parliament.uk/h8w2BHwS>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"754\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/h8w2BHwS> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 147\" .\r\n<https://id.parliament.uk/h8w2BHwS>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/PVt9t1Mf>
+        .\r\n<https://id.parliament.uk/h8w2BHwS> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/GQOruZBT> .\r\n<https://id.parliament.uk/PVt9t1Mf>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/PVt9t1Mf> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-25+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/PVt9t1Mf>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/5LQ5Ar74>
+        .\r\n<https://id.parliament.uk/GQOruZBT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/GQOruZBT>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/UD4HjKbu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/UD4HjKbu>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/UD4HjKbu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/UD4HjKbu>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 148\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/UD4HjKbu>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 148\" .\r\n<https://id.parliament.uk/UD4HjKbu> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"748\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/UD4HjKbu>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 148\" .\r\n<https://id.parliament.uk/UD4HjKbu> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/9UPBD2Md> .\r\n<https://id.parliament.uk/UD4HjKbu>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/3dE9HsCE>
+        .\r\n<https://id.parliament.uk/9UPBD2Md> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/9UPBD2Md>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-25+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/9UPBD2Md> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/NDZSYjeE> .\r\n<https://id.parliament.uk/3dE9HsCE>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/3dE9HsCE> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/HZod54jz>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/HZod54jz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/HZod54jz>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/HZod54jz> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 149\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/HZod54jz> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 149\" .\r\n<https://id.parliament.uk/HZod54jz>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"771\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/HZod54jz> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 149\" .\r\n<https://id.parliament.uk/HZod54jz>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/tDtOGEse>
+        .\r\n<https://id.parliament.uk/HZod54jz> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/3WxJmYZD> .\r\n<https://id.parliament.uk/tDtOGEse>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/tDtOGEse> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-28+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/tDtOGEse>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/5LQ5Ar74>
+        .\r\n<https://id.parliament.uk/3WxJmYZD> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/3WxJmYZD>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/zfcsMSD3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/zfcsMSD3>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/zfcsMSD3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/zfcsMSD3>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 150\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/zfcsMSD3>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 150\" .\r\n<https://id.parliament.uk/zfcsMSD3> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"769\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/zfcsMSD3>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 150\" .\r\n<https://id.parliament.uk/zfcsMSD3> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/Qol6iEYA> .\r\n<https://id.parliament.uk/zfcsMSD3>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/1po2BJxp>
+        .\r\n<https://id.parliament.uk/Qol6iEYA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/Qol6iEYA>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-28+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/Qol6iEYA> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XbTBTDMo> .\r\n<https://id.parliament.uk/1po2BJxp>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/1po2BJxp> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/NTd30zpo>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/NTd30zpo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/NTd30zpo>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/NTd30zpo> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 151\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/NTd30zpo> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 151\" .\r\n<https://id.parliament.uk/NTd30zpo>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"764\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/NTd30zpo> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 151\" .\r\n<https://id.parliament.uk/NTd30zpo>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/IsIZtZBp>
+        .\r\n<https://id.parliament.uk/NTd30zpo> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/XNmQJL6V> .\r\n<https://id.parliament.uk/IsIZtZBp>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/IsIZtZBp> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-28+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/IsIZtZBp>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/XouN12Ow>
+        .\r\n<https://id.parliament.uk/XNmQJL6V> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/XNmQJL6V>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/5dLGzkeI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/5dLGzkeI>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/5dLGzkeI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/5dLGzkeI>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 152\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/5dLGzkeI>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 152\" .\r\n<https://id.parliament.uk/5dLGzkeI> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 152\" .\r\n<https://id.parliament.uk/5dLGzkeI>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/whjpgchX>
+        .\r\n<https://id.parliament.uk/5dLGzkeI> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/3bZHylgr> .\r\n<https://id.parliament.uk/whjpgchX>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/whjpgchX> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-28+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/whjpgchX>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/BRTNQywN>
+        .\r\n<https://id.parliament.uk/3bZHylgr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/3bZHylgr>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/98auwKwP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/98auwKwP>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/98auwKwP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/98auwKwP>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 153\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/98auwKwP>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 153\" .\r\n<https://id.parliament.uk/98auwKwP> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"770\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/98auwKwP>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 153\" .\r\n<https://id.parliament.uk/98auwKwP> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/wgDLFyxo> .\r\n<https://id.parliament.uk/98auwKwP>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/F7LRwguI>
+        .\r\n<https://id.parliament.uk/wgDLFyxo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/wgDLFyxo>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-28+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/wgDLFyxo> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/BRTNQywN> .\r\n<https://id.parliament.uk/F7LRwguI>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/F7LRwguI> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/P5Zu6fkP>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/P5Zu6fkP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/P5Zu6fkP>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/P5Zu6fkP> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 154\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/P5Zu6fkP> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 154\" .\r\n<https://id.parliament.uk/P5Zu6fkP>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 154\" .\r\n<https://id.parliament.uk/P5Zu6fkP> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/FafO3XiI> .\r\n<https://id.parliament.uk/P5Zu6fkP>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/fa5HaWHq>
+        .\r\n<https://id.parliament.uk/FafO3XiI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/FafO3XiI>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-28+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/FafO3XiI> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/NDZSYjeE> .\r\n<https://id.parliament.uk/fa5HaWHq>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/fa5HaWHq> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/4GqD7K0p>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/4GqD7K0p> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/4GqD7K0p>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/4GqD7K0p> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 155\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/4GqD7K0p> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 155\" .\r\n<https://id.parliament.uk/4GqD7K0p>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"755\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/4GqD7K0p> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 155\" .\r\n<https://id.parliament.uk/4GqD7K0p>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/xGF76JwA>
+        .\r\n<https://id.parliament.uk/4GqD7K0p> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/PHiVZHeP> .\r\n<https://id.parliament.uk/xGF76JwA>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/xGF76JwA> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-29+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/xGF76JwA>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/fpWTqVKh>
+        .\r\n<https://id.parliament.uk/PHiVZHeP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/PHiVZHeP>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/Foe6fVxK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/Foe6fVxK>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/Foe6fVxK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/Foe6fVxK>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 156\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/Foe6fVxK>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 156\" .\r\n<https://id.parliament.uk/Foe6fVxK> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"756\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/Foe6fVxK>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 156\" .\r\n<https://id.parliament.uk/Foe6fVxK> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/J1PeCqRi> .\r\n<https://id.parliament.uk/Foe6fVxK>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/iOR7pNdJ>
+        .\r\n<https://id.parliament.uk/J1PeCqRi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/J1PeCqRi>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-29+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/J1PeCqRi> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fpWTqVKh> .\r\n<https://id.parliament.uk/iOR7pNdJ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/iOR7pNdJ> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/RS3W2NQw>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/RS3W2NQw> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/RS3W2NQw>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/RS3W2NQw> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 157\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/RS3W2NQw> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 157\" .\r\n<https://id.parliament.uk/RS3W2NQw>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"757\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/RS3W2NQw> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 157\" .\r\n<https://id.parliament.uk/RS3W2NQw>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/YoZD3Wma>
+        .\r\n<https://id.parliament.uk/RS3W2NQw> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/jQuzcqf5> .\r\n<https://id.parliament.uk/YoZD3Wma>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/YoZD3Wma> <https://id.parliament.uk/schema/layingDate>
+        \"2018-06-29+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/YoZD3Wma>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/fpWTqVKh>
+        .\r\n<https://id.parliament.uk/jQuzcqf5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/jQuzcqf5>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/m1AZ18wg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/m1AZ18wg>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/m1AZ18wg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/m1AZ18wg>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 158\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/m1AZ18wg>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 158\" .\r\n<https://id.parliament.uk/m1AZ18wg> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"788\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/m1AZ18wg>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 158\" .\r\n<https://id.parliament.uk/m1AZ18wg> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/7cMqzvFg> .\r\n<https://id.parliament.uk/m1AZ18wg>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/ms7N7n0G>
+        .\r\n<https://id.parliament.uk/7cMqzvFg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/7cMqzvFg>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-29+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/7cMqzvFg> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fpWTqVKh> .\r\n<https://id.parliament.uk/ms7N7n0G>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/ms7N7n0G> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/JPx0duf2>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/JPx0duf2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/JPx0duf2>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/JPx0duf2> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 159\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/JPx0duf2> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 159\" .\r\n<https://id.parliament.uk/JPx0duf2>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"794\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/JPx0duf2> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 159\" .\r\n<https://id.parliament.uk/JPx0duf2>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/XyqblZIf>
+        .\r\n<https://id.parliament.uk/JPx0duf2> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/Kesi1bdT> .\r\n<https://id.parliament.uk/XyqblZIf>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/XyqblZIf> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-02+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/XyqblZIf>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/7dSvuueH>
+        .\r\n<https://id.parliament.uk/Kesi1bdT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/Kesi1bdT>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/C8kKvTBL> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/C8kKvTBL>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/C8kKvTBL> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/C8kKvTBL>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 160\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/C8kKvTBL>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 160\" .\r\n<https://id.parliament.uk/C8kKvTBL> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"784\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/C8kKvTBL>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 160\" .\r\n<https://id.parliament.uk/C8kKvTBL> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/YX81GShN> .\r\n<https://id.parliament.uk/C8kKvTBL>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/6kgJ0bGh>
+        .\r\n<https://id.parliament.uk/YX81GShN> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/YX81GShN>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-02+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/YX81GShN> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XouN12Ow> .\r\n<https://id.parliament.uk/6kgJ0bGh>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/6kgJ0bGh> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/c0IpQmwt>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/c0IpQmwt> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/c0IpQmwt>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/c0IpQmwt> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 161\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/c0IpQmwt> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 161\" .\r\n<https://id.parliament.uk/c0IpQmwt>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"903\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/c0IpQmwt> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 161\" .\r\n<https://id.parliament.uk/c0IpQmwt>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/ttdjT68P>
+        .\r\n<https://id.parliament.uk/c0IpQmwt> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/G9ni0BQM> .\r\n<https://id.parliament.uk/ttdjT68P>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/ttdjT68P> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-02+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/ttdjT68P>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/7dSvuueH>
+        .\r\n<https://id.parliament.uk/G9ni0BQM> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/G9ni0BQM>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/2KKfR6RI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/2KKfR6RI>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/2KKfR6RI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/2KKfR6RI>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 162\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/2KKfR6RI>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 162\" .\r\n<https://id.parliament.uk/2KKfR6RI> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"786\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/2KKfR6RI>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 162\" .\r\n<https://id.parliament.uk/2KKfR6RI> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/UbCkOSbi> .\r\n<https://id.parliament.uk/2KKfR6RI>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/ZlOeT88V>
+        .\r\n<https://id.parliament.uk/UbCkOSbi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/UbCkOSbi>
+        <https://id.parliament.uk/schema/layingDate> \"2018-06-29+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/UbCkOSbi> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/HYfypSOE> .\r\n<https://id.parliament.uk/ZlOeT88V>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/ZlOeT88V> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/BZPGfEza>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/BZPGfEza> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/BZPGfEza>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/BZPGfEza> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 163\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/BZPGfEza> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 163\" .\r\n<https://id.parliament.uk/BZPGfEza>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"785\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/BZPGfEza> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 163\" .\r\n<https://id.parliament.uk/BZPGfEza>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/ftFuVyQ5>
+        .\r\n<https://id.parliament.uk/BZPGfEza> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/J8EN7E6N> .\r\n<https://id.parliament.uk/ftFuVyQ5>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/ftFuVyQ5> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-02+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/ftFuVyQ5>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/XouN12Ow>
+        .\r\n<https://id.parliament.uk/J8EN7E6N> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/J8EN7E6N>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/JXxhQblu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/JXxhQblu>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/JXxhQblu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/JXxhQblu>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 164\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/JXxhQblu>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 164\" .\r\n<https://id.parliament.uk/JXxhQblu> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"801\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/JXxhQblu>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 164\" .\r\n<https://id.parliament.uk/JXxhQblu> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/Wd3zlHhD> .\r\n<https://id.parliament.uk/JXxhQblu>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/H6mzvSsA>
+        .\r\n<https://id.parliament.uk/Wd3zlHhD> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/Wd3zlHhD>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-03+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/Wd3zlHhD> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/NDZSYjeE> .\r\n<https://id.parliament.uk/H6mzvSsA>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/H6mzvSsA> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/9Brknpn7>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/9Brknpn7> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/9Brknpn7>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/9Brknpn7> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 165\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/9Brknpn7> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 165\" .\r\n<https://id.parliament.uk/9Brknpn7>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"795\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/9Brknpn7> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 165\" .\r\n<https://id.parliament.uk/9Brknpn7>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/VPUSkLJO>
+        .\r\n<https://id.parliament.uk/9Brknpn7> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/D63ld0id> .\r\n<https://id.parliament.uk/VPUSkLJO>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/VPUSkLJO> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-03+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/VPUSkLJO>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/yiuTaSI4>
+        .\r\n<https://id.parliament.uk/D63ld0id> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/D63ld0id>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/IjLgnN8z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/IjLgnN8z>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/IjLgnN8z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/IjLgnN8z>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 166\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/IjLgnN8z>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 166\" .\r\n<https://id.parliament.uk/IjLgnN8z> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"928\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/IjLgnN8z>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 166\" .\r\n<https://id.parliament.uk/IjLgnN8z> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/i4m8WLDM> .\r\n<https://id.parliament.uk/IjLgnN8z>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/Y6qiLSBv>
+        .\r\n<https://id.parliament.uk/i4m8WLDM> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/i4m8WLDM>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-02+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/i4m8WLDM> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/NDZSYjeE> .\r\n<https://id.parliament.uk/Y6qiLSBv>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/Y6qiLSBv> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/1aUCYOe7>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/1aUCYOe7> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/1aUCYOe7>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/1aUCYOe7> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 167\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/1aUCYOe7> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 167\" .\r\n<https://id.parliament.uk/1aUCYOe7>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"803\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/1aUCYOe7> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 167\" .\r\n<https://id.parliament.uk/1aUCYOe7>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/K7jOJhiU>
+        .\r\n<https://id.parliament.uk/1aUCYOe7> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/EayTsjgy> .\r\n<https://id.parliament.uk/K7jOJhiU>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/K7jOJhiU> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-02+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/K7jOJhiU>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/BRTNQywN>
+        .\r\n<https://id.parliament.uk/EayTsjgy> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/EayTsjgy>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/zd4ymhhN> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/zd4ymhhN>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/zd4ymhhN> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/zd4ymhhN>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 168\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/zd4ymhhN>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 168\" .\r\n<https://id.parliament.uk/zd4ymhhN> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"781\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/zd4ymhhN>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 168\" .\r\n<https://id.parliament.uk/zd4ymhhN> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/HIYdvdKZ> .\r\n<https://id.parliament.uk/zd4ymhhN>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/vdPBBc3g>
+        .\r\n<https://id.parliament.uk/HIYdvdKZ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/HIYdvdKZ>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/HIYdvdKZ> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/yiuTaSI4> .\r\n<https://id.parliament.uk/vdPBBc3g>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/vdPBBc3g> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/MIqYKT1i>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/MIqYKT1i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/MIqYKT1i>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/MIqYKT1i> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 169\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/MIqYKT1i> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 169\" .\r\n<https://id.parliament.uk/MIqYKT1i>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"812\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/MIqYKT1i> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 169\" .\r\n<https://id.parliament.uk/MIqYKT1i>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/Boe0Cd42>
+        .\r\n<https://id.parliament.uk/MIqYKT1i> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/TUVPHf9x> .\r\n<https://id.parliament.uk/Boe0Cd42>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/Boe0Cd42> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/Boe0Cd42>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/BRTNQywN>
+        .\r\n<https://id.parliament.uk/TUVPHf9x> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/TUVPHf9x>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/YhwigIF6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/YhwigIF6>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/YhwigIF6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/YhwigIF6>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 170\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/YhwigIF6>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 170\" .\r\n<https://id.parliament.uk/YhwigIF6> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"0\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/YhwigIF6>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 170\" .\r\n<https://id.parliament.uk/YhwigIF6> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/g01JvVJo> .\r\n<https://id.parliament.uk/YhwigIF6>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/PnLLjtW0>
+        .\r\n<https://id.parliament.uk/g01JvVJo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/g01JvVJo>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/g01JvVJo> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/yiuTaSI4> .\r\n<https://id.parliament.uk/PnLLjtW0>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/PnLLjtW0> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/SUtuR6qs>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/SUtuR6qs> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/SUtuR6qs>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/SUtuR6qs> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 171\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/SUtuR6qs> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 171\" .\r\n<https://id.parliament.uk/SUtuR6qs>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"780\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/SUtuR6qs> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 171\" .\r\n<https://id.parliament.uk/SUtuR6qs>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/DTIQmiVQ>
+        .\r\n<https://id.parliament.uk/SUtuR6qs> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/UNTY7PNO> .\r\n<https://id.parliament.uk/DTIQmiVQ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/DTIQmiVQ> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/DTIQmiVQ>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/JVJB3tuB>
+        .\r\n<https://id.parliament.uk/UNTY7PNO> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/UNTY7PNO>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/UBL9i00X> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/UBL9i00X>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/UBL9i00X> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/UBL9i00X>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 172\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/UBL9i00X>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 172\" .\r\n<https://id.parliament.uk/UBL9i00X> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"810\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/UBL9i00X>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 172\" .\r\n<https://id.parliament.uk/UBL9i00X> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/lenIZKiU> .\r\n<https://id.parliament.uk/UBL9i00X>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/42YVAgkz>
+        .\r\n<https://id.parliament.uk/lenIZKiU> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/lenIZKiU>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-06+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/lenIZKiU> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/7dSvuueH> .\r\n<https://id.parliament.uk/42YVAgkz>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/42YVAgkz> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/KF90wtY4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/KF90wtY4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/KF90wtY4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/KF90wtY4> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 173\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/KF90wtY4> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 173\" .\r\n<https://id.parliament.uk/KF90wtY4>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"816\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/KF90wtY4> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 173\" .\r\n<https://id.parliament.uk/KF90wtY4>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/AWsJmRFZ>
+        .\r\n<https://id.parliament.uk/KF90wtY4> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/gfOq850z> .\r\n<https://id.parliament.uk/AWsJmRFZ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/AWsJmRFZ> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-09+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/AWsJmRFZ>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/XouN12Ow>
+        .\r\n<https://id.parliament.uk/gfOq850z> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/gfOq850z>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/gcbZWM8q> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/gcbZWM8q>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/gcbZWM8q> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/gcbZWM8q>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 174\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/gcbZWM8q>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 174\" .\r\n<https://id.parliament.uk/gcbZWM8q> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"0\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/gcbZWM8q>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 174\" .\r\n<https://id.parliament.uk/gcbZWM8q> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/5wkrOAtY> .\r\n<https://id.parliament.uk/gcbZWM8q>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/PIfP18CQ>
+        .\r\n<https://id.parliament.uk/5wkrOAtY> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/5wkrOAtY>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-10+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/5wkrOAtY> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fpWTqVKh> .\r\n<https://id.parliament.uk/PIfP18CQ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/PIfP18CQ> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/Hw2xKRsZ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/Hw2xKRsZ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/Hw2xKRsZ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/Hw2xKRsZ> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 175\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/Hw2xKRsZ> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 175\" .\r\n<https://id.parliament.uk/Hw2xKRsZ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"825\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/Hw2xKRsZ> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 175\" .\r\n<https://id.parliament.uk/Hw2xKRsZ>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/GB5n2CDh>
+        .\r\n<https://id.parliament.uk/Hw2xKRsZ> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/mnCKpXns> .\r\n<https://id.parliament.uk/GB5n2CDh>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/GB5n2CDh> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-10+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/GB5n2CDh>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/yiuTaSI4>
+        .\r\n<https://id.parliament.uk/mnCKpXns> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/mnCKpXns>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/vUb6Fcnn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/vUb6Fcnn>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/vUb6Fcnn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/vUb6Fcnn>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 176\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/vUb6Fcnn>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 176\" .\r\n<https://id.parliament.uk/vUb6Fcnn> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"833\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/vUb6Fcnn>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 176\" .\r\n<https://id.parliament.uk/vUb6Fcnn> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/Wu1mmRM1> .\r\n<https://id.parliament.uk/vUb6Fcnn>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/H0wSQ5qG>
+        .\r\n<https://id.parliament.uk/Wu1mmRM1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/Wu1mmRM1>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-12+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/Wu1mmRM1> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/HYfypSOE> .\r\n<https://id.parliament.uk/H0wSQ5qG>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/H0wSQ5qG> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/BRZBy463>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/BRZBy463> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/BRZBy463>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/BRZBy463> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 177\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/BRZBy463> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 177\" .\r\n<https://id.parliament.uk/BRZBy463>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"0\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/BRZBy463> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 177\" .\r\n<https://id.parliament.uk/BRZBy463>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/JBIhn7el>
+        .\r\n<https://id.parliament.uk/BRZBy463> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/FKyIv1xY> .\r\n<https://id.parliament.uk/JBIhn7el>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/JBIhn7el> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-12+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/JBIhn7el>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/NDZSYjeE>
+        .\r\n<https://id.parliament.uk/FKyIv1xY> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/FKyIv1xY>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/bYMAmxYQ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/bYMAmxYQ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/bYMAmxYQ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/bYMAmxYQ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 178\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/bYMAmxYQ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 178\" .\r\n<https://id.parliament.uk/bYMAmxYQ> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"827\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/bYMAmxYQ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 178\" .\r\n<https://id.parliament.uk/bYMAmxYQ> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/Wna4PL6v> .\r\n<https://id.parliament.uk/bYMAmxYQ>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/K4kH9tSl>
+        .\r\n<https://id.parliament.uk/Wna4PL6v> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/Wna4PL6v>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-12+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/Wna4PL6v> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fKqMNz79> .\r\n<https://id.parliament.uk/K4kH9tSl>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/K4kH9tSl> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/cXKDMYqV>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/cXKDMYqV> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/cXKDMYqV>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/cXKDMYqV> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 179\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/cXKDMYqV> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 179\" .\r\n<https://id.parliament.uk/cXKDMYqV>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"834\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/cXKDMYqV> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 179\" .\r\n<https://id.parliament.uk/cXKDMYqV>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/N5MVHv16>
+        .\r\n<https://id.parliament.uk/cXKDMYqV> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/nns38yQv> .\r\n<https://id.parliament.uk/N5MVHv16>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/N5MVHv16> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-12+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/N5MVHv16>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/yiuTaSI4>
+        .\r\n<https://id.parliament.uk/nns38yQv> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/nns38yQv>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/cDVVk8C2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/cDVVk8C2>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/cDVVk8C2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/cDVVk8C2>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 180\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/cDVVk8C2>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 180\" .\r\n<https://id.parliament.uk/cDVVk8C2> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"0\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/cDVVk8C2>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 180\" .\r\n<https://id.parliament.uk/cDVVk8C2> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/KLBRomRn> .\r\n<https://id.parliament.uk/cDVVk8C2>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/38oel2on>
+        .\r\n<https://id.parliament.uk/KLBRomRn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/KLBRomRn>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-12+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/KLBRomRn> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XbTBTDMo> .\r\n<https://id.parliament.uk/38oel2on>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/38oel2on> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/JHmYoIfJ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/JHmYoIfJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/JHmYoIfJ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/JHmYoIfJ> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 181\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/JHmYoIfJ> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 181\" .\r\n<https://id.parliament.uk/JHmYoIfJ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"852\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/JHmYoIfJ> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 181\" .\r\n<https://id.parliament.uk/JHmYoIfJ>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/LwHhcLOH>
+        .\r\n<https://id.parliament.uk/JHmYoIfJ> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/6OQ1w3DW> .\r\n<https://id.parliament.uk/LwHhcLOH>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/LwHhcLOH> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-16+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/LwHhcLOH>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/7gnSwbLO>
+        .\r\n<https://id.parliament.uk/6OQ1w3DW> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/6OQ1w3DW>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/55gPdheg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/55gPdheg>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/55gPdheg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/55gPdheg>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 182\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/55gPdheg>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 182\" .\r\n<https://id.parliament.uk/55gPdheg> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"819\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/55gPdheg>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 182\" .\r\n<https://id.parliament.uk/55gPdheg> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/9T8nEUBG> .\r\n<https://id.parliament.uk/55gPdheg>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/2587nSWp>
+        .\r\n<https://id.parliament.uk/9T8nEUBG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/9T8nEUBG>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-13+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/9T8nEUBG> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XouN12Ow> .\r\n<https://id.parliament.uk/2587nSWp>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/2587nSWp> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/qSs9kGvu>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/qSs9kGvu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/qSs9kGvu>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/qSs9kGvu> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 183\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/qSs9kGvu> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 183\" .\r\n<https://id.parliament.uk/qSs9kGvu>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"844\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/qSs9kGvu> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 183\" .\r\n<https://id.parliament.uk/qSs9kGvu>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/wNIEHC5o>
+        .\r\n<https://id.parliament.uk/qSs9kGvu> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/gyec2cjN> .\r\n<https://id.parliament.uk/wNIEHC5o>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/wNIEHC5o> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-16+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/wNIEHC5o>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/fpWTqVKh>
+        .\r\n<https://id.parliament.uk/gyec2cjN> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/gyec2cjN>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/QsAJ99E3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/QsAJ99E3>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/QsAJ99E3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/QsAJ99E3>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 184\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/QsAJ99E3>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 184\" .\r\n<https://id.parliament.uk/QsAJ99E3> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"850\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/QsAJ99E3>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 184\" .\r\n<https://id.parliament.uk/QsAJ99E3> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/BFTcwmEt> .\r\n<https://id.parliament.uk/QsAJ99E3>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/mA0R8oxO>
+        .\r\n<https://id.parliament.uk/BFTcwmEt> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/BFTcwmEt>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-16+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/BFTcwmEt> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/5LQ5Ar74> .\r\n<https://id.parliament.uk/mA0R8oxO>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/mA0R8oxO> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/wIlQG2bb>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/wIlQG2bb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/wIlQG2bb>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/wIlQG2bb> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 185\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/wIlQG2bb> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 185\" .\r\n<https://id.parliament.uk/wIlQG2bb>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"0\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/wIlQG2bb> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 185\" .\r\n<https://id.parliament.uk/wIlQG2bb>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/EqDEAgrl>
+        .\r\n<https://id.parliament.uk/wIlQG2bb> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/RvO51D8Y> .\r\n<https://id.parliament.uk/EqDEAgrl>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/EqDEAgrl> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-16+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/EqDEAgrl>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/HYfypSOE>
+        .\r\n<https://id.parliament.uk/RvO51D8Y> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/RvO51D8Y>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/Qeou2KIY> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/Qeou2KIY>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/Qeou2KIY> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/Qeou2KIY>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 186\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/Qeou2KIY>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 186\" .\r\n<https://id.parliament.uk/Qeou2KIY> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"849\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/Qeou2KIY>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 186\" .\r\n<https://id.parliament.uk/Qeou2KIY> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/Es4s1iwT> .\r\n<https://id.parliament.uk/Qeou2KIY>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/alYVrL7p>
+        .\r\n<https://id.parliament.uk/Es4s1iwT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/Es4s1iwT>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-16+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/Es4s1iwT> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/5LQ5Ar74> .\r\n<https://id.parliament.uk/alYVrL7p>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/alYVrL7p> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/ySndNUxm>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/ySndNUxm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/ySndNUxm>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/ySndNUxm> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 187\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/ySndNUxm> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 187\" .\r\n<https://id.parliament.uk/ySndNUxm>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"847\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/ySndNUxm> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 187\" .\r\n<https://id.parliament.uk/ySndNUxm>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/dAvXzDoh>
+        .\r\n<https://id.parliament.uk/ySndNUxm> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/Jqw7AKcM> .\r\n<https://id.parliament.uk/dAvXzDoh>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/dAvXzDoh> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-16+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/dAvXzDoh>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/BRTNQywN>
+        .\r\n<https://id.parliament.uk/Jqw7AKcM> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/Jqw7AKcM>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/zVuPoOWp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/zVuPoOWp>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/zVuPoOWp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/zVuPoOWp>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 188\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/zVuPoOWp>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 188\" .\r\n<https://id.parliament.uk/zVuPoOWp> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"858\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/zVuPoOWp>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 188\" .\r\n<https://id.parliament.uk/zVuPoOWp> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/JRyvYZXd> .\r\n<https://id.parliament.uk/zVuPoOWp>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/8zjP35K1>
+        .\r\n<https://id.parliament.uk/JRyvYZXd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/JRyvYZXd>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-17+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/JRyvYZXd> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/HYfypSOE> .\r\n<https://id.parliament.uk/8zjP35K1>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/8zjP35K1> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/DS1GQhA5>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/DS1GQhA5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/DS1GQhA5>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/DS1GQhA5> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 189\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/DS1GQhA5> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 189\" .\r\n<https://id.parliament.uk/DS1GQhA5>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"0\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/DS1GQhA5> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 189\" .\r\n<https://id.parliament.uk/DS1GQhA5>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/0oJHqI9L>
+        .\r\n<https://id.parliament.uk/DS1GQhA5> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/xVDuhFhy> .\r\n<https://id.parliament.uk/0oJHqI9L>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/0oJHqI9L> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-18+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/0oJHqI9L>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/yiuTaSI4>
+        .\r\n<https://id.parliament.uk/xVDuhFhy> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/xVDuhFhy>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/m6w1ruLC> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/m6w1ruLC>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/m6w1ruLC> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/m6w1ruLC>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 190\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/m6w1ruLC>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 190\" .\r\n<https://id.parliament.uk/m6w1ruLC> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"0\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/m6w1ruLC>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 190\" .\r\n<https://id.parliament.uk/m6w1ruLC> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/bWBbaJiz> .\r\n<https://id.parliament.uk/m6w1ruLC>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/k2fiopk4>
+        .\r\n<https://id.parliament.uk/bWBbaJiz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/bWBbaJiz>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-18+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/bWBbaJiz> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/DkHdH4kZ> .\r\n<https://id.parliament.uk/k2fiopk4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/k2fiopk4> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/VXLHPnoP>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/VXLHPnoP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/VXLHPnoP>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/VXLHPnoP> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 191\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/VXLHPnoP> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 191\" .\r\n<https://id.parliament.uk/VXLHPnoP>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"841\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/VXLHPnoP> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 191\" .\r\n<https://id.parliament.uk/VXLHPnoP>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/z1cXXUlX>
+        .\r\n<https://id.parliament.uk/VXLHPnoP> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/WNbpxbb2> .\r\n<https://id.parliament.uk/z1cXXUlX>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/z1cXXUlX> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-18+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/z1cXXUlX>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/JVJB3tuB>
+        .\r\n<https://id.parliament.uk/WNbpxbb2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/WNbpxbb2>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/uPVA7EvA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/uPVA7EvA>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/uPVA7EvA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/uPVA7EvA>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 192\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/uPVA7EvA>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 192\" .\r\n<https://id.parliament.uk/uPVA7EvA> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"0\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/uPVA7EvA>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 192\" .\r\n<https://id.parliament.uk/uPVA7EvA> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/2Xu3cFqr> .\r\n<https://id.parliament.uk/uPVA7EvA>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/skuLtkzM>
+        .\r\n<https://id.parliament.uk/2Xu3cFqr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/2Xu3cFqr>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-19+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/2Xu3cFqr> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/ni8aOEk3> .\r\n<https://id.parliament.uk/skuLtkzM>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/skuLtkzM> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/Uhsvsfdn>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/Uhsvsfdn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/Uhsvsfdn>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/Uhsvsfdn> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 193\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/Uhsvsfdn> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 193\" .\r\n<https://id.parliament.uk/Uhsvsfdn>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"851\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/Uhsvsfdn> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 193\" .\r\n<https://id.parliament.uk/Uhsvsfdn>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/MAHrwKV2>
+        .\r\n<https://id.parliament.uk/Uhsvsfdn> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/RxC0FtSg> .\r\n<https://id.parliament.uk/MAHrwKV2>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/MAHrwKV2> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-19+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/MAHrwKV2>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/NDZSYjeE>
+        .\r\n<https://id.parliament.uk/RxC0FtSg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/RxC0FtSg>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/QI5WArIQ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/QI5WArIQ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/QI5WArIQ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/QI5WArIQ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 194\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/QI5WArIQ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 194\" .\r\n<https://id.parliament.uk/QI5WArIQ> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"0\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/QI5WArIQ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 194\" .\r\n<https://id.parliament.uk/QI5WArIQ> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/FDFI2J2G> .\r\n<https://id.parliament.uk/QI5WArIQ>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/bm6TrRXM>
+        .\r\n<https://id.parliament.uk/FDFI2J2G> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/FDFI2J2G>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-19+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/FDFI2J2G> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XouN12Ow> .\r\n<https://id.parliament.uk/bm6TrRXM>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/bm6TrRXM> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/a8wT3ym2>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/a8wT3ym2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/a8wT3ym2>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/a8wT3ym2> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 195\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/a8wT3ym2> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 195\" .\r\n<https://id.parliament.uk/a8wT3ym2>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"869\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/a8wT3ym2> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 195\" .\r\n<https://id.parliament.uk/a8wT3ym2>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/FzvGkYUO>
+        .\r\n<https://id.parliament.uk/a8wT3ym2> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/aU26TzPE> .\r\n<https://id.parliament.uk/FzvGkYUO>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/FzvGkYUO> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-19+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/FzvGkYUO>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/ZU3IXBtP>
+        .\r\n<https://id.parliament.uk/aU26TzPE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/aU26TzPE>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/M3L8iguJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/M3L8iguJ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/M3L8iguJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/M3L8iguJ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 196\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/M3L8iguJ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 196\" .\r\n<https://id.parliament.uk/M3L8iguJ> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"866\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/M3L8iguJ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 196\" .\r\n<https://id.parliament.uk/M3L8iguJ> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/TGtwlRb9> .\r\n<https://id.parliament.uk/M3L8iguJ>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/Foc4rbD1>
+        .\r\n<https://id.parliament.uk/TGtwlRb9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/TGtwlRb9>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-19+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/TGtwlRb9> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/79sn5e3n> .\r\n<https://id.parliament.uk/Foc4rbD1>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/Foc4rbD1> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/EqisWZtW>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/EqisWZtW> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/EqisWZtW>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/EqisWZtW> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 197\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/EqisWZtW> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 197\" .\r\n<https://id.parliament.uk/EqisWZtW>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"872\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/EqisWZtW> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 197\" .\r\n<https://id.parliament.uk/EqisWZtW>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/mpHFbBPU>
+        .\r\n<https://id.parliament.uk/EqisWZtW> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/hAmklf7q> .\r\n<https://id.parliament.uk/mpHFbBPU>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/mpHFbBPU> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-19+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/mpHFbBPU>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/nFL8Pq3e>
+        .\r\n<https://id.parliament.uk/hAmklf7q> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/hAmklf7q>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/BP4IoUgX> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/BP4IoUgX>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/BP4IoUgX> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/BP4IoUgX>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 198\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/BP4IoUgX>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 198\" .\r\n<https://id.parliament.uk/BP4IoUgX> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"861\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/BP4IoUgX>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 198\" .\r\n<https://id.parliament.uk/BP4IoUgX> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/rflh2rcM> .\r\n<https://id.parliament.uk/BP4IoUgX>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/8vXQJ2xK>
+        .\r\n<https://id.parliament.uk/rflh2rcM> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/rflh2rcM>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-18+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/rflh2rcM> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/HYfypSOE> .\r\n<https://id.parliament.uk/8vXQJ2xK>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/8vXQJ2xK> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/xItHTyZP>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/xItHTyZP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/xItHTyZP>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/xItHTyZP> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 199\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/xItHTyZP> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 199\" .\r\n<https://id.parliament.uk/xItHTyZP>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"0\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/xItHTyZP> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 199\" .\r\n<https://id.parliament.uk/xItHTyZP>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/sK45Ez26>
+        .\r\n<https://id.parliament.uk/xItHTyZP> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/nUXQzBUI> .\r\n<https://id.parliament.uk/sK45Ez26>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/sK45Ez26> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-19+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/sK45Ez26>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/KSMOf7aM>
+        .\r\n<https://id.parliament.uk/KSMOf7aM> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Group> .\r\n<https://id.parliament.uk/KSMOf7aM>
+        <https://id.parliament.uk/schema/groupName> \"groupName - 22\" .\r\n<https://id.parliament.uk/nUXQzBUI>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/nUXQzBUI> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/pyflzxxb>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/pyflzxxb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/pyflzxxb>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/pyflzxxb> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 200\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/pyflzxxb> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 200\" .\r\n<https://id.parliament.uk/pyflzxxb>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"0\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/pyflzxxb> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 200\" .\r\n<https://id.parliament.uk/pyflzxxb>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/QfOk6t8o>
+        .\r\n<https://id.parliament.uk/pyflzxxb> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/fYStL7le> .\r\n<https://id.parliament.uk/QfOk6t8o>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/QfOk6t8o> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-19+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/QfOk6t8o>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/yiuTaSI4>
+        .\r\n<https://id.parliament.uk/fYStL7le> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/fYStL7le>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/bnrksmBb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/bnrksmBb>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/bnrksmBb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/bnrksmBb>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 201\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/bnrksmBb>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 201\" .\r\n<https://id.parliament.uk/bnrksmBb> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"0\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/bnrksmBb>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 201\" .\r\n<https://id.parliament.uk/bnrksmBb> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/FqjhORVJ> .\r\n<https://id.parliament.uk/bnrksmBb>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/eWrOts77>
+        .\r\n<https://id.parliament.uk/FqjhORVJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/FqjhORVJ>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-19+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/FqjhORVJ> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/HYfypSOE> .\r\n<https://id.parliament.uk/eWrOts77>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/eWrOts77> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/ORfYwwEX>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/ORfYwwEX> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/ORfYwwEX>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/ORfYwwEX> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 202\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/ORfYwwEX> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 202\" .\r\n<https://id.parliament.uk/ORfYwwEX>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"0\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/ORfYwwEX> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 202\" .\r\n<https://id.parliament.uk/ORfYwwEX>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/jg2LgPjI>
+        .\r\n<https://id.parliament.uk/ORfYwwEX> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/NHkRuD74> .\r\n<https://id.parliament.uk/jg2LgPjI>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/jg2LgPjI> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-19+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/jg2LgPjI>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/fpWTqVKh>
+        .\r\n<https://id.parliament.uk/NHkRuD74> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/NHkRuD74>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/SbxmGLcR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/SbxmGLcR>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/SbxmGLcR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/SbxmGLcR>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 203\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/SbxmGLcR>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 203\" .\r\n<https://id.parliament.uk/SbxmGLcR> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"875\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/SbxmGLcR>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 203\" .\r\n<https://id.parliament.uk/SbxmGLcR> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/vAu6L0Zc> .\r\n<https://id.parliament.uk/SbxmGLcR>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/eqBIsv19>
+        .\r\n<https://id.parliament.uk/vAu6L0Zc> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/vAu6L0Zc>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-20+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/vAu6L0Zc> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/NDZSYjeE> .\r\n<https://id.parliament.uk/eqBIsv19>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/eqBIsv19> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/dHwDR0Xw>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/dHwDR0Xw> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/dHwDR0Xw>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/dHwDR0Xw> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 204\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/dHwDR0Xw> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 204\" .\r\n<https://id.parliament.uk/dHwDR0Xw>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"0\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/dHwDR0Xw> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 204\" .\r\n<https://id.parliament.uk/dHwDR0Xw>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/D8EFDOPR>
+        .\r\n<https://id.parliament.uk/dHwDR0Xw> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/FJdkYpZ5> .\r\n<https://id.parliament.uk/D8EFDOPR>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/D8EFDOPR> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/D8EFDOPR>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/7dSvuueH>
+        .\r\n<https://id.parliament.uk/FJdkYpZ5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/FJdkYpZ5>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/ePPVgmgN> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/ePPVgmgN>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/ePPVgmgN> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/ePPVgmgN>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 205\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/ePPVgmgN>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 205\" .\r\n<https://id.parliament.uk/ePPVgmgN> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"0\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/ePPVgmgN>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 205\" .\r\n<https://id.parliament.uk/ePPVgmgN> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/72UR3b5X> .\r\n<https://id.parliament.uk/ePPVgmgN>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/RTAa8Xxs>
+        .\r\n<https://id.parliament.uk/72UR3b5X> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/72UR3b5X>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/72UR3b5X> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XouN12Ow> .\r\n<https://id.parliament.uk/RTAa8Xxs>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/RTAa8Xxs> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/qRweamaE>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/qRweamaE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/qRweamaE>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/qRweamaE> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 206\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/qRweamaE> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 206\" .\r\n<https://id.parliament.uk/qRweamaE>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"0\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/qRweamaE> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 206\" .\r\n<https://id.parliament.uk/qRweamaE>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/Bc9nWfWq>
+        .\r\n<https://id.parliament.uk/qRweamaE> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/DdWTiUjw> .\r\n<https://id.parliament.uk/Bc9nWfWq>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/Bc9nWfWq> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/Bc9nWfWq>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/XouN12Ow>
+        .\r\n<https://id.parliament.uk/DdWTiUjw> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/DdWTiUjw>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/zRBB7JhE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/zRBB7JhE>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/zRBB7JhE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/zRBB7JhE>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 207\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/zRBB7JhE>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 207\" .\r\n<https://id.parliament.uk/zRBB7JhE> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"0\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/zRBB7JhE>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 207\" .\r\n<https://id.parliament.uk/zRBB7JhE> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/AP8xkl7P> .\r\n<https://id.parliament.uk/zRBB7JhE>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/rDRNBssE>
+        .\r\n<https://id.parliament.uk/AP8xkl7P> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/AP8xkl7P>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/AP8xkl7P> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/7dSvuueH> .\r\n<https://id.parliament.uk/rDRNBssE>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/rDRNBssE> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/pg1MaN6V>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/pg1MaN6V> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/pg1MaN6V>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/pg1MaN6V> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 208\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/pg1MaN6V> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 208\" .\r\n<https://id.parliament.uk/pg1MaN6V>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"0\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/pg1MaN6V> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 208\" .\r\n<https://id.parliament.uk/pg1MaN6V>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/evLLP3No>
+        .\r\n<https://id.parliament.uk/pg1MaN6V> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/P3nQG8UQ> .\r\n<https://id.parliament.uk/evLLP3No>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/evLLP3No> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/evLLP3No>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/KSMOf7aM>
+        .\r\n<https://id.parliament.uk/P3nQG8UQ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/P3nQG8UQ>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/j0R3vR5s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/j0R3vR5s>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/j0R3vR5s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/j0R3vR5s>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 209\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/j0R3vR5s>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 209\" .\r\n<https://id.parliament.uk/j0R3vR5s> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"0\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/j0R3vR5s>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 209\" .\r\n<https://id.parliament.uk/j0R3vR5s> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/XEGCwVKv> .\r\n<https://id.parliament.uk/j0R3vR5s>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/83lMBlLs>
+        .\r\n<https://id.parliament.uk/XEGCwVKv> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/XEGCwVKv>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/XEGCwVKv> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/7dSvuueH> .\r\n<https://id.parliament.uk/83lMBlLs>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/83lMBlLs> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/xRUG9ARI>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/xRUG9ARI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/xRUG9ARI>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/xRUG9ARI> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 210\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/xRUG9ARI> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 210\" .\r\n<https://id.parliament.uk/xRUG9ARI>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"0\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/xRUG9ARI> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 210\" .\r\n<https://id.parliament.uk/xRUG9ARI>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/7tpTjp7H>
+        .\r\n<https://id.parliament.uk/xRUG9ARI> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/Elsc9n58> .\r\n<https://id.parliament.uk/7tpTjp7H>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/7tpTjp7H> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/7tpTjp7H>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/7dSvuueH>
+        .\r\n<https://id.parliament.uk/Elsc9n58> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/Elsc9n58>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/DVgODdNe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/DVgODdNe>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/DVgODdNe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/DVgODdNe>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 211\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/DVgODdNe>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 211\" .\r\n<https://id.parliament.uk/DVgODdNe> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"0\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/DVgODdNe>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 211\" .\r\n<https://id.parliament.uk/DVgODdNe> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/jnt1PLtp> .\r\n<https://id.parliament.uk/DVgODdNe>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/h5Fp2H9d>
+        .\r\n<https://id.parliament.uk/jnt1PLtp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/jnt1PLtp>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/jnt1PLtp> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/7dSvuueH> .\r\n<https://id.parliament.uk/h5Fp2H9d>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/h5Fp2H9d> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/2JipSGt3>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/2JipSGt3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/2JipSGt3>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/2JipSGt3> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 212\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/2JipSGt3> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 212\" .\r\n<https://id.parliament.uk/2JipSGt3>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"0\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/2JipSGt3> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 212\" .\r\n<https://id.parliament.uk/2JipSGt3>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/SOGo1tod>
+        .\r\n<https://id.parliament.uk/2JipSGt3> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/AFYBjHvC> .\r\n<https://id.parliament.uk/SOGo1tod>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/SOGo1tod> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/SOGo1tod>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/7dSvuueH>
+        .\r\n<https://id.parliament.uk/AFYBjHvC> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/AFYBjHvC>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/YdIWHZS3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/YdIWHZS3>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/YdIWHZS3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/YdIWHZS3>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 213\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/YdIWHZS3>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 213\" .\r\n<https://id.parliament.uk/YdIWHZS3> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"874\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/YdIWHZS3>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 213\" .\r\n<https://id.parliament.uk/YdIWHZS3> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/WwdgeYfb> .\r\n<https://id.parliament.uk/YdIWHZS3>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/oLsZBZZy>
+        .\r\n<https://id.parliament.uk/WwdgeYfb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/WwdgeYfb>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/WwdgeYfb> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XouN12Ow> .\r\n<https://id.parliament.uk/oLsZBZZy>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/oLsZBZZy> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/I22Wlejq>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/I22Wlejq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/I22Wlejq>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/I22Wlejq> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 214\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/I22Wlejq> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 214\" .\r\n<https://id.parliament.uk/I22Wlejq>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 214\" .\r\n<https://id.parliament.uk/I22Wlejq> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/s2yCncQX> .\r\n<https://id.parliament.uk/I22Wlejq>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/BOeaxUck>
+        .\r\n<https://id.parliament.uk/s2yCncQX> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/s2yCncQX>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-24+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/s2yCncQX> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fKqMNz79> .\r\n<https://id.parliament.uk/BOeaxUck>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/BOeaxUck> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/uIHeCzNz>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/uIHeCzNz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/uIHeCzNz>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/uIHeCzNz> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 215\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/uIHeCzNz> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 215\" .\r\n<https://id.parliament.uk/uIHeCzNz>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 215\" .\r\n<https://id.parliament.uk/uIHeCzNz> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/QbhSYBUT> .\r\n<https://id.parliament.uk/uIHeCzNz>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/a5kzSCS7>
+        .\r\n<https://id.parliament.uk/QbhSYBUT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/QbhSYBUT>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-24+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/QbhSYBUT> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/DkHdH4kZ> .\r\n<https://id.parliament.uk/a5kzSCS7>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/a5kzSCS7> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/tlSbgoyG>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/tlSbgoyG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/tlSbgoyG>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/tlSbgoyG> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 216\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/tlSbgoyG> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 216\" .\r\n<https://id.parliament.uk/tlSbgoyG>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"894\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/tlSbgoyG> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 216\" .\r\n<https://id.parliament.uk/tlSbgoyG>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/OKImXzFs>
+        .\r\n<https://id.parliament.uk/tlSbgoyG> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/1wA2fFJh> .\r\n<https://id.parliament.uk/OKImXzFs>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/OKImXzFs> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-24+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/OKImXzFs>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/ni8aOEk3>
+        .\r\n<https://id.parliament.uk/1wA2fFJh> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/1wA2fFJh>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/3Iw5OmCs> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/3Iw5OmCs>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/3Iw5OmCs> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/3Iw5OmCs>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 217\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/3Iw5OmCs>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 217\" .\r\n<https://id.parliament.uk/3Iw5OmCs> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 217\" .\r\n<https://id.parliament.uk/3Iw5OmCs>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/nHmQ7MZc>
+        .\r\n<https://id.parliament.uk/3Iw5OmCs> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/cDVt360N> .\r\n<https://id.parliament.uk/nHmQ7MZc>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/nHmQ7MZc> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-24+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/nHmQ7MZc>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/HYfypSOE>
+        .\r\n<https://id.parliament.uk/cDVt360N> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/cDVt360N>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/zo2QN0LF> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/zo2QN0LF>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/zo2QN0LF> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/zo2QN0LF>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 218\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/zo2QN0LF>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 218\" .\r\n<https://id.parliament.uk/zo2QN0LF> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 218\" .\r\n<https://id.parliament.uk/zo2QN0LF>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/JZZ4q14z>
+        .\r\n<https://id.parliament.uk/zo2QN0LF> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/YffANOfi> .\r\n<https://id.parliament.uk/JZZ4q14z>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/JZZ4q14z> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-24+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/JZZ4q14z>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/eup4DwE5>
+        .\r\n<https://id.parliament.uk/YffANOfi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/YffANOfi>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/gTgidljI>
+        .\r\n<https://id.parliament.uk/3ovJSqCK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/3ovJSqCK>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/3ovJSqCK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/3ovJSqCK>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 219\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/3ovJSqCK>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 219\" .\r\n<https://id.parliament.uk/3ovJSqCK> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 219\" .\r\n<https://id.parliament.uk/3ovJSqCK>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/ufUDatXl>
+        .\r\n<https://id.parliament.uk/3ovJSqCK> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/msKM10hC> .\r\n<https://id.parliament.uk/ufUDatXl>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/ufUDatXl> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-24+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/ufUDatXl>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/eup4DwE5>
+        .\r\n<https://id.parliament.uk/msKM10hC> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/msKM10hC>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/gTgidljI>
+        .\r\n<https://id.parliament.uk/URYwfkWz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/URYwfkWz>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/URYwfkWz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/URYwfkWz>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 220\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/URYwfkWz>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 220\" .\r\n<https://id.parliament.uk/URYwfkWz> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 220\" .\r\n<https://id.parliament.uk/URYwfkWz>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/FK5c5p1r>
+        .\r\n<https://id.parliament.uk/URYwfkWz> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/YZVMPIjK> .\r\n<https://id.parliament.uk/FK5c5p1r>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/FK5c5p1r> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-24+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/FK5c5p1r>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/eup4DwE5>
+        .\r\n<https://id.parliament.uk/YZVMPIjK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/YZVMPIjK>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/gTgidljI>
+        .\r\n<https://id.parliament.uk/KKMVpl6g> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/KKMVpl6g>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/KKMVpl6g> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/KKMVpl6g>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 221\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/KKMVpl6g>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 221\" .\r\n<https://id.parliament.uk/KKMVpl6g> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"901\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/KKMVpl6g>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 221\" .\r\n<https://id.parliament.uk/KKMVpl6g> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/1ZRRE2Ea> .\r\n<https://id.parliament.uk/KKMVpl6g>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/MQChNjSY>
+        .\r\n<https://id.parliament.uk/1ZRRE2Ea> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/1ZRRE2Ea>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-26+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/1ZRRE2Ea> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/7dSvuueH> .\r\n<https://id.parliament.uk/MQChNjSY>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/MQChNjSY> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/hLF7ZU6f>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/hLF7ZU6f> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/hLF7ZU6f>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/hLF7ZU6f> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 222\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/hLF7ZU6f> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 222\" .\r\n<https://id.parliament.uk/hLF7ZU6f>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"902\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/hLF7ZU6f> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 222\" .\r\n<https://id.parliament.uk/hLF7ZU6f>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/biZLgqIV>
+        .\r\n<https://id.parliament.uk/hLF7ZU6f> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/lZwrpAHu> .\r\n<https://id.parliament.uk/biZLgqIV>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/biZLgqIV> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-26+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/biZLgqIV>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/NDZSYjeE>
+        .\r\n<https://id.parliament.uk/lZwrpAHu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/lZwrpAHu>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/MyKmEbhB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/MyKmEbhB>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/MyKmEbhB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/MyKmEbhB>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 223\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/MyKmEbhB>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 223\" .\r\n<https://id.parliament.uk/MyKmEbhB> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"910\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/MyKmEbhB>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 223\" .\r\n<https://id.parliament.uk/MyKmEbhB> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/heXs0Wrz> .\r\n<https://id.parliament.uk/MyKmEbhB>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/sOWsIoTo>
+        .\r\n<https://id.parliament.uk/heXs0Wrz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/heXs0Wrz>
+        <https://id.parliament.uk/schema/layingDate> \"2018-07-30+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/heXs0Wrz> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/5LQ5Ar74> .\r\n<https://id.parliament.uk/sOWsIoTo>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/sOWsIoTo> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/hNYeAr2M>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/hNYeAr2M> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/hNYeAr2M>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/hNYeAr2M> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 224\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/hNYeAr2M> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 224\" .\r\n<https://id.parliament.uk/hNYeAr2M>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"908\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/hNYeAr2M> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 224\" .\r\n<https://id.parliament.uk/hNYeAr2M>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/1ZEDgLFK>
+        .\r\n<https://id.parliament.uk/hNYeAr2M> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/wpuFhzm5> .\r\n<https://id.parliament.uk/1ZEDgLFK>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/1ZEDgLFK> <https://id.parliament.uk/schema/layingDate>
+        \"2018-07-27+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/1ZEDgLFK>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/5LQ5Ar74>
+        .\r\n<https://id.parliament.uk/wpuFhzm5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/wpuFhzm5>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/VqC2MUZE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/VqC2MUZE>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/VqC2MUZE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/VqC2MUZE>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 225\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/VqC2MUZE>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 225\" .\r\n<https://id.parliament.uk/VqC2MUZE> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"911\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/VqC2MUZE>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 225\" .\r\n<https://id.parliament.uk/VqC2MUZE> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/j0wZpU1d> .\r\n<https://id.parliament.uk/VqC2MUZE>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/eouZnE6o>
+        .\r\n<https://id.parliament.uk/j0wZpU1d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/j0wZpU1d>
+        <https://id.parliament.uk/schema/layingDate> \"2018-08-01+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/j0wZpU1d> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fKqMNz79> .\r\n<https://id.parliament.uk/eouZnE6o>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/eouZnE6o> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/QtfEa5YW>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/QtfEa5YW> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/QtfEa5YW>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/QtfEa5YW> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 226\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/QtfEa5YW> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 226\" .\r\n<https://id.parliament.uk/QtfEa5YW>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"915\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/QtfEa5YW> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 226\" .\r\n<https://id.parliament.uk/QtfEa5YW>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/JkGkZfQA>
+        .\r\n<https://id.parliament.uk/QtfEa5YW> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/WzY4kI4B> .\r\n<https://id.parliament.uk/JkGkZfQA>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/JkGkZfQA> <https://id.parliament.uk/schema/layingDate>
+        \"2018-08-02+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/JkGkZfQA>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/fKqMNz79>
+        .\r\n<https://id.parliament.uk/WzY4kI4B> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/WzY4kI4B>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/IlH0bFJC> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/IlH0bFJC>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/IlH0bFJC> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/IlH0bFJC>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 227\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/IlH0bFJC>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 227\" .\r\n<https://id.parliament.uk/IlH0bFJC> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"924\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/IlH0bFJC>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 227\" .\r\n<https://id.parliament.uk/IlH0bFJC> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/RA0Z5x0S> .\r\n<https://id.parliament.uk/IlH0bFJC>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/1dkAzf5G>
+        .\r\n<https://id.parliament.uk/RA0Z5x0S> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/RA0Z5x0S>
+        <https://id.parliament.uk/schema/layingDate> \"2018-08-06+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/RA0Z5x0S> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fKqMNz79> .\r\n<https://id.parliament.uk/1dkAzf5G>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/1dkAzf5G> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/evNAwjHg>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/evNAwjHg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/evNAwjHg>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/evNAwjHg> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 228\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/evNAwjHg> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 228\" .\r\n<https://id.parliament.uk/evNAwjHg>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"927\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/evNAwjHg> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 228\" .\r\n<https://id.parliament.uk/evNAwjHg>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/CzsYFrka>
+        .\r\n<https://id.parliament.uk/evNAwjHg> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/z7s90NTp> .\r\n<https://id.parliament.uk/CzsYFrka>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/CzsYFrka> <https://id.parliament.uk/schema/layingDate>
+        \"2018-08-08+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/CzsYFrka>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/7dSvuueH>
+        .\r\n<https://id.parliament.uk/z7s90NTp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/z7s90NTp>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/Wa2pnyo2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/Wa2pnyo2>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/Wa2pnyo2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/Wa2pnyo2>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 229\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/Wa2pnyo2>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 229\" .\r\n<https://id.parliament.uk/Wa2pnyo2> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"933\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/Wa2pnyo2>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 229\" .\r\n<https://id.parliament.uk/Wa2pnyo2> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/knwsOk1D> .\r\n<https://id.parliament.uk/Wa2pnyo2>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/j6FFo1kf>
+        .\r\n<https://id.parliament.uk/knwsOk1D> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/knwsOk1D>
+        <https://id.parliament.uk/schema/layingDate> \"2018-08-13+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/knwsOk1D> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/7dSvuueH> .\r\n<https://id.parliament.uk/j6FFo1kf>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/j6FFo1kf> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/qQXoON26>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/qQXoON26> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/qQXoON26>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/qQXoON26> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 230\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/qQXoON26> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 230\" .\r\n<https://id.parliament.uk/qQXoON26>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"930\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/qQXoON26> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 230\" .\r\n<https://id.parliament.uk/qQXoON26>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/8bnEskMz>
+        .\r\n<https://id.parliament.uk/qQXoON26> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/pjtvqXCz> .\r\n<https://id.parliament.uk/8bnEskMz>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/8bnEskMz> <https://id.parliament.uk/schema/layingDate>
+        \"2018-08-13+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/8bnEskMz>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/fKqMNz79>
+        .\r\n<https://id.parliament.uk/pjtvqXCz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/pjtvqXCz>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/GuV3tchN> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/GuV3tchN>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/GuV3tchN> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/GuV3tchN>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 231\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/GuV3tchN>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 231\" .\r\n<https://id.parliament.uk/GuV3tchN> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"932\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/GuV3tchN>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 231\" .\r\n<https://id.parliament.uk/GuV3tchN> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/tvf2XMq0> .\r\n<https://id.parliament.uk/GuV3tchN>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/gW4ShvE2>
+        .\r\n<https://id.parliament.uk/tvf2XMq0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/tvf2XMq0>
+        <https://id.parliament.uk/schema/layingDate> \"2018-08-15+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/tvf2XMq0> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XbTBTDMo> .\r\n<https://id.parliament.uk/gW4ShvE2>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/gW4ShvE2> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/GonuHKX2>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/GonuHKX2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/GonuHKX2>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/GonuHKX2> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 232\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/GonuHKX2> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 232\" .\r\n<https://id.parliament.uk/GonuHKX2>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"942\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/GonuHKX2> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 232\" .\r\n<https://id.parliament.uk/GonuHKX2>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/NBR4kWJn>
+        .\r\n<https://id.parliament.uk/GonuHKX2> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/lQQjF54h> .\r\n<https://id.parliament.uk/NBR4kWJn>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/NBR4kWJn> <https://id.parliament.uk/schema/layingDate>
+        \"2018-08-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/NBR4kWJn>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/5LQ5Ar74>
+        .\r\n<https://id.parliament.uk/lQQjF54h> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/lQQjF54h>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/n7DYBZTg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/n7DYBZTg>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/n7DYBZTg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/n7DYBZTg>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 233\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/n7DYBZTg>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 233\" .\r\n<https://id.parliament.uk/n7DYBZTg> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"939\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/n7DYBZTg>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 233\" .\r\n<https://id.parliament.uk/n7DYBZTg> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/vqpd5hRo> .\r\n<https://id.parliament.uk/n7DYBZTg>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/K1GI1d9e>
+        .\r\n<https://id.parliament.uk/vqpd5hRo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/vqpd5hRo>
+        <https://id.parliament.uk/schema/layingDate> \"2018-08-22+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/vqpd5hRo> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/ni8aOEk3> .\r\n<https://id.parliament.uk/K1GI1d9e>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/K1GI1d9e> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/8NOTbqcG>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/8NOTbqcG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/8NOTbqcG>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/8NOTbqcG> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 234\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/8NOTbqcG> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 234\" .\r\n<https://id.parliament.uk/8NOTbqcG>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"947\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/8NOTbqcG> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 234\" .\r\n<https://id.parliament.uk/8NOTbqcG>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/xSmvWpfZ>
+        .\r\n<https://id.parliament.uk/8NOTbqcG> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/vKAEAnJF> .\r\n<https://id.parliament.uk/xSmvWpfZ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/xSmvWpfZ> <https://id.parliament.uk/schema/layingDate>
+        \"2018-08-30+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/xSmvWpfZ>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/fKqMNz79>
+        .\r\n<https://id.parliament.uk/vKAEAnJF> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/vKAEAnJF>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/nuicNnFk> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/nuicNnFk>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/nuicNnFk> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/nuicNnFk>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 235\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/nuicNnFk>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 235\" .\r\n<https://id.parliament.uk/nuicNnFk> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"946\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/nuicNnFk>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 235\" .\r\n<https://id.parliament.uk/nuicNnFk> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/Fd8PgclA> .\r\n<https://id.parliament.uk/nuicNnFk>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/NoHwsgYC>
+        .\r\n<https://id.parliament.uk/Fd8PgclA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/Fd8PgclA>
+        <https://id.parliament.uk/schema/layingDate> \"2018-08-31+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/Fd8PgclA> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/7dSvuueH> .\r\n<https://id.parliament.uk/NoHwsgYC>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/NoHwsgYC> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/peR5eFWQ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/peR5eFWQ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/peR5eFWQ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/peR5eFWQ> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 236\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/peR5eFWQ> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 236\" .\r\n<https://id.parliament.uk/peR5eFWQ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"952\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/peR5eFWQ> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 236\" .\r\n<https://id.parliament.uk/peR5eFWQ>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/yS3Jzq50>
+        .\r\n<https://id.parliament.uk/peR5eFWQ> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/WHAQG0Ch> .\r\n<https://id.parliament.uk/yS3Jzq50>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/yS3Jzq50> <https://id.parliament.uk/schema/layingDate>
+        \"2018-08-31+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/yS3Jzq50>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/7gnSwbLO>
+        .\r\n<https://id.parliament.uk/WHAQG0Ch> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/WHAQG0Ch>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/jKZxBFHe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/jKZxBFHe>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/jKZxBFHe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/jKZxBFHe>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 237\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/jKZxBFHe>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 237\" .\r\n<https://id.parliament.uk/jKZxBFHe> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 237\" .\r\n<https://id.parliament.uk/jKZxBFHe>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/FBbatZym>
+        .\r\n<https://id.parliament.uk/jKZxBFHe> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/DL1I4kiC> .\r\n<https://id.parliament.uk/FBbatZym>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/FBbatZym> <https://id.parliament.uk/schema/layingDate>
+        \"2018-09-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/FBbatZym>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/79sn5e3n>
+        .\r\n<https://id.parliament.uk/DL1I4kiC> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/DL1I4kiC>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/RmycV0kO> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/RmycV0kO>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/RmycV0kO> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/RmycV0kO>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 238\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/RmycV0kO>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 238\" .\r\n<https://id.parliament.uk/RmycV0kO> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"961\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/RmycV0kO>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 238\" .\r\n<https://id.parliament.uk/RmycV0kO> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/8ymuy646> .\r\n<https://id.parliament.uk/RmycV0kO>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/kAWq2agx>
+        .\r\n<https://id.parliament.uk/8ymuy646> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/8ymuy646>
+        <https://id.parliament.uk/schema/layingDate> \"2018-09-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/8ymuy646> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/BRTNQywN> .\r\n<https://id.parliament.uk/kAWq2agx>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/kAWq2agx> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/8nULnQBi>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/8nULnQBi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/8nULnQBi>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/8nULnQBi> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 239\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/8nULnQBi> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 239\" .\r\n<https://id.parliament.uk/8nULnQBi>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 239\" .\r\n<https://id.parliament.uk/8nULnQBi> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/rvMGR4sj> .\r\n<https://id.parliament.uk/8nULnQBi>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/mFpCbqOz>
+        .\r\n<https://id.parliament.uk/rvMGR4sj> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/rvMGR4sj>
+        <https://id.parliament.uk/schema/layingDate> \"2018-09-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/rvMGR4sj> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/79sn5e3n> .\r\n<https://id.parliament.uk/mFpCbqOz>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/mFpCbqOz> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/fgDYoYbL>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/fgDYoYbL> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/fgDYoYbL>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/fgDYoYbL> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 240\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/fgDYoYbL> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 240\" .\r\n<https://id.parliament.uk/fgDYoYbL>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 240\" .\r\n<https://id.parliament.uk/fgDYoYbL> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/BUVreee5> .\r\n<https://id.parliament.uk/fgDYoYbL>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/E9yCU1c9>
+        .\r\n<https://id.parliament.uk/BUVreee5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/BUVreee5>
+        <https://id.parliament.uk/schema/layingDate> \"2018-09-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/BUVreee5> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/79sn5e3n> .\r\n<https://id.parliament.uk/E9yCU1c9>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/E9yCU1c9> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/QjdlkhkP>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/QjdlkhkP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/QjdlkhkP>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/QjdlkhkP> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 241\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/QjdlkhkP> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 241\" .\r\n<https://id.parliament.uk/QjdlkhkP>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 241\" .\r\n<https://id.parliament.uk/QjdlkhkP> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/k3z0eE4m> .\r\n<https://id.parliament.uk/QjdlkhkP>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/MyVni6Ej>
+        .\r\n<https://id.parliament.uk/k3z0eE4m> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/k3z0eE4m>
+        <https://id.parliament.uk/schema/layingDate> \"2018-09-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/k3z0eE4m> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fKqMNz79> .\r\n<https://id.parliament.uk/MyVni6Ej>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/MyVni6Ej> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/yPyq3chO>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/yPyq3chO> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/yPyq3chO>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/yPyq3chO> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 242\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/yPyq3chO> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 242\" .\r\n<https://id.parliament.uk/yPyq3chO>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"960\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/yPyq3chO> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 242\" .\r\n<https://id.parliament.uk/yPyq3chO>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/ooPYSalN>
+        .\r\n<https://id.parliament.uk/yPyq3chO> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/vxPj3xad> .\r\n<https://id.parliament.uk/ooPYSalN>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/ooPYSalN> <https://id.parliament.uk/schema/layingDate>
+        \"2018-09-04+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/ooPYSalN>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/BRTNQywN>
+        .\r\n<https://id.parliament.uk/vxPj3xad> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/vxPj3xad>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/tRaHj88K> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/tRaHj88K>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/tRaHj88K> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/tRaHj88K>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 243\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/tRaHj88K>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 243\" .\r\n<https://id.parliament.uk/tRaHj88K> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 243\" .\r\n<https://id.parliament.uk/tRaHj88K>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/TAPJzsYR>
+        .\r\n<https://id.parliament.uk/tRaHj88K> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/ZanXOGcI> .\r\n<https://id.parliament.uk/TAPJzsYR>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/TAPJzsYR> <https://id.parliament.uk/schema/layingDate>
+        \"2018-09-05+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/TAPJzsYR>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/yiuTaSI4>
+        .\r\n<https://id.parliament.uk/ZanXOGcI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/ZanXOGcI>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/TFdnSOeu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/TFdnSOeu>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/TFdnSOeu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/TFdnSOeu>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 244\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/TFdnSOeu>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 244\" .\r\n<https://id.parliament.uk/TFdnSOeu> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 244\" .\r\n<https://id.parliament.uk/TFdnSOeu>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/i4B3H1Cp>
+        .\r\n<https://id.parliament.uk/TFdnSOeu> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/IU7gREgJ> .\r\n<https://id.parliament.uk/i4B3H1Cp>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/i4B3H1Cp> <https://id.parliament.uk/schema/layingDate>
+        \"2018-09-05+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/i4B3H1Cp>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/7dSvuueH>
+        .\r\n<https://id.parliament.uk/IU7gREgJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/IU7gREgJ>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/9nwPn9YY> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/9nwPn9YY>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/9nwPn9YY> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/9nwPn9YY>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 245\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/9nwPn9YY>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 245\" .\r\n<https://id.parliament.uk/9nwPn9YY> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"964\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/9nwPn9YY>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 245\" .\r\n<https://id.parliament.uk/9nwPn9YY> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/ggxpUJ3C> .\r\n<https://id.parliament.uk/9nwPn9YY>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/aj8r4hAP>
+        .\r\n<https://id.parliament.uk/ggxpUJ3C> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/ggxpUJ3C>
+        <https://id.parliament.uk/schema/layingDate> \"2018-09-05+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/ggxpUJ3C> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/5LQ5Ar74> .\r\n<https://id.parliament.uk/aj8r4hAP>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/aj8r4hAP> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/J8EUQxAg>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/J8EUQxAg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/J8EUQxAg>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/J8EUQxAg> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 246\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/J8EUQxAg> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 246\" .\r\n<https://id.parliament.uk/J8EUQxAg>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 246\" .\r\n<https://id.parliament.uk/J8EUQxAg> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/HoC5X7Og> .\r\n<https://id.parliament.uk/J8EUQxAg>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/hpbakMhj>
+        .\r\n<https://id.parliament.uk/HoC5X7Og> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/HoC5X7Og>
+        <https://id.parliament.uk/schema/layingDate> \"2018-09-05+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/HoC5X7Og> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/HYfypSOE> .\r\n<https://id.parliament.uk/hpbakMhj>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/hpbakMhj> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/EAXHUZt7>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/EAXHUZt7> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/EAXHUZt7>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/EAXHUZt7> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 247\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/EAXHUZt7> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 247\" .\r\n<https://id.parliament.uk/EAXHUZt7>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"966\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/EAXHUZt7> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 247\" .\r\n<https://id.parliament.uk/EAXHUZt7>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/ugkRO7lo>
+        .\r\n<https://id.parliament.uk/EAXHUZt7> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/SrxpslCY> .\r\n<https://id.parliament.uk/ugkRO7lo>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/ugkRO7lo> <https://id.parliament.uk/schema/layingDate>
+        \"2018-09-06+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/ugkRO7lo>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/yiuTaSI4>
+        .\r\n<https://id.parliament.uk/SrxpslCY> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/SrxpslCY>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/DcVb33WY> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/DcVb33WY>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/DcVb33WY> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/DcVb33WY>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 248\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/DcVb33WY>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 248\" .\r\n<https://id.parliament.uk/DcVb33WY> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"975\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/DcVb33WY>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 248\" .\r\n<https://id.parliament.uk/DcVb33WY> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/gZF71mro> .\r\n<https://id.parliament.uk/DcVb33WY>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/EelSQMxX>
+        .\r\n<https://id.parliament.uk/gZF71mro> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/gZF71mro>
+        <https://id.parliament.uk/schema/layingDate> \"2018-09-06+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/gZF71mro> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/BRTNQywN> .\r\n<https://id.parliament.uk/EelSQMxX>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/EelSQMxX> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/fUqRRBH5>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/fUqRRBH5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/fUqRRBH5>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/fUqRRBH5> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 249\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/fUqRRBH5> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 249\" .\r\n<https://id.parliament.uk/fUqRRBH5>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"967\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/fUqRRBH5> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 249\" .\r\n<https://id.parliament.uk/fUqRRBH5>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/uSJGnOBq>
+        .\r\n<https://id.parliament.uk/fUqRRBH5> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/Wg3eh80v> .\r\n<https://id.parliament.uk/uSJGnOBq>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/uSJGnOBq> <https://id.parliament.uk/schema/layingDate>
+        \"2018-09-06+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/uSJGnOBq>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/yiuTaSI4>
+        .\r\n<https://id.parliament.uk/Wg3eh80v> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/Wg3eh80v>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/BuMKAKjA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/BuMKAKjA>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/BuMKAKjA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/BuMKAKjA>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 250\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/BuMKAKjA>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 250\" .\r\n<https://id.parliament.uk/BuMKAKjA> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"970\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/BuMKAKjA>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 250\" .\r\n<https://id.parliament.uk/BuMKAKjA> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/jNi948H2> .\r\n<https://id.parliament.uk/BuMKAKjA>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/bYtCFU4N>
+        .\r\n<https://id.parliament.uk/jNi948H2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/jNi948H2>
+        <https://id.parliament.uk/schema/layingDate> \"2018-09-06+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/jNi948H2> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/NDZSYjeE> .\r\n<https://id.parliament.uk/bYtCFU4N>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/bYtCFU4N> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/l05U8jIT>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/l05U8jIT> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/l05U8jIT>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/l05U8jIT> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 251\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/l05U8jIT> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 251\" .\r\n<https://id.parliament.uk/l05U8jIT>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"971\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/l05U8jIT> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 251\" .\r\n<https://id.parliament.uk/l05U8jIT>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/8pfIlVcp>
+        .\r\n<https://id.parliament.uk/l05U8jIT> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/2O7xiVcu> .\r\n<https://id.parliament.uk/8pfIlVcp>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/8pfIlVcp> <https://id.parliament.uk/schema/layingDate>
+        \"2018-09-07+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/8pfIlVcp>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/XouN12Ow>
+        .\r\n<https://id.parliament.uk/2O7xiVcu> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/2O7xiVcu>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/WBlaNvyq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/WBlaNvyq>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/WBlaNvyq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/WBlaNvyq>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 252\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/WBlaNvyq>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 252\" .\r\n<https://id.parliament.uk/WBlaNvyq> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"982\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/WBlaNvyq>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 252\" .\r\n<https://id.parliament.uk/WBlaNvyq> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/yGqCp359> .\r\n<https://id.parliament.uk/WBlaNvyq>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/3q8YccUw>
+        .\r\n<https://id.parliament.uk/yGqCp359> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/yGqCp359>
+        <https://id.parliament.uk/schema/layingDate> \"2018-09-10+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/yGqCp359> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/NDZSYjeE> .\r\n<https://id.parliament.uk/3q8YccUw>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/3q8YccUw> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/3iuaNj8A>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/3iuaNj8A> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/3iuaNj8A>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/3iuaNj8A> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 253\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/3iuaNj8A> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 253\" .\r\n<https://id.parliament.uk/3iuaNj8A>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"974\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/3iuaNj8A> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 253\" .\r\n<https://id.parliament.uk/3iuaNj8A>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/RqUBuUBD>
+        .\r\n<https://id.parliament.uk/3iuaNj8A> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/FB2aMTBN> .\r\n<https://id.parliament.uk/RqUBuUBD>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/RqUBuUBD> <https://id.parliament.uk/schema/layingDate>
+        \"2018-09-07+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/RqUBuUBD>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/5LQ5Ar74>
+        .\r\n<https://id.parliament.uk/FB2aMTBN> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/FB2aMTBN>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/n39tcDnk> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/n39tcDnk>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/n39tcDnk> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/n39tcDnk>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 254\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/n39tcDnk>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 254\" .\r\n<https://id.parliament.uk/n39tcDnk> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"985\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/n39tcDnk>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 254\" .\r\n<https://id.parliament.uk/n39tcDnk> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/uVArZwJx> .\r\n<https://id.parliament.uk/n39tcDnk>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/BJVsUfLW>
+        .\r\n<https://id.parliament.uk/uVArZwJx> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/uVArZwJx>
+        <https://id.parliament.uk/schema/layingDate> \"2018-09-10+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/uVArZwJx> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XbTBTDMo> .\r\n<https://id.parliament.uk/BJVsUfLW>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/BJVsUfLW> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/pGJAClSs>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/pGJAClSs> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/pGJAClSs>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/pGJAClSs> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 255\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/pGJAClSs> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 255\" .\r\n<https://id.parliament.uk/pGJAClSs>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"980\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/pGJAClSs> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 255\" .\r\n<https://id.parliament.uk/pGJAClSs>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/i4sxEq6S>
+        .\r\n<https://id.parliament.uk/pGJAClSs> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/vu0GPgyl> .\r\n<https://id.parliament.uk/i4sxEq6S>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/i4sxEq6S> <https://id.parliament.uk/schema/layingDate>
+        \"2018-09-10+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/i4sxEq6S>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/yiuTaSI4>
+        .\r\n<https://id.parliament.uk/vu0GPgyl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/vu0GPgyl>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/d3F9OZoU> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/d3F9OZoU>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/d3F9OZoU> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/d3F9OZoU>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 256\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/d3F9OZoU>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 256\" .\r\n<https://id.parliament.uk/d3F9OZoU> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"988\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/d3F9OZoU>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 256\" .\r\n<https://id.parliament.uk/d3F9OZoU> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/CHm8aIF3> .\r\n<https://id.parliament.uk/d3F9OZoU>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/gQreLll1>
+        .\r\n<https://id.parliament.uk/CHm8aIF3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/CHm8aIF3>
+        <https://id.parliament.uk/schema/layingDate> \"2018-09-11+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/CHm8aIF3> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XbTBTDMo> .\r\n<https://id.parliament.uk/gQreLll1>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/gQreLll1> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/dj1ROT0l>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/dj1ROT0l> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/dj1ROT0l>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/dj1ROT0l> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 257\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/dj1ROT0l> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 257\" .\r\n<https://id.parliament.uk/dj1ROT0l>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"989\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/dj1ROT0l> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 257\" .\r\n<https://id.parliament.uk/dj1ROT0l>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/jwVRKtQU>
+        .\r\n<https://id.parliament.uk/dj1ROT0l> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/RlbS8X8u> .\r\n<https://id.parliament.uk/jwVRKtQU>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/jwVRKtQU> <https://id.parliament.uk/schema/layingDate>
+        \"2018-09-11+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/jwVRKtQU>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/XbTBTDMo>
+        .\r\n<https://id.parliament.uk/RlbS8X8u> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/RlbS8X8u>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/FoxP8Wi7> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/FoxP8Wi7>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/FoxP8Wi7> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/FoxP8Wi7>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 258\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/FoxP8Wi7>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 258\" .\r\n<https://id.parliament.uk/FoxP8Wi7> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 258\" .\r\n<https://id.parliament.uk/FoxP8Wi7>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/fpD5NOqa>
+        .\r\n<https://id.parliament.uk/FoxP8Wi7> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/cRe5nDqS> .\r\n<https://id.parliament.uk/fpD5NOqa>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/fpD5NOqa> <https://id.parliament.uk/schema/layingDate>
+        \"2018-09-12+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/fpD5NOqa>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/XbTBTDMo>
+        .\r\n<https://id.parliament.uk/cRe5nDqS> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/cRe5nDqS>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/CoWkZnVU> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/CoWkZnVU>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/CoWkZnVU> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/CoWkZnVU>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 259\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/CoWkZnVU>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 259\" .\r\n<https://id.parliament.uk/CoWkZnVU> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"993\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/CoWkZnVU>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 259\" .\r\n<https://id.parliament.uk/CoWkZnVU> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/1rss0fox> .\r\n<https://id.parliament.uk/CoWkZnVU>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/mmJtbuq0>
+        .\r\n<https://id.parliament.uk/1rss0fox> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/1rss0fox>
+        <https://id.parliament.uk/schema/layingDate> \"2018-09-12+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/1rss0fox> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/7dSvuueH> .\r\n<https://id.parliament.uk/mmJtbuq0>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/mmJtbuq0> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/v9p3YHSe>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/v9p3YHSe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/v9p3YHSe>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/v9p3YHSe> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 260\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/v9p3YHSe> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 260\" .\r\n<https://id.parliament.uk/v9p3YHSe>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"995\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/v9p3YHSe> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 260\" .\r\n<https://id.parliament.uk/v9p3YHSe>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/w6nwZ5Qi>
+        .\r\n<https://id.parliament.uk/v9p3YHSe> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/VGG0Gv4P> .\r\n<https://id.parliament.uk/w6nwZ5Qi>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/w6nwZ5Qi> <https://id.parliament.uk/schema/layingDate>
+        \"2018-09-12+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/w6nwZ5Qi>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/yiuTaSI4>
+        .\r\n<https://id.parliament.uk/VGG0Gv4P> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/VGG0Gv4P>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/lSRBYtGi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/lSRBYtGi>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/lSRBYtGi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/lSRBYtGi>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 261\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/lSRBYtGi>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 261\" .\r\n<https://id.parliament.uk/lSRBYtGi> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"999\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/lSRBYtGi>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 261\" .\r\n<https://id.parliament.uk/lSRBYtGi> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/4JKyg0Au> .\r\n<https://id.parliament.uk/lSRBYtGi>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/86fSY4P0>
+        .\r\n<https://id.parliament.uk/4JKyg0Au> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/4JKyg0Au>
+        <https://id.parliament.uk/schema/layingDate> \"2018-09-13+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/4JKyg0Au> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/NDZSYjeE> .\r\n<https://id.parliament.uk/86fSY4P0>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/86fSY4P0> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/H1uGO0VI>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/H1uGO0VI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/H1uGO0VI>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/H1uGO0VI> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 262\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/H1uGO0VI> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 262\" .\r\n<https://id.parliament.uk/H1uGO0VI>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"997\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/H1uGO0VI> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 262\" .\r\n<https://id.parliament.uk/H1uGO0VI>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/C6qh45v5>
+        .\r\n<https://id.parliament.uk/H1uGO0VI> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/CnbVFSFE> .\r\n<https://id.parliament.uk/C6qh45v5>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/C6qh45v5> <https://id.parliament.uk/schema/layingDate>
+        \"2018-09-13+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/C6qh45v5>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/NDZSYjeE>
+        .\r\n<https://id.parliament.uk/CnbVFSFE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/CnbVFSFE>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/IyxF7Re7> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/IyxF7Re7>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/IyxF7Re7> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/IyxF7Re7>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 263\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/IyxF7Re7>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 263\" .\r\n<https://id.parliament.uk/IyxF7Re7> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"984\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/IyxF7Re7>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 263\" .\r\n<https://id.parliament.uk/IyxF7Re7> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/O5x2bz0C> .\r\n<https://id.parliament.uk/IyxF7Re7>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/9mNfFnUB>
+        .\r\n<https://id.parliament.uk/O5x2bz0C> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/O5x2bz0C>
+        <https://id.parliament.uk/schema/layingDate> \"2018-09-13+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/O5x2bz0C> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XouN12Ow> .\r\n<https://id.parliament.uk/9mNfFnUB>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/9mNfFnUB> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/vWSvjJPY>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/vWSvjJPY> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/vWSvjJPY>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/vWSvjJPY> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 264\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/vWSvjJPY> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 264\" .\r\n<https://id.parliament.uk/vWSvjJPY>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 264\" .\r\n<https://id.parliament.uk/vWSvjJPY> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/BoIqC4vN> .\r\n<https://id.parliament.uk/vWSvjJPY>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/zefBXzh8>
+        .\r\n<https://id.parliament.uk/BoIqC4vN> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/BoIqC4vN>
+        <https://id.parliament.uk/schema/layingDate> \"2018-09-13+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/BoIqC4vN> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XouN12Ow> .\r\n<https://id.parliament.uk/zefBXzh8>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/zefBXzh8> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/558R1vHw>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/558R1vHw> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/558R1vHw>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/558R1vHw> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 265\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/558R1vHw> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 265\" .\r\n<https://id.parliament.uk/558R1vHw>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"1004\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/558R1vHw> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 265\" .\r\n<https://id.parliament.uk/558R1vHw>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/JO1GX0Yc>
+        .\r\n<https://id.parliament.uk/558R1vHw> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/5CAiPg2v> .\r\n<https://id.parliament.uk/JO1GX0Yc>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/JO1GX0Yc> <https://id.parliament.uk/schema/layingDate>
+        \"2018-09-17+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/JO1GX0Yc>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/XouN12Ow>
+        .\r\n<https://id.parliament.uk/5CAiPg2v> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/5CAiPg2v>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/gVLa6U8S> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/gVLa6U8S>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/gVLa6U8S> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/gVLa6U8S>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 266\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/gVLa6U8S>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 266\" .\r\n<https://id.parliament.uk/gVLa6U8S> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"998\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/gVLa6U8S>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 266\" .\r\n<https://id.parliament.uk/gVLa6U8S> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/1laD3RMi> .\r\n<https://id.parliament.uk/gVLa6U8S>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/oUyGCgS5>
+        .\r\n<https://id.parliament.uk/1laD3RMi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/1laD3RMi>
+        <https://id.parliament.uk/schema/layingDate> \"2018-09-14+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/1laD3RMi> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/7dSvuueH> .\r\n<https://id.parliament.uk/oUyGCgS5>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/oUyGCgS5> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/6gNGlxXz>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/6gNGlxXz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/6gNGlxXz>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/6gNGlxXz> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 267\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/6gNGlxXz> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 267\" .\r\n<https://id.parliament.uk/6gNGlxXz>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"1011\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/6gNGlxXz> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 267\" .\r\n<https://id.parliament.uk/6gNGlxXz>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/qsdwaP2w>
+        .\r\n<https://id.parliament.uk/6gNGlxXz> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/ZAc8K0r4> .\r\n<https://id.parliament.uk/qsdwaP2w>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/qsdwaP2w> <https://id.parliament.uk/schema/layingDate>
+        \"2018-09-20+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/qsdwaP2w>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/KSMOf7aM>
+        .\r\n<https://id.parliament.uk/ZAc8K0r4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/ZAc8K0r4>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/SSIdUxdK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/SSIdUxdK>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/SSIdUxdK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/SSIdUxdK>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 268\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/SSIdUxdK>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 268\" .\r\n<https://id.parliament.uk/SSIdUxdK> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"1012\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/SSIdUxdK>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 268\" .\r\n<https://id.parliament.uk/SSIdUxdK> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/clek4Qpe> .\r\n<https://id.parliament.uk/SSIdUxdK>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/xl31EYMX>
+        .\r\n<https://id.parliament.uk/clek4Qpe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/clek4Qpe>
+        <https://id.parliament.uk/schema/layingDate> \"2018-09-20+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/clek4Qpe> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/KSMOf7aM> .\r\n<https://id.parliament.uk/xl31EYMX>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/xl31EYMX> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/WMZkgw45>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/WMZkgw45> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/WMZkgw45>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/WMZkgw45> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 269\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/WMZkgw45> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 269\" .\r\n<https://id.parliament.uk/WMZkgw45>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"1026\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/WMZkgw45> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 269\" .\r\n<https://id.parliament.uk/WMZkgw45>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/Wp00cYcL>
+        .\r\n<https://id.parliament.uk/WMZkgw45> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/rINYVove> .\r\n<https://id.parliament.uk/Wp00cYcL>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/Wp00cYcL> <https://id.parliament.uk/schema/layingDate>
+        \"2018-09-26+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/Wp00cYcL>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/5LQ5Ar74>
+        .\r\n<https://id.parliament.uk/rINYVove> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/rINYVove>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/sUFFmPCo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/sUFFmPCo>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/sUFFmPCo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/sUFFmPCo>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 270\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/sUFFmPCo>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 270\" .\r\n<https://id.parliament.uk/sUFFmPCo> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"1025\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/sUFFmPCo>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 270\" .\r\n<https://id.parliament.uk/sUFFmPCo> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/GUK5AtG9> .\r\n<https://id.parliament.uk/sUFFmPCo>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/xrQp8wjo>
+        .\r\n<https://id.parliament.uk/GUK5AtG9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/GUK5AtG9>
+        <https://id.parliament.uk/schema/layingDate> \"2018-09-25+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/GUK5AtG9> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/5LQ5Ar74> .\r\n<https://id.parliament.uk/xrQp8wjo>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/xrQp8wjo> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/Ez5LhVPl>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/Ez5LhVPl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/Ez5LhVPl>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/Ez5LhVPl> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 271\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/Ez5LhVPl> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 271\" .\r\n<https://id.parliament.uk/Ez5LhVPl>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"1033\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/Ez5LhVPl> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 271\" .\r\n<https://id.parliament.uk/Ez5LhVPl>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/HkXhKKPX>
+        .\r\n<https://id.parliament.uk/Ez5LhVPl> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/SGkBjU1C> .\r\n<https://id.parliament.uk/HkXhKKPX>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/HkXhKKPX> <https://id.parliament.uk/schema/layingDate>
+        \"2018-09-27+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/HkXhKKPX>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/5LQ5Ar74>
+        .\r\n<https://id.parliament.uk/SGkBjU1C> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/SGkBjU1C>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/x1lCTIsz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/x1lCTIsz>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/x1lCTIsz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/x1lCTIsz>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 272\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/x1lCTIsz>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 272\" .\r\n<https://id.parliament.uk/x1lCTIsz> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"1034\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/x1lCTIsz>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 272\" .\r\n<https://id.parliament.uk/x1lCTIsz> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/oOTesb2Y> .\r\n<https://id.parliament.uk/x1lCTIsz>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/O1seG0Nv>
+        .\r\n<https://id.parliament.uk/oOTesb2Y> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/oOTesb2Y>
+        <https://id.parliament.uk/schema/layingDate> \"2018-09-27+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/oOTesb2Y> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/5LQ5Ar74> .\r\n<https://id.parliament.uk/O1seG0Nv>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/O1seG0Nv> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/V9OJief9>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/V9OJief9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/V9OJief9>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/V9OJief9> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 273\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/V9OJief9> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 273\" .\r\n<https://id.parliament.uk/V9OJief9>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"1038\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/V9OJief9> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 273\" .\r\n<https://id.parliament.uk/V9OJief9>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/mGTRkI6E>
+        .\r\n<https://id.parliament.uk/V9OJief9> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/zdW1LizR> .\r\n<https://id.parliament.uk/mGTRkI6E>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/mGTRkI6E> <https://id.parliament.uk/schema/layingDate>
+        \"2018-09-28+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/mGTRkI6E>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/HYfypSOE>
+        .\r\n<https://id.parliament.uk/zdW1LizR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/zdW1LizR>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/YeYkel8w> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/YeYkel8w>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/YeYkel8w> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/YeYkel8w>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 274\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/YeYkel8w>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 274\" .\r\n<https://id.parliament.uk/YeYkel8w> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 274\" .\r\n<https://id.parliament.uk/YeYkel8w>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/CfajRCrp>
+        .\r\n<https://id.parliament.uk/YeYkel8w> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/Zo9nO92C> .\r\n<https://id.parliament.uk/CfajRCrp>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/CfajRCrp> <https://id.parliament.uk/schema/layingDate>
+        \"2018-03-29+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/CfajRCrp>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/yiuTaSI4>
+        .\r\n<https://id.parliament.uk/Zo9nO92C> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/Zo9nO92C>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/XGB9Cj8C> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/XGB9Cj8C>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/XGB9Cj8C> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/XGB9Cj8C>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 275\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/XGB9Cj8C>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 275\" .\r\n<https://id.parliament.uk/XGB9Cj8C> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"507\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/XGB9Cj8C>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 275\" .\r\n<https://id.parliament.uk/XGB9Cj8C> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/L97rEr0s> .\r\n<https://id.parliament.uk/XGB9Cj8C>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/F8pP8ZhB>
+        .\r\n<https://id.parliament.uk/L97rEr0s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/L97rEr0s>
+        <https://id.parliament.uk/schema/layingDate> \"2018-04-23+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/L97rEr0s> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/79sn5e3n> .\r\n<https://id.parliament.uk/F8pP8ZhB>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/F8pP8ZhB> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/2zCfE0jG>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/2zCfE0jG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/2zCfE0jG>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/2zCfE0jG> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 276\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/2zCfE0jG> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 276\" .\r\n<https://id.parliament.uk/2zCfE0jG>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"899\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/2zCfE0jG> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 276\" .\r\n<https://id.parliament.uk/2zCfE0jG>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/3xRYolQn>
+        .\r\n<https://id.parliament.uk/3xRYolQn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/3xRYolQn>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/fqzYAhp8> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/fqzYAhp8>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/fqzYAhp8> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/fqzYAhp8>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 277\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/fqzYAhp8>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 277\" .\r\n<https://id.parliament.uk/fqzYAhp8> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"900\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/fqzYAhp8>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 277\" .\r\n<https://id.parliament.uk/fqzYAhp8> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/twB3lRXS> .\r\n<https://id.parliament.uk/twB3lRXS>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/twB3lRXS> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/AbFupFPb>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/AbFupFPb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/AbFupFPb>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/AbFupFPb> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 278\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/AbFupFPb> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 278\" .\r\n<https://id.parliament.uk/AbFupFPb>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"906\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/AbFupFPb> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 278\" .\r\n<https://id.parliament.uk/AbFupFPb>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/T1Z8xmPJ>
+        .\r\n<https://id.parliament.uk/T1Z8xmPJ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/T1Z8xmPJ>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/LCvP8PWr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/LCvP8PWr>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/LCvP8PWr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/LCvP8PWr>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 279\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/LCvP8PWr>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 279\" .\r\n<https://id.parliament.uk/LCvP8PWr> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"1037\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/LCvP8PWr>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 279\" .\r\n<https://id.parliament.uk/LCvP8PWr> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/cGNDQyi9> .\r\n<https://id.parliament.uk/LCvP8PWr>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/nqDtLBR9>
+        .\r\n<https://id.parliament.uk/cGNDQyi9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/cGNDQyi9>
+        <https://id.parliament.uk/schema/layingDate> \"2018-09-28+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/cGNDQyi9> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/5LQ5Ar74> .\r\n<https://id.parliament.uk/nqDtLBR9>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/nqDtLBR9> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/VW7e0Sva>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/VW7e0Sva> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/VW7e0Sva>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/VW7e0Sva> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 280\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/VW7e0Sva> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 280\" .\r\n<https://id.parliament.uk/VW7e0Sva>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"1039\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/VW7e0Sva> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 280\" .\r\n<https://id.parliament.uk/VW7e0Sva>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/CyeKcrpK>
+        .\r\n<https://id.parliament.uk/VW7e0Sva> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/jaYLRoUo> .\r\n<https://id.parliament.uk/CyeKcrpK>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/CyeKcrpK> <https://id.parliament.uk/schema/layingDate>
+        \"2018-09-28+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/CyeKcrpK>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/HYfypSOE>
+        .\r\n<https://id.parliament.uk/jaYLRoUo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/jaYLRoUo>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/nmnBg42M> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/nmnBg42M>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/nmnBg42M> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/nmnBg42M>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 281\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/nmnBg42M>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 281\" .\r\n<https://id.parliament.uk/nmnBg42M> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"1043\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/nmnBg42M>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 281\" .\r\n<https://id.parliament.uk/nmnBg42M> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/HaM33HDN> .\r\n<https://id.parliament.uk/nmnBg42M>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/HHrQwR8D>
+        .\r\n<https://id.parliament.uk/HaM33HDN> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/HaM33HDN>
+        <https://id.parliament.uk/schema/layingDate> \"2018-10-05+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/HaM33HDN> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fKqMNz79> .\r\n<https://id.parliament.uk/HHrQwR8D>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/HHrQwR8D> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/HD6sJ5Bq>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/HD6sJ5Bq> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/HD6sJ5Bq>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/HD6sJ5Bq> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 282\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/HD6sJ5Bq> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 282\" .\r\n<https://id.parliament.uk/HD6sJ5Bq>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 282\" .\r\n<https://id.parliament.uk/HD6sJ5Bq> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/CgLkkosK> .\r\n<https://id.parliament.uk/HD6sJ5Bq>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/fvbuf8S8>
+        .\r\n<https://id.parliament.uk/CgLkkosK> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/CgLkkosK>
+        <https://id.parliament.uk/schema/layingDate> \"2018-10-09+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/CgLkkosK> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XouN12Ow> .\r\n<https://id.parliament.uk/fvbuf8S8>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/fvbuf8S8> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/AWmzydlB>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/AWmzydlB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/AWmzydlB>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/AWmzydlB> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 283\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/AWmzydlB> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 283\" .\r\n<https://id.parliament.uk/AWmzydlB>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"1053\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/AWmzydlB> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 283\" .\r\n<https://id.parliament.uk/AWmzydlB>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/9z7FUKoK>
+        .\r\n<https://id.parliament.uk/AWmzydlB> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/OEpUFoMB> .\r\n<https://id.parliament.uk/9z7FUKoK>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/9z7FUKoK> <https://id.parliament.uk/schema/layingDate>
+        \"2018-10-09+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/9z7FUKoK>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/BRTNQywN>
+        .\r\n<https://id.parliament.uk/OEpUFoMB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/OEpUFoMB>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/5ISSgu1W> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/5ISSgu1W>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/5ISSgu1W> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/5ISSgu1W>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 284\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/5ISSgu1W>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 284\" .\r\n<https://id.parliament.uk/5ISSgu1W> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 284\" .\r\n<https://id.parliament.uk/5ISSgu1W>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/MeQ6jkaq>
+        .\r\n<https://id.parliament.uk/5ISSgu1W> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/Tdu2Oxdn> .\r\n<https://id.parliament.uk/MeQ6jkaq>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/MeQ6jkaq> <https://id.parliament.uk/schema/layingDate>
+        \"2018-10-09+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/MeQ6jkaq>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/XouN12Ow>
+        .\r\n<https://id.parliament.uk/Tdu2Oxdn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/Tdu2Oxdn>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/hhJ7dD7c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/hhJ7dD7c>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/hhJ7dD7c> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/hhJ7dD7c>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 285\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/hhJ7dD7c>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 285\" .\r\n<https://id.parliament.uk/hhJ7dD7c> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"1052\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/hhJ7dD7c>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 285\" .\r\n<https://id.parliament.uk/hhJ7dD7c> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/eVLueRWf> .\r\n<https://id.parliament.uk/hhJ7dD7c>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/l3feUJPF>
+        .\r\n<https://id.parliament.uk/eVLueRWf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/eVLueRWf>
+        <https://id.parliament.uk/schema/layingDate> \"2018-10-09+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/eVLueRWf> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/yiuTaSI4> .\r\n<https://id.parliament.uk/l3feUJPF>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/l3feUJPF> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/57kWuZb4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/57kWuZb4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/57kWuZb4>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/57kWuZb4> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 286\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/57kWuZb4> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 286\" .\r\n<https://id.parliament.uk/57kWuZb4>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 286\" .\r\n<https://id.parliament.uk/57kWuZb4> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/VRwZK1dd> .\r\n<https://id.parliament.uk/57kWuZb4>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/A35mNYan>
+        .\r\n<https://id.parliament.uk/VRwZK1dd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/VRwZK1dd>
+        <https://id.parliament.uk/schema/layingDate> \"2018-10-09+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/VRwZK1dd> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/HYfypSOE> .\r\n<https://id.parliament.uk/A35mNYan>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/A35mNYan> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/mEVKpToG>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/mEVKpToG> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/mEVKpToG>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/mEVKpToG> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 287\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/mEVKpToG> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 287\" .\r\n<https://id.parliament.uk/mEVKpToG>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 287\" .\r\n<https://id.parliament.uk/mEVKpToG> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/DK5agjiR> .\r\n<https://id.parliament.uk/mEVKpToG>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/JthygHIN>
+        .\r\n<https://id.parliament.uk/DK5agjiR> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/DK5agjiR>
+        <https://id.parliament.uk/schema/layingDate> \"2018-10-09+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/DK5agjiR> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/HYfypSOE> .\r\n<https://id.parliament.uk/JthygHIN>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/JthygHIN> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/WFivvWVa>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/WFivvWVa> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/WFivvWVa>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/WFivvWVa> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 288\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/WFivvWVa> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 288\" .\r\n<https://id.parliament.uk/WFivvWVa>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 288\" .\r\n<https://id.parliament.uk/WFivvWVa> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/8AwnVijm> .\r\n<https://id.parliament.uk/WFivvWVa>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/khiR4R9R>
+        .\r\n<https://id.parliament.uk/8AwnVijm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/8AwnVijm>
+        <https://id.parliament.uk/schema/layingDate> \"2018-10-09+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/8AwnVijm> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/HYfypSOE> .\r\n<https://id.parliament.uk/khiR4R9R>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/khiR4R9R> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/Rcqh3lsI>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/Rcqh3lsI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/Rcqh3lsI>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/Rcqh3lsI> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 289\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/Rcqh3lsI> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 289\" .\r\n<https://id.parliament.uk/Rcqh3lsI>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"1047\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/Rcqh3lsI> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 289\" .\r\n<https://id.parliament.uk/Rcqh3lsI>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/zIcQBtiW>
+        .\r\n<https://id.parliament.uk/Rcqh3lsI> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/dcsrL0EB> .\r\n<https://id.parliament.uk/zIcQBtiW>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/zIcQBtiW> <https://id.parliament.uk/schema/layingDate>
+        \"2018-10-09+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/zIcQBtiW>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/ZU3IXBtP>
+        .\r\n<https://id.parliament.uk/dcsrL0EB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/dcsrL0EB>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/03b7Krn2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/03b7Krn2>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/03b7Krn2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/03b7Krn2>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 290\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/03b7Krn2>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 290\" .\r\n<https://id.parliament.uk/03b7Krn2> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 290\" .\r\n<https://id.parliament.uk/03b7Krn2>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/KPDgfIaG>
+        .\r\n<https://id.parliament.uk/03b7Krn2> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/1Tn8ZUle> .\r\n<https://id.parliament.uk/KPDgfIaG>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/KPDgfIaG> <https://id.parliament.uk/schema/layingDate>
+        \"2018-10-09+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/KPDgfIaG>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/HYfypSOE>
+        .\r\n<https://id.parliament.uk/1Tn8ZUle> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/1Tn8ZUle>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/EuWVmkrN> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/EuWVmkrN>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/EuWVmkrN> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/EuWVmkrN>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 291\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/EuWVmkrN>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 291\" .\r\n<https://id.parliament.uk/EuWVmkrN> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"1046\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/EuWVmkrN>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 291\" .\r\n<https://id.parliament.uk/EuWVmkrN> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/m6mEHuqF> .\r\n<https://id.parliament.uk/EuWVmkrN>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/QsaNlrbs>
+        .\r\n<https://id.parliament.uk/m6mEHuqF> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/m6mEHuqF>
+        <https://id.parliament.uk/schema/layingDate> \"2018-10-09+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/m6mEHuqF> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/yiuTaSI4> .\r\n<https://id.parliament.uk/QsaNlrbs>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/QsaNlrbs> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/k7Ytkpuk>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/k7Ytkpuk> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/k7Ytkpuk>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/k7Ytkpuk> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 292\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/k7Ytkpuk> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 292\" .\r\n<https://id.parliament.uk/k7Ytkpuk>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 292\" .\r\n<https://id.parliament.uk/k7Ytkpuk> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/uTZ2QVny> .\r\n<https://id.parliament.uk/k7Ytkpuk>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/lZAXVvXl>
+        .\r\n<https://id.parliament.uk/uTZ2QVny> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/uTZ2QVny>
+        <https://id.parliament.uk/schema/layingDate> \"2018-10-09+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/uTZ2QVny> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/HYfypSOE> .\r\n<https://id.parliament.uk/lZAXVvXl>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/lZAXVvXl> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/T8QuQbfp>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/T8QuQbfp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/T8QuQbfp>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/T8QuQbfp> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 293\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/T8QuQbfp> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 293\" .\r\n<https://id.parliament.uk/T8QuQbfp>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 293\" .\r\n<https://id.parliament.uk/T8QuQbfp> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/m3e3JF2S> .\r\n<https://id.parliament.uk/T8QuQbfp>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/VAKIqdsw>
+        .\r\n<https://id.parliament.uk/m3e3JF2S> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/m3e3JF2S>
+        <https://id.parliament.uk/schema/layingDate> \"2018-10-10+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/m3e3JF2S> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/yiuTaSI4> .\r\n<https://id.parliament.uk/VAKIqdsw>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/VAKIqdsw> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/HDMCkDND>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/HDMCkDND> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/HDMCkDND>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/HDMCkDND> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 294\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/HDMCkDND> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 294\" .\r\n<https://id.parliament.uk/HDMCkDND>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"1048\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/HDMCkDND> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 294\" .\r\n<https://id.parliament.uk/HDMCkDND>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/5zo0e99B>
+        .\r\n<https://id.parliament.uk/HDMCkDND> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/qAaoszxP> .\r\n<https://id.parliament.uk/5zo0e99B>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/5zo0e99B> <https://id.parliament.uk/schema/layingDate>
+        \"2018-10-10+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/5zo0e99B>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/5LQ5Ar74>
+        .\r\n<https://id.parliament.uk/qAaoszxP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/qAaoszxP>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/Y5wgjNCe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/Y5wgjNCe>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/Y5wgjNCe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/Y5wgjNCe>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 295\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/Y5wgjNCe>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 295\" .\r\n<https://id.parliament.uk/Y5wgjNCe> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"1044\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/Y5wgjNCe>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 295\" .\r\n<https://id.parliament.uk/Y5wgjNCe> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/b6EduGTz> .\r\n<https://id.parliament.uk/Y5wgjNCe>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/wNXTPpGh>
+        .\r\n<https://id.parliament.uk/b6EduGTz> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/b6EduGTz>
+        <https://id.parliament.uk/schema/layingDate> \"2018-10-10+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/b6EduGTz> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/XouN12Ow> .\r\n<https://id.parliament.uk/wNXTPpGh>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/wNXTPpGh> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/ogDjrUru>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/ogDjrUru> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/ogDjrUru>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/ogDjrUru> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 296\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/ogDjrUru> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 296\" .\r\n<https://id.parliament.uk/ogDjrUru>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 296\" .\r\n<https://id.parliament.uk/ogDjrUru> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/7Z61hi24> .\r\n<https://id.parliament.uk/ogDjrUru>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/OI2sXT42>
+        .\r\n<https://id.parliament.uk/7Z61hi24> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/7Z61hi24>
+        <https://id.parliament.uk/schema/layingDate> \"2018-10-10+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/7Z61hi24> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/ZU3IXBtP> .\r\n<https://id.parliament.uk/OI2sXT42>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/OI2sXT42> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/90n67zWF>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/90n67zWF> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/90n67zWF>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/90n67zWF> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 297\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/90n67zWF> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 297\" .\r\n<https://id.parliament.uk/90n67zWF>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"1051\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/90n67zWF> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 297\" .\r\n<https://id.parliament.uk/90n67zWF>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/5sGlX5ld>
+        .\r\n<https://id.parliament.uk/90n67zWF> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/PgzOMcNk> .\r\n<https://id.parliament.uk/5sGlX5ld>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/5sGlX5ld> <https://id.parliament.uk/schema/layingDate>
+        \"2018-10-10+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/5sGlX5ld>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/5LQ5Ar74>
+        .\r\n<https://id.parliament.uk/PgzOMcNk> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/PgzOMcNk>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/iKgIQsG9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/iKgIQsG9>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/iKgIQsG9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/iKgIQsG9>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 298\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/iKgIQsG9>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 298\" .\r\n<https://id.parliament.uk/iKgIQsG9> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 298\" .\r\n<https://id.parliament.uk/iKgIQsG9>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/JBmPy40P>
+        .\r\n<https://id.parliament.uk/iKgIQsG9> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/Goj1Zra6> .\r\n<https://id.parliament.uk/JBmPy40P>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/JBmPy40P> <https://id.parliament.uk/schema/layingDate>
+        \"2018-10-10+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/JBmPy40P>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/kv2Qqfn9>
+        .\r\n<https://id.parliament.uk/Goj1Zra6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/Goj1Zra6>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/qN5SIpKr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/qN5SIpKr>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/qN5SIpKr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/qN5SIpKr>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 299\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/qN5SIpKr>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 299\" .\r\n<https://id.parliament.uk/qN5SIpKr> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 299\" .\r\n<https://id.parliament.uk/qN5SIpKr>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/OTs9pC6Q>
+        .\r\n<https://id.parliament.uk/qN5SIpKr> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/YH5Tygda> .\r\n<https://id.parliament.uk/OTs9pC6Q>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/OTs9pC6Q> <https://id.parliament.uk/schema/layingDate>
+        \"2018-10-11+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/OTs9pC6Q>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/NDZSYjeE>
+        .\r\n<https://id.parliament.uk/YH5Tygda> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/YH5Tygda>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/H5YJQsK2>
+        .\r\n<https://id.parliament.uk/WcxZPA5i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/WcxZPA5i>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/WcxZPA5i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/WcxZPA5i>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 300\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/WcxZPA5i>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 300\" .\r\n<https://id.parliament.uk/WcxZPA5i> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"1062\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/WcxZPA5i>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 300\" .\r\n<https://id.parliament.uk/WcxZPA5i> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/xxamoGFE> .\r\n<https://id.parliament.uk/WcxZPA5i>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/kz8tjyyh>
+        .\r\n<https://id.parliament.uk/xxamoGFE> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/xxamoGFE>
+        <https://id.parliament.uk/schema/layingDate> \"2018-10-11+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/xxamoGFE> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/JVJB3tuB> .\r\n<https://id.parliament.uk/kz8tjyyh>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/kz8tjyyh> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/0l2kwZPW>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/0l2kwZPW> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/0l2kwZPW>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/0l2kwZPW> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 301\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/0l2kwZPW> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 301\" .\r\n<https://id.parliament.uk/0l2kwZPW>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"1055\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/0l2kwZPW> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 301\" .\r\n<https://id.parliament.uk/0l2kwZPW>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/HgDlGoDg>
+        .\r\n<https://id.parliament.uk/0l2kwZPW> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/aYjkd3c2> .\r\n<https://id.parliament.uk/HgDlGoDg>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/HgDlGoDg> <https://id.parliament.uk/schema/layingDate>
+        \"2018-10-11+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/HgDlGoDg>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/NDZSYjeE>
+        .\r\n<https://id.parliament.uk/aYjkd3c2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/aYjkd3c2>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/eOlu960r> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/eOlu960r>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/eOlu960r> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/eOlu960r>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 302\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/eOlu960r>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 302\" .\r\n<https://id.parliament.uk/eOlu960r> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"1056\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/eOlu960r>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 302\" .\r\n<https://id.parliament.uk/eOlu960r> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/dOYT5tSO> .\r\n<https://id.parliament.uk/eOlu960r>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/XO8Wq7au>
+        .\r\n<https://id.parliament.uk/dOYT5tSO> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/dOYT5tSO>
+        <https://id.parliament.uk/schema/layingDate> \"2018-10-11+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/dOYT5tSO> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/fKqMNz79> .\r\n<https://id.parliament.uk/XO8Wq7au>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/XO8Wq7au> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/d2bXwUKW>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/d2bXwUKW> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/d2bXwUKW>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/d2bXwUKW> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 303\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/d2bXwUKW> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 303\" .\r\n<https://id.parliament.uk/d2bXwUKW>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 303\" .\r\n<https://id.parliament.uk/d2bXwUKW> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/R12ebcaQ> .\r\n<https://id.parliament.uk/d2bXwUKW>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/Fg6Xjml5>
+        .\r\n<https://id.parliament.uk/R12ebcaQ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/R12ebcaQ>
+        <https://id.parliament.uk/schema/layingDate> \"2018-10-11+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/R12ebcaQ> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/NDZSYjeE> .\r\n<https://id.parliament.uk/Fg6Xjml5>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/Fg6Xjml5> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/H5YJQsK2> .\r\n<https://id.parliament.uk/CFyWykUZ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/CFyWykUZ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/CFyWykUZ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/CFyWykUZ> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 304\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/CFyWykUZ> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 304\" .\r\n<https://id.parliament.uk/CFyWykUZ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"1059\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/CFyWykUZ> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 304\" .\r\n<https://id.parliament.uk/CFyWykUZ>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/i2utXKbv>
+        .\r\n<https://id.parliament.uk/CFyWykUZ> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/8wxb6BWd> .\r\n<https://id.parliament.uk/i2utXKbv>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/i2utXKbv> <https://id.parliament.uk/schema/layingDate>
+        \"2018-10-11+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/i2utXKbv>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/7dSvuueH>
+        .\r\n<https://id.parliament.uk/8wxb6BWd> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/8wxb6BWd>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/J097gJjm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/J097gJjm>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/J097gJjm> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/J097gJjm>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 305\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/J097gJjm>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 305\" .\r\n<https://id.parliament.uk/J097gJjm> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"1083\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/J097gJjm>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 305\" .\r\n<https://id.parliament.uk/J097gJjm> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/PhCUmQY7> .\r\n<https://id.parliament.uk/J097gJjm>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/mMJoin9d>
+        .\r\n<https://id.parliament.uk/PhCUmQY7> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/PhCUmQY7>
+        <https://id.parliament.uk/schema/layingDate> \"2018-10-15+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/PhCUmQY7> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/ZU3IXBtP> .\r\n<https://id.parliament.uk/mMJoin9d>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/mMJoin9d> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/4CQsOYHF>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/4CQsOYHF> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/4CQsOYHF>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/4CQsOYHF> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 306\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/4CQsOYHF> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 306\" .\r\n<https://id.parliament.uk/4CQsOYHF>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"1072\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/4CQsOYHF> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 306\" .\r\n<https://id.parliament.uk/4CQsOYHF>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/vWBoX8Kn>
+        .\r\n<https://id.parliament.uk/4CQsOYHF> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/sqake64i> .\r\n<https://id.parliament.uk/vWBoX8Kn>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/vWBoX8Kn> <https://id.parliament.uk/schema/layingDate>
+        \"2018-10-12+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/vWBoX8Kn>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/NDZSYjeE>
+        .\r\n<https://id.parliament.uk/sqake64i> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/sqake64i>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/PdffL1zZ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/PdffL1zZ>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/PdffL1zZ> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/PdffL1zZ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 307\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/PdffL1zZ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 307\" .\r\n<https://id.parliament.uk/PdffL1zZ> <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber>
+        \"1082\"^^<http://www.w3.org/2001/XMLSchema#integer> .\r\n<https://id.parliament.uk/PdffL1zZ>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperName> \"statutoryInstrumentPaperName
+        - 307\" .\r\n<https://id.parliament.uk/PdffL1zZ> <https://id.parliament.uk/schema/laidThingHasLaying>
+        <https://id.parliament.uk/ubciSMWL> .\r\n<https://id.parliament.uk/PdffL1zZ>
+        <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage> <https://id.parliament.uk/HqIRueFW>
+        .\r\n<https://id.parliament.uk/ubciSMWL> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/Laying> .\r\n<https://id.parliament.uk/ubciSMWL>
+        <https://id.parliament.uk/schema/layingDate> \"2018-10-15+01:00\"^^<http://www.w3.org/2001/XMLSchema#date>
+        .\r\n<https://id.parliament.uk/ubciSMWL> <https://id.parliament.uk/schema/layingHasLayingBody>
+        <https://id.parliament.uk/yiuTaSI4> .\r\n<https://id.parliament.uk/HqIRueFW>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackage>
+        .\r\n<https://id.parliament.uk/HqIRueFW> <https://id.parliament.uk/schema/workPackageHasProcedure>
+        <https://id.parliament.uk/5S6p4YsP> .\r\n<https://id.parliament.uk/VQdXrdx2>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/StatutoryInstrumentPaper>
+        .\r\n<https://id.parliament.uk/VQdXrdx2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/LaidThing> .\r\n<https://id.parliament.uk/VQdXrdx2>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/WorkPackagedThing>
+        .\r\n<https://id.parliament.uk/VQdXrdx2> <https://id.parliament.uk/schema/statutoryInstrumentPaperYear>
+        \"statutoryInstrumentPaperYear - 308\"^^<http://www.w3.org/2001/XMLSchema#gYear>
+        .\r\n<https://id.parliament.uk/VQdXrdx2> <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix>
+        \"statutoryInstrumentPaperPrefix - 308\" .\r\n<https://id.parliament.uk/VQdXrdx2>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperNumber> \"1086\"^^<http://www.w3.org/2001/XMLSchema#integer>
+        .\r\n<https://id.parliament.uk/VQdXrdx2> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 308\" .\r\n<https://id.parliament.uk/VQdXrdx2>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/MblgQ49Y>
+        .\r\n<https://id.parliament.uk/VQdXrdx2> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/1KElI7j4> .\r\n<https://id.parliament.uk/MblgQ49Y>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/MblgQ49Y> <https://id.parliament.uk/schema/layingDate>
+        \"2018-10-15+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/MblgQ49Y>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/ZU3IXBtP>
+        .\r\n<https://id.parliament.uk/1KElI7j4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/1KElI7j4>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/5S6p4YsP>
+        .\r\n<https://id.parliament.uk/ykZHxqox> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/ykZHxqox>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/ykZHxqox> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/ykZHxqox>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 309\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/ykZHxqox>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 309\" .\r\n<https://id.parliament.uk/ykZHxqox> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 309\" .\r\n<https://id.parliament.uk/ykZHxqox>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/t155HrTe>
+        .\r\n<https://id.parliament.uk/ykZHxqox> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/kcEjmWpr> .\r\n<https://id.parliament.uk/t155HrTe>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/t155HrTe> <https://id.parliament.uk/schema/layingDate>
+        \"2018-10-16+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/t155HrTe>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/eup4DwE5>
+        .\r\n<https://id.parliament.uk/kcEjmWpr> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/kcEjmWpr>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/gTgidljI>
+        .\r\n<https://id.parliament.uk/ig2TxYLa> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/ig2TxYLa>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/ig2TxYLa> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/ig2TxYLa>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 310\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/ig2TxYLa>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 310\" .\r\n<https://id.parliament.uk/ig2TxYLa> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 310\" .\r\n<https://id.parliament.uk/ig2TxYLa>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/3DMhopcY>
+        .\r\n<https://id.parliament.uk/ig2TxYLa> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/YTS410BP> .\r\n<https://id.parliament.uk/3DMhopcY>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/3DMhopcY> <https://id.parliament.uk/schema/layingDate>
+        \"2018-10-16+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/3DMhopcY>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/eup4DwE5>
+        .\r\n<https://id.parliament.uk/YTS410BP> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/YTS410BP>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/gTgidljI>
+        .\r\n<https://id.parliament.uk/bV5IlI9d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/bV5IlI9d>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/bV5IlI9d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/bV5IlI9d>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 311\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/bV5IlI9d>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 311\" .\r\n<https://id.parliament.uk/bV5IlI9d> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 311\" .\r\n<https://id.parliament.uk/bV5IlI9d>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/1PEG8aEE>
+        .\r\n<https://id.parliament.uk/bV5IlI9d> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/p4h9qzxn> .\r\n<https://id.parliament.uk/1PEG8aEE>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/1PEG8aEE> <https://id.parliament.uk/schema/layingDate>
+        \"2018-10-16+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/1PEG8aEE>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/eup4DwE5>
+        .\r\n<https://id.parliament.uk/p4h9qzxn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/p4h9qzxn>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/gTgidljI>
+        .\r\n<https://id.parliament.uk/8NE6wEFF> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/8NE6wEFF>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/8NE6wEFF> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/8NE6wEFF>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 312\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/8NE6wEFF>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 312\" .\r\n<https://id.parliament.uk/8NE6wEFF> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 312\" .\r\n<https://id.parliament.uk/8NE6wEFF>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/Veq7J900>
+        .\r\n<https://id.parliament.uk/8NE6wEFF> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/jeyEtajA> .\r\n<https://id.parliament.uk/Veq7J900>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/Veq7J900> <https://id.parliament.uk/schema/layingDate>
+        \"2018-10-16+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/Veq7J900>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/eup4DwE5>
+        .\r\n<https://id.parliament.uk/jeyEtajA> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/jeyEtajA>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/gTgidljI>
+        .\r\n<https://id.parliament.uk/yK2eW3VI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/StatutoryInstrumentPaper> .\r\n<https://id.parliament.uk/yK2eW3VI>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/LaidThing>
+        .\r\n<https://id.parliament.uk/yK2eW3VI> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackagedThing> .\r\n<https://id.parliament.uk/yK2eW3VI>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperYear> \"statutoryInstrumentPaperYear
+        - 313\"^^<http://www.w3.org/2001/XMLSchema#gYear> .\r\n<https://id.parliament.uk/yK2eW3VI>
+        <https://id.parliament.uk/schema/statutoryInstrumentPaperPrefix> \"statutoryInstrumentPaperPrefix
+        - 313\" .\r\n<https://id.parliament.uk/yK2eW3VI> <https://id.parliament.uk/schema/statutoryInstrumentPaperName>
+        \"statutoryInstrumentPaperName - 313\" .\r\n<https://id.parliament.uk/yK2eW3VI>
+        <https://id.parliament.uk/schema/laidThingHasLaying> <https://id.parliament.uk/LQEg2yuf>
+        .\r\n<https://id.parliament.uk/yK2eW3VI> <https://id.parliament.uk/schema/workPackagedThingHasWorkPackage>
+        <https://id.parliament.uk/y8mNGRax> .\r\n<https://id.parliament.uk/LQEg2yuf>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://id.parliament.uk/schema/Laying>
+        .\r\n<https://id.parliament.uk/LQEg2yuf> <https://id.parliament.uk/schema/layingDate>
+        \"2018-10-16+01:00\"^^<http://www.w3.org/2001/XMLSchema#date> .\r\n<https://id.parliament.uk/LQEg2yuf>
+        <https://id.parliament.uk/schema/layingHasLayingBody> <https://id.parliament.uk/eup4DwE5>
+        .\r\n<https://id.parliament.uk/y8mNGRax> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <https://id.parliament.uk/schema/WorkPackage> .\r\n<https://id.parliament.uk/y8mNGRax>
+        <https://id.parliament.uk/schema/workPackageHasProcedure> <https://id.parliament.uk/gTgidljI>
+        .\r\n"
+    http_version: 
+  recorded_at: Thu, 25 Oct 2018 11:17:00 GMT
+recorded_with: VCR 4.0.0

--- a/spec/serializers/page_serializer/statutory_instruments_show_page_serializer_spec.rb
+++ b/spec/serializers/page_serializer/statutory_instruments_show_page_serializer_spec.rb
@@ -3,9 +3,9 @@ require_relative '../../rails_helper'
 RSpec.describe PageSerializer::StatutoryInstrumentsShowPageSerializer, vcr: true do
   include_context "sample request", include_shared: true
 
-  let(:response) {Parliament::Request::UrlRequest.new(base_url:   ENV['PARLIAMENT_BASE_URL'],
+  let(:response) { Parliament::Request::UrlRequest.new(base_url:   ENV['PARLIAMENT_BASE_URL'],
                                                       builder:    Parliament::Builder::NTripleResponseBuilder,
-                                                      decorators: Parliament::Grom::Decorator).statutory_instrument_by_id.get}
+                                                      decorators: Parliament::Grom::Decorator).statutory_instrument_by_id.get }
 
   let(:statutory_instrument) { response.filter('https://id.parliament.uk/schema/StatutoryInstrumentPaper').first }
 


### PR DESCRIPTION
* Allows grouping of objects by a block or methods calls.
* Allows sorting of a hash by keys and values.
* Updated SI and PNSI index pages to use GroupSortHelper.